### PR TITLE
Improve compatibly with some clients ( discord.js )

### DIFF
--- a/api/src/routes/channels/#channel_id/messages/index.ts
+++ b/api/src/routes/channels/#channel_id/messages/index.ts
@@ -126,6 +126,13 @@ router.get("/", async (req: Request, res: Response) => {
 				y.proxy_url = `${endpoint == null ? "" : endpoint}${new URL(uri).pathname}`;
 			});
 
+			//Some clients ( discord.js ) only check if a property exists within the response,
+			//which causes erorrs when, say, the `application` property is `null`.
+			for (var curr in x) {
+				if (x[curr] === null)
+					delete x[curr];
+			}
+
 			return x;
 		})
 	);


### PR DESCRIPTION
Some clients ( in particular, discord.js ) only check if a property exists within a response rather than if it's the type they expect.
This causes issues when, for example, the `application` or `components` fields are `null` rather than completely absent.

This PR removes nulled properties from the response of GET `/channels/:id/messages`. I'm sure the same issue exists in other places, but oh well.

This could perhaps be implemented better ( and more university ) through the use of typeorm transformers. I may come back and reimplement it that way later.
As it stands right now, it doesn't seem this causes any issues.