### PR TITLE
Fixed potential guild message SQL constraints

### DIFF
--- a/util/src/entities/Message.ts
+++ b/util/src/entities/Message.ts
@@ -84,8 +84,10 @@ export class Message extends BaseClass {
 	@RelationId((message: Message) => message.member)
 	member_id: string;
 
-	@JoinColumn({ name: "member_id" })
-	@ManyToOne(() => Member)
+	@JoinColumn({ name: "author_id", referencedColumnName: "id" })
+	@ManyToOne(() => User, {
+		onDelete: "CASCADE",
+	})
 	member?: Member;
 
 	@Column({ nullable: true })


### PR DESCRIPTION
i have tied member dependencies to the author id rather than the member id to avoid a dependency cycle and you can now kick/ban someone from a guild/server (with messages in the guild) and the messages will remain in the guild (just like discord) as stated in issue #441

I have also tested this code seems clean so far
(new pull request opened because of branch commit issues)