### PR TITLE
Fixed crash in Discord Electron client when loading guild

### DIFF
--- a/util/src/entities/Member.ts
+++ b/util/src/entities/Member.ts
@@ -86,7 +86,7 @@ export class Member extends BaseClassWithoutId {
 	joined_at: Date;
 
 	@Column({ nullable: true })
-	premium_since?: Date;
+	premium_since?: number;
 
 	@Column()
 	deaf: boolean;


### PR DESCRIPTION
Potentially solves #652 ? Haven't seen what the stack trace of that error is client side yet though. If it *is* the same error the client's stack trace will mention rendering premium status.

I'm not entirely sure why changing the type back from Date to number solves this, especially given that Discord *says* they expect an ISO8601 date string, but it works as indented when it's stored ( and served? not entire sure it's not being converted somewhere ) as a number, so oh well.