### PR TITLE
[Test client] Branding updates

### DIFF
--- a/api/assets/fosscord-login.css
+++ b/api/assets/fosscord-login.css
@@ -22,10 +22,10 @@ h3.title-jXR8lp.marginBottom8-AtZOdT.base-1x0h_U.size24-RIRrxO::after {
 /* Logo in top left when bg removed */
 #app-mount > div.app-1q1i1E > div > a {
 	/* replace me: original dimensions: 130x36 */
-	background: url(https://raw.githubusercontent.com/fosscord/fosscord/9900329e5ef2c17bdeb6893e04c0511f72027f97/assets/logo/temp.svg);
+	background: url(https://raw.githubusercontent.com/fosscord/fosscord/master/assets-rebrand/svg/Fosscord-Wordmark-Gradient.svg);
+	width: 130px;
+	height: 23px;
 	background-size: contain;
-	width: 128px;
-	height: 128px;
 	border-radius: 50%;
 }
 

--- a/api/assets/fosscord.css
+++ b/api/assets/fosscord.css
@@ -13,9 +13,13 @@
 /* home button icon */
 #app-mount > div.app-1q1i1E > div > div.layers-3iHuyZ.layers-3q14ss > div > div > nav > ul > div.scroller-1Bvpku.none-2Eo-qx.scrollerBase-289Jih > div.tutorialContainer-2sGCg9 > div > div.listItemWrapper-KhRmzM > div > svg > foreignObject > div > div
 {
-    background-image: url(https://raw.githubusercontent.com/fosscord/fosscord/9900329e5ef2c17bdeb6893e04c0511f72027f97/assets/logo/temp.svg);
+    background-image: url(https://raw.githubusercontent.com/fosscord/fosscord/master/assets-rebrand/svg/Fosscord-Icon-Rounded-Subtract.svg);
     background-size: contain;
     border-radius: 50%;
+}
+
+#app-mount > div.app-1q1i1E > div > div.layers-3iHuyZ.layers-3q14ss > div > div > nav > ul > div.scroller-1Bvpku.none-2Eo-qx.scrollerBase-289Jih > div.tutorialContainer-2sGCg9 > div > div.listItemWrapper-KhRmzM > div > svg > foreignObject > div > div, #app-mount > div.app-1q1i1E > div > div.layers-3iHuyZ.layers-3q14ss > div > div > nav > ul > div.scroller-1Bvpku.none-2Eo-qx.scrollerBase-289Jih > div.tutorialContainer-2sGCg9 > div > div.listItemWrapper-KhRmzM > div > svg > foreignObject > div > div:hover {
+	background-color: white;
 }
 /* Login QR */
 #app-mount > div.app-1q1i1E > div > div > div > div > form > div > div > div.transitionGroup-aR7y1d.qrLogin-1AOZMt,


### PR DESCRIPTION
Preview of the changes (available on Nostalgicord fork w/ fork-specific changes ofc):
![librewolf_uG48AbTy4x](https://user-images.githubusercontent.com/88265031/150650298-a281f636-a92a-44dc-8023-e600b068432e.png)
![librewolf_fUcR0XzcL5](https://user-images.githubusercontent.com/88265031/150650308-a11fa6c1-a917-4cca-ad60-740155a3f11e.png)

Not included (aka exclusive to Nostalgicord fork):
"Fosscord email" text
Old client