### PR TITLE
fix(api): add vanity urls creation/update

### DIFF
--- a/api/src/routes/guilds/#guild_id/vanity-url.ts
+++ b/api/src/routes/guilds/#guild_id/vanity-url.ts
@@ -39,24 +39,18 @@ router.patch("/", route({ body: "VanityUrlSchema", permission: "MANAGE_GUILD" })
 
 	const { id } = await Channel.findOneOrFail({ guild_id, type: ChannelType.GUILD_TEXT });
 
-	const oldInvite = await Invite.findOne({ vanity_url: true, guild_id });
-
-	if (oldInvite) {
-		await Invite.update({ vanity_url: true, guild_id }, { code: code, channel_id: id });
-	} else {
-		await new Invite({
-			vanity_url: true,
-			code: code,
-			temporary: false,
-			uses: 0,
-			max_uses: 0,
-			max_age: 0,
-			created_at: new Date(),
-			expires_at: new Date(),
-			guild_id: guild_id,
-			channel_id: id
-		}).save();
-	}
+	await new Invite({
+		vanity_url: true,
+		code: code,
+		temporary: false,
+		uses: 0,
+		max_uses: 0,
+		max_age: 0,
+		created_at: new Date(),
+		expires_at: new Date(),
+		guild_id: guild_id,
+		channel_id: id
+	}).save();
 
 	return res.json({ code: code });
 });


### PR DESCRIPTION
This PR is a fix for vanity url endpoint.

Features:
- [x] Check for `VANITY_URL` feature flag.
- [x] Create or update a vanity url.
- [ ] Multiple names (#407)
- [ ] Delete vanity url using "Delete Vanity URL" link (you can delete vanity urls on "invites" tab).

**EDIT:** "Delete vanity URL" could be easily fixable (openapi.json/schema.json -> VanityUrlSchema -> minLength: 0), but according to feature suggest #407, what should be the default behavior of this button?

Please note that I don't use TypeScript and TypeORM a lot (I'm a pure JS guy), sorry for possible inconsistent changes.