### PR TITLE
Fix request failiure with "400: BITFIELD INVALID:0"

### DIFF
--- a/api/src/middlewares/Authentication.ts
+++ b/api/src/middlewares/Authentication.ts
@@ -47,7 +47,7 @@ export async function Authentication(req: Request, res: Response, next: NextFunc
 		req.token = decoded;
 		req.user_id = decoded.id;
 		req.user_bot = user.bot;
-		req.rights = new Rights(user.rights);
+		req.rights = new Rights(Number(user.rights));
 		return next();
 	} catch (error: any) {
 		return next(new HTTPError(error?.toString(), 400));


### PR DESCRIPTION
After @Flam3rboy's user right management implementation the server declined some packets with the error message: "400: BITFIELD INVALID:0". This happened because the user rights value is being stored as a String.