### PR TITLE
Setup: Dockerize the API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:lts-alpine
+RUN mkdir -p /usr/src/fosscord-api
+WORKDIR /usr/src/fosscord-api
+COPY package.json /usr/src/fosscord-api
+RUN npm install
+COPY . /usr/src/fosscord-api
+CMD ["npm", "start"]


### PR DESCRIPTION
This pull request Dockerizes the API, so it can run as part of the main FOSScord instance