### PR TITLE
Add gateway support for Discord desktop clients

### DIFF
--- a/gateway/src/schema/Identify.ts
+++ b/gateway/src/schema/Identify.ts
@@ -26,6 +26,8 @@ export const IdentifySchema = {
 		$client_event_source: String,
 		$client_version: String,
 		$system_locale: String,
+		$window_manager: String,
+		$distro: String,
 	},
 	$presence: ActivitySchema,
 	$compress: Boolean,


### PR DESCRIPTION
This PR adds support for Discord desktop clients to connect to the gateway. If people choose to use [my Fosscord injector for Discord desktop clients](github.com/mugman174/fosscord-injector), the Fosscord instance will need this.