### PR TITLE
npm run build fails if Windows username contains space

### DIFF
--- a/bundle/scripts/build.js
+++ b/bundle/scripts/build.js
@@ -56,7 +56,7 @@ function transpileFiles() {
 
 function util() {
 	// const child = spawn("node", `${swcBin}  src --out-dir dist --sync`.split(" "), {
-	const child = spawn("node", `${tscBin} -b .`.split(" "), {
+	const child = spawn("node", `\"${tscBin}\" -b .`.split(" "), {
 		cwd: path.join(__dirname, "..", "..", "util"),
 		env: process.env,
 		shell: true,


### PR DESCRIPTION
Fixed by escaping tscBin variable in bundle/build.js. The same bug doesn't seem to come up anywhere else, but then again I have not checked other usernames/etc.

Very open to criticism if I've done this PR incorrectly, thanks!