### PR TITLE
Add nan to dependencies

### DIFF
--- a/bundle/package.json
+++ b/bundle/package.json
@@ -105,6 +105,7 @@
 		"typeorm": "^0.2.37",
 		"typescript": "^4.1.2",
 		"typescript-json-schema": "^0.50.1",
-		"ws": "^7.4.2"
+		"ws": "^7.4.2",
+		"nan": "^2.15.0"
 	}
 }


### PR DESCRIPTION
sqlite requires it, setup not going through without it, and manual install isn't working. does work when adding to dependencies tho.