### PR TITLE
Updated stop.ts

### DIFF
--- a/api/src/routes/stop.ts
+++ b/api/src/routes/stop.ts
@@ -5,21 +5,22 @@ import { User } from "@fosscord/util";
 const router: Router = Router();
 
 router.post("/", route({}), async (req: Request, res: Response) => {
-	//TODO: have an "OPERATOR" platform permission implemented for this API route
-	const user = await User.findOneOrFail({ where: { id: req.user_id }, select: ["flags"] });
-	if(user.flags == '4096') {
+	//EXPERIMENTAL: have an "OPERATOR" platform permission implemented for this API route
+	const user = await User.findOneOrFail({ where: { id: req.user_id }, select: ["rights"] });
+	if(user.rights == '1') {
 		console.log("user that POSTed to the API was ALLOWED");
-		console.log(user.flags);
+		console.log(user.rights);
 		res.sendStatus(200)
 		process.kill(process.pid, 'SIGTERM')
 	}
 	else {
 		console.log("operation failed");
-		console.log(user.flags);
+		console.log(user.rights);
 		res.sendStatus(403)
 	}
 });
 
 export default router;
 
-//THIS API CAN ONLY BE USED BY USERS WITH THE 'SYSTEM' FLAG ONLY IF ANY OTHER FLAGS ARE ADDED THE REQUEST WILL RETURN 403 'FORBIDDEN'
+//THIS API CAN ONLY BE USED BY USERS WITH THE 'OPERATOR' RIGHT (which is the value of 1) ONLY IF ANY OTHER RIGHTS ARE ADDED OR IF THE USER DOESNT HAVE PERMISSION,
+//THE REQUEST WILL RETURN 403 'FORBIDDEN'

--- a/api/src/routes/stop.ts
+++ b/api/src/routes/stop.ts
@@ -7,7 +7,7 @@ const router: Router = Router();
 router.post("/", route({}), async (req: Request, res: Response) => {
 	//EXPERIMENTAL: have an "OPERATOR" platform permission implemented for this API route
 	const user = await User.findOneOrFail({ where: { id: req.user_id }, select: ["rights"] });
-	if(user.rights == '1') {
+	if((Number(user.rights) << Number(0))%Number(2)==Number(1)) {
 		console.log("user that POSTed to the API was ALLOWED");
 		console.log(user.rights);
 		res.sendStatus(200)


### PR DESCRIPTION
updated stop.ts so it checks for user rights instead of the SYSTEM flag which can possibly cause some unnecessary complications when it comes to instance management

*also has been tested with multiple tokens to be sure that this does NOT permit normal users to POST to the /stop API route
**NOTE**: instance owners will have to re-run `npm run setup` for these changes to take effect