### PR TITLE
[Fix] Fix for role default permissions

### DIFF
--- a/api/src/routes/guilds/#guild_id/roles.ts
+++ b/api/src/routes/guilds/#guild_id/roles.ts
@@ -60,7 +60,7 @@ router.post("/", route({ body: "RoleModifySchema", permission: "MANAGE_ROLES" })
 		...body,
 		guild_id: guild_id,
 		managed: false,
-		permissions: String(req.permission!.bitfield & BigInt(body.permissions || "0")),
+		permissions: "242769972801",
 		tags: undefined,
 		icon: null,
 		unicode_emoji: null


### PR DESCRIPTION
This causes a lot of bugs unless the role is created with default permissions (Removes the @everyone role unless it has default permissions)