### PR TITLE
Fixes STR instead of JSON response and timestamps

### DIFF
--- a/src/routes/channels/#channel_id/messages/index.ts
+++ b/src/routes/channels/#channel_id/messages/index.ts
@@ -126,7 +126,7 @@ router.post("/", messageUpload.single("file"), async (req: Request, res: Respons
 
 	const embeds = [];
 	if (body.embed) embeds.push(body.embed);
-	const data = await sendMessage({ ...body, type: 0, pinned: false, author_id: req.user_id, embeds, channel_id, attachments });
+	const data = await sendMessage({ ...body, type: 0, pinned: false, author_id: req.user_id, embeds, channel_id, attachments, edited_timestamp: null });
 
 	return res.send(data);
 });

--- a/src/routes/gateway.ts
+++ b/src/routes/gateway.ts
@@ -5,8 +5,7 @@ const router = Router();
 
 router.get("/", (req: Request, res: Response) => {
 	const { endpoint } = Config.get().gateway;
-	res.setHeader('Content-Type', 'application/json');
-	res.send(JSON.stringify({ url: endpoint || process.env.GATEWAY || "ws://localhost:3002" }));
+	res.json({ url: endpoint || process.env.GATEWAY || "ws://localhost:3002" });
 });
 
 export default router;

--- a/src/routes/gateway.ts
+++ b/src/routes/gateway.ts
@@ -5,7 +5,8 @@ const router = Router();
 
 router.get("/", (req: Request, res: Response) => {
 	const { endpoint } = Config.get().gateway;
-	res.send({ url: endpoint || process.env.GATEWAY || "ws://localhost:3002" });
+	res.setHeader('Content-Type', 'application/json');
+	res.send(JSON.stringify({ url: endpoint || process.env.GATEWAY || "ws://localhost:3002" }));
 });
 
 export default router;

--- a/src/start.ts
+++ b/src/start.ts
@@ -5,6 +5,7 @@ import "missing-native-js-functions";
 import { config } from "dotenv";
 config();
 import { FosscordServer } from "./Server";
+console.log(process.env.MONGO_URL)
 import cluster from "cluster";
 import os from "os";
 const cores = Number(process.env.threads) || os.cpus().length;


### PR DESCRIPTION
1. Fixes an issue where, the `gateway` endpoint would return a string, instead of a JSON payload.
2. Adds the edited_timestamps property to messages, even if it is NULL.