### PR TITLE
Fix `servers[0].url` in `openapi.json`.

### DIFF
--- a/api/assets/openapi.json
+++ b/api/assets/openapi.json
@@ -2,7 +2,7 @@
 	"openapi": "3.0.0",
 	"servers": [
 		{
-			"url": "https://api.fosscord.com/v{version}",
+			"url": "https://api.fosscord.com/api/v{version}",
 			"description": "Official fosscord instance",
 			"variables": {
 				"version": {


### PR DESCRIPTION
A tiny fix within [`openapi.json`](https://github.com/fosscord/fosscord-server/blob/master/api/assets/openapi.json), that changes the URL in servers property to the correct ones.