### PR TITLE
[Fix] Invisible space username

### DIFF
--- a/api/src/routes/users/@me/index.ts
+++ b/api/src/routes/users/@me/index.ts
@@ -57,6 +57,13 @@ router.patch("/", route({ body: "UserModifySchema" }), async (req: Request, res:
 		user.data.hash = await bcrypt.hash(body.new_password, 12);
 	}
 
+	var check_username = body?.username?.replace(/\s/g, '');
+	if(!check_username) {
+		throw FieldErrors({
+			username: { code: "BASE_TYPE_REQUIRED", message: req.t("common:field.BASE_TYPE_REQUIRED") }
+		});
+	}
+
 	await user.save();
 
 	// @ts-ignore


### PR DESCRIPTION
You can send only spaces to the server and have a invisible username, this way you can remove the spaces and check and if it wasn't null after you know it's not just spaces