### PR TITLE
fix the message endpoint always returning Empty message error

### DIFF
--- a/api/src/util/handlers/Message.ts
+++ b/api/src/util/handlers/Message.ts
@@ -89,7 +89,7 @@ export async function handleMessage(opts: MessageOptions): Promise<Message> {
 	}
 
 	// TODO: stickers/activity
-	if (!allow_empty || (!opts.content && !opts.embeds?.length && !opts.attachments?.length && !opts.sticker_ids?.length)) {
+	if (!allow_empty && (!opts.content && !opts.embeds?.length && !opts.attachments?.length && !opts.sticker_ids?.length)) {
 		throw new HTTPError("Empty messages are not allowed", 50006);
 	}
 


### PR DESCRIPTION
fix an issue introduced by #581 which causes the send message endpoint always return an empty message error.