### PR TITLE
Implement guild/id/region endpoint

### DIFF
--- a/src/routes/guilds/#guild_id/regions.ts
+++ b/src/routes/guilds/#guild_id/regions.ts
@@ -1,0 +1,10 @@
+import { Config } from "@fosscord/server-util";
+import { Request, Response, Router } from "express";
+
+const router = Router();
+
+router.get("/", async (req: Request, res: Response) => {
+	return res.json(Config.get().regions.available);
+});
+
+export default router;

--- a/src/routes/guilds/index.ts
+++ b/src/routes/guilds/index.ts
@@ -24,7 +24,7 @@ router.post("/", check(GuildCreateSchema), async (req: Request, res: Response) =
 	const guild_id = Snowflake.generate();
 	const guild: Guild = {
 		name: body.name,
-		region: body.region || "en-US",
+		region: Config.get().regions.default,
 		owner_id: req.user_id,
 		icon: undefined,
 		afk_channel_id: undefined,


### PR DESCRIPTION
Implement a basic `guild/id/region` endpoint that returns regions defined in the config and use the default region for new Guilds. As of now regions have no functionality and are purely visual. 

This requires fosscord/fosscord-server-util#10 to be merged first