### PR TITLE
Add /users/@me/connections

### DIFF
--- a/api/src/routes/users/@me/connections.ts
+++ b/api/src/routes/users/@me/connections.ts
@@ -1,8 +1,9 @@
 import { Request, Response, Router } from "express";
+import { route } from "@fosscord/api";
 
 const router: Router = Router();
 
-router.get("/", async (req: Request, res: Response) => {
+router.get("/", route({}), async (req: Request, res: Response) => {
 	//TODO
 	res.json([]).status(200);
 });

--- a/api/src/routes/users/@me/connections.ts
+++ b/api/src/routes/users/@me/connections.ts
@@ -1,0 +1,10 @@
+import { Request, Response, Router } from "express";
+
+const router: Router = Router();
+
+router.get("/", async (req: Request, res: Response) => {
+	//TODO
+	res.json([]).status(200);
+});
+
+export default router;


### PR DESCRIPTION
This commit adds a dummy implementation for the /users/@me/connections endpoint.
This endpoint returns an array of Connection objects, aka linked accounts on your profile.
It is completely safe to return an empty array here (Discord does this when you have no connections.)