### PR TITLE
Fix typo in commit 277b28c

### DIFF
--- a/api/src/util/handlers/Message.ts
+++ b/api/src/util/handlers/Message.ts
@@ -82,7 +82,7 @@ export async function handleMessage(opts: MessageOptions): Promise<Message> {
 	if (opts.message_reference) {
 		permission.hasThrow("READ_MESSAGE_HISTORY");
 		// code below has to be redone when we add custom message routing and cross-channel replies
-		const guild = await Guild.findOneOrFail({ id: guild_id });
+		const guild = await Guild.findOneOrFail({ id: channel.guild_id });
 		if (!guild.features.includes("CROSS_CHANNEL_REPLIES")) {
 			if (opts.message_reference.guild_id !== channel.guild_id) throw new HTTPError("You can only reference messages from this guild");
 			if (opts.message_reference.channel_id !== opts.channel_id) throw new HTTPError("You can only reference messages from this channel");


### PR DESCRIPTION
277b28c `guild_id` variable doesn't exist, is meant to be `channel.guild_id`.