### PR TITLE
[Fix] Client bug

### DIFF
--- a/api/src/routes/channels/#channel_id/messages/index.ts
+++ b/api/src/routes/channels/#channel_id/messages/index.ts
@@ -219,7 +219,10 @@ router.post(
 				})
 			);
 		}
-
+	
+		//Fix for the client bug
+		delete message.member
+		
 		await Promise.all([
 			message.save(),
 			emitEvent({ event: "MESSAGE_CREATE", channel_id: channel_id, data: message } as MessageCreateEvent),


### PR DESCRIPTION
If you don't delete this property for some reasons after you send a message in a guild, your roles will be removed (client sided) for everyone, this fixes it.