### PR TITLE
Make gateway auth required

### DIFF
--- a/api/src/middlewares/Authentication.ts
+++ b/api/src/middlewares/Authentication.ts
@@ -7,7 +7,6 @@ export const NO_AUTHORIZATION_ROUTES = [
 	"/auth/register",
 	"/webhooks/",
 	"/ping",
-	"/gateway",
 	"/experiments",
 	/\/guilds\/\d+\/widget\.(json|png)/
 ];


### PR DESCRIPTION
We do not have unclaimed accounts feature, hence do not need unauthenticated gateway access.