### PR TITLE
refactor(gateway): delete hardcoded guild boosts

### DIFF
--- a/gateway/src/opcodes/Identify.ts
+++ b/gateway/src/opcodes/Identify.ts
@@ -240,8 +240,6 @@ export async function onIdentify(this: WebSocket, data: Payload) {
 			x.guild_hashes = {}; // @ts-ignore
 			x.guild_scheduled_events = []; // @ts-ignore
 			x.threads = [];
-			x.premium_subscription_count = 30;
-			x.premium_tier = 3;
 			return x;
 		}),
 		guild_experiments: [], // TODO


### PR DESCRIPTION
Since you can set `premium_subscription_count` and `premium_tier` by editing the database (and it works fine), this shouldn't be hardcoded.