### PR TITLE
Speed up setup by not installing optional packages

### DIFF
--- a/bundle/package.json
+++ b/bundle/package.json
@@ -4,7 +4,7 @@
 	"description": "",
 	"main": "src/start.js",
 	"scripts": {
-		"setup": "node scripts/install.js && npm install && ts-patch install -s && patch-package --patch-dir ../api/patches/ && npm run build",
+		"setup": "node scripts/install.js && npm install --no-optional && ts-patch install -s && patch-package --patch-dir ../api/patches/ && npm run build",
 		"build": "node scripts/build.js",
 		"start": "node scripts/build.js && node dist/bundle/src/start.js",
 		"start:bundle": "node dist/bundle/src/start.js",


### PR DESCRIPTION
Only downside is no db engines are included by default, removing compile time for packages like sqlite3.