### PR TITLE
Add `INTERNAL_EMPLOYEE_ONLY` feature and do minor API work

### DIFF
--- a/api/src/middlewares/Authentication.ts
+++ b/api/src/middlewares/Authentication.ts
@@ -3,17 +3,25 @@ import { HTTPError } from "lambert-server";
 import { checkToken, Config, Rights } from "@fosscord/util";
 
 export const NO_AUTHORIZATION_ROUTES = [
+	//Authentication routes
 	"/auth/login",
 	"/auth/register",
+	"/auth/location-metadata",
+	//Routes with a seperate auth system
 	"/webhooks/",
+	//Public information endpoints 
 	"/ping",
 	"/gateway",
 	"/experiments",
+	//Public kubernetes integration
 	"/-/readyz",
 	"/-/healthz",
+	//Client nalytics
 	"/science",
 	"/track",
+	//Public policy pages
 	"/policies/instance",
+	//Asset delivery
 	/\/guilds\/\d+\/widget\.(json|png)/
 ];
 

--- a/api/src/middlewares/TestClient.ts
+++ b/api/src/middlewares/TestClient.ts
@@ -87,6 +87,7 @@ export default function TestClient(app: Application) {
 		res.set("Cache-Control", "public, max-age=" + 60 * 60 * 24);
 		res.set("content-type", "text/html");
 
+    if(req.url.startsWith("/api")) return;
 		if (req.url.startsWith("/invite")) return res.send(html.replace("9b2b7f0632acd0c5e781", "9f24f709a3de09b67c49"));
 
 		res.send(html);

--- a/api/src/routes/invites/index.ts
+++ b/api/src/routes/invites/index.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from "express";
-import { emitEvent, getPermission, Guild, Invite, InviteDeleteEvent, Member, PublicInviteRelation } from "@fosscord/util";
+import { emitEvent, getPermission, Guild, Invite, InviteDeleteEvent, User, PublicInviteRelation } from "@fosscord/util";
 import { route } from "@fosscord/api";
 import { HTTPError } from "lambert-server";
 
@@ -15,6 +15,11 @@ router.get("/:code", route({}), async (req: Request, res: Response) => {
 
 router.post("/:code", route({}), async (req: Request, res: Response) => {
 	const { code } = req.params;
+	const { features } = await Guild.findOneOrFail({where: { code }});
+	const { public_flags } = await User.findOneOrFail({ id: req.user_id });
+	
+	if(features.includes("INTERNAL_EMPLOYEE_ONLY") && (public_flags & 1) !== 1) throw new HTTPError("You are not allowed to join this guild.", 401)
+	
 	const invite = await Invite.joinGuild(req.user_id, code);
 
 	res.json(invite);

--- a/bundle/scripts/build.js
+++ b/bundle/scripts/build.js
@@ -26,9 +26,9 @@ dirs.forEach((a) => {
 	if (verbose) console.log(`Copied ${"../" + a + "/dist"} -> ${"dist/" + a + "/src"}!`);
 });
 
-console.log("Copying src files done");
+console.log("[1/2] Copying src files done");
 if (!argv.includes("copyonly")) {
-	console.log("Compiling src files ...");
+	console.log("[2/2] Compiling src files ...");
 
 	console.log(
 		execSync(


### PR DESCRIPTION
This feature makes a guild exclusive to users with staff flag and this Discord internal can have a good use in Fosscord Official instance and staff guilds of instances.
Also added `location-metadata` to no authorization routes and added commentary on that section.