### PR TITLE
Add dummy missing routes

### DIFF
--- a/api/src/routes/applications/detectable.ts
+++ b/api/src/routes/applications/detectable.ts
@@ -1,0 +1,10 @@
+import { Request, Response, Router } from "express";
+
+const router: Router = Router();
+
+router.get("/", async (req: Request, res: Response) => {
+	//TODO
+	res.json([]).status(200);
+});
+
+export default router;

--- a/api/src/routes/outbound-promotions.ts
+++ b/api/src/routes/outbound-promotions.ts
@@ -1,0 +1,10 @@
+import { Request, Response, Router } from "express";
+
+const router: Router = Router();
+
+router.get("/", async (req: Request, res: Response) => {
+	//TODO
+	res.json([]).status(200);
+});
+
+export default router;

--- a/api/src/routes/users/@me/affinities/users.ts
+++ b/api/src/routes/users/@me/affinities/users.ts
@@ -3,7 +3,7 @@ import { Router, Response, Request } from "express";
 const router = Router();
 
 router.get("/", (req: Request, res: Response) => {
-	// TODO:
+	//TODO
 	res.status(200).send({ user_affinities: [], inverse_user_affinities: [] });
 });
 

--- a/api/src/routes/users/@me/applications/#app_id/entitlements.ts
+++ b/api/src/routes/users/@me/applications/#app_id/entitlements.ts
@@ -1,0 +1,10 @@
+import { Request, Response, Router } from "express";
+
+const router: Router = Router();
+
+router.get("/", async (req: Request, res: Response) => {
+	//TODO
+	res.json([]).status(200);
+});
+
+export default router;

--- a/api/src/routes/users/@me/billing/country-code.ts
+++ b/api/src/routes/users/@me/billing/country-code.ts
@@ -1,0 +1,10 @@
+import { Request, Response, Router } from "express";
+
+const router: Router = Router();
+
+router.get("/", async (req: Request, res: Response) => {
+	//TODO
+	res.json({ "country_code": "US" }).status(200);
+});
+
+export default router;

--- a/api/src/routes/users/@me/billing/subscriptions.ts
+++ b/api/src/routes/users/@me/billing/subscriptions.ts
@@ -1,0 +1,10 @@
+import { Request, Response, Router } from "express";
+
+const router: Router = Router();
+
+router.get("/", async (req: Request, res: Response) => {
+	//TODO
+	res.json([]).status(200);
+});
+
+export default router;


### PR DESCRIPTION
Added dummy for these routes:
```
/applications/detectable
/outbound-promotions
/users/@me/affinities/users
/users/@me/applications/#app_id/entitlements
/users/@me/billing/country-code
/users/@me/billing/subscriptions
```
This prevent several `Uncaught (in promise) TypeError: e is null`  kind of errors in the Discord client 