### PR TITLE
npm run build fails if Windows username contains space

### DIFF
--- a/bundle/scripts/build.js
+++ b/bundle/scripts/build.js
@@ -34,9 +34,9 @@ console.log("Compiling src files ...");
 
 console.log(
 	execSync(
-		"node " +
+		"node \"" +
 			path.join(__dirname, "..", "node_modules", "typescript", "lib", "tsc.js") +
-			" -p " +
+			"\" -p " +
 			path.join(__dirname, ".."),
 		{
 			cwd: path.join(__dirname, ".."),


### PR DESCRIPTION
#438 fix from dev branch redone in master.