### PR TITLE
Add /download route base

### DIFF
--- a/api/src/middlewares/Authentication.ts
+++ b/api/src/middlewares/Authentication.ts
@@ -9,6 +9,7 @@ export const NO_AUTHORIZATION_ROUTES = [
 	"/ping",
 	"/gateway",
 	"/experiments",
+	"/download"
 	/\/guilds\/\d+\/widget\.(json|png)/
 ];
 

--- a/api/src/routes/download.ts
+++ b/api/src/routes/download.ts
@@ -1,10 +1,9 @@
-import { Config } from "@fosscord/util";
 import { Router, Response, Request } from "express";
 
 const router = Router();
 
 router.get("/", (req: Request, res: Response) => {
-	res.send("We don't support donwloads at the moment");
+	res.send("We don't support donwloads at the moment.");
 });
 
 export default router;

--- a/api/src/routes/download.ts
+++ b/api/src/routes/download.ts
@@ -3,7 +3,7 @@ import { Router, Response, Request } from "express";
 const router = Router();
 
 router.get("/", (req: Request, res: Response) => {
-	res.send("We don't support donwloads at the moment.");
+	res.sendStatus(204);
 });
 
 export default router;

--- a/api/src/routes/download.ts
+++ b/api/src/routes/download.ts
@@ -1,0 +1,10 @@
+import { Config } from "@fosscord/util";
+import { Router, Response, Request } from "express";
+
+const router = Router();
+
+router.get("/", (req: Request, res: Response) => {
+	res.send("We don't support donwloads at the moment");
+});
+
+export default router;


### PR DESCRIPTION
Because we don't provide client downloads for now, he return a string who says there is not download now.