### PR TITLE
Fix canvas build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:lts-alpine
 RUN apk add --no-cache make gcc g++ python cairo-dev jpeg-dev pango-dev giflib-dev
 WORKDIR /usr/src/fosscord-api
 COPY package.json .
-RUN npm rebuild bcrypt --build-from-source && npm rebuild canvas --build-from-source
+RUN npm rebuild bcrypt --build-from-source && npm install canvas --build-from-source
 RUN npm install
 COPY . .
 EXPOSE 3001

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"assert": "^1.5.0",
 		"atomically": "^1.7.0",
 		"bcrypt": "^5.0.1",
+		"canvas": "^2.8.0",
 		"body-parser": "^1.19.0",
 		"cheerio": "^1.0.0-rc.9",
 		"dot-prop": "^6.0.1",


### PR DESCRIPTION
This adds canvas to package.json and installs it. Without this change, `guilds/id/widget.png` route will fail with `Module 'canvas' not found`