### PR TITLE
Typo fix in Start.ts

### DIFF
--- a/bundle/src/start.ts
+++ b/bundle/src/start.ts
@@ -31,7 +31,7 @@ if (cluster.isMaster) {
 ╚═╝      ╚═════╝ ╚══════╝╚══════╝ ╚═════╝ ╚═════╝ ╚═╝  ╚═╝╚═════╝
 
 		fosscord-server | ${yellow(
-			`Pre-relase (${
+			`Pre-Release (${
 				commit !== null
 					? commit.slice(0, 7)
 					: "Unknown (Git cannot be found)"


### PR DESCRIPTION
fixed typo under the bold fosscord logo "Pre-relase" and replaced it with "Pre-Release"