### PR TITLE
Fix(API): @everyone role

### DIFF
--- a/api/src/routes/guilds/#guild_id/members/#member_id/index.ts
+++ b/api/src/routes/guilds/#guild_id/members/#member_id/index.ts
@@ -30,7 +30,7 @@ router.patch("/", route({ body: "MemberChangeSchema" }), async (req: Request, re
 		permission.hasThrow("MANAGE_ROLES");
 
 		const everyone = await Role.findOneOrFail({ guild_id: guild_id, name: "@everyone", position: 0 });
-		body.roles.push(everyone?.id);
+		if (body.roles.indexOf(everyone.id) === -1) body.roles.push(everyone.id);
 		member.roles = body.roles.map((x) => new Role({ id: x })); // foreign key constraint will fail if role doesn't exist
 	}
 

--- a/api/src/routes/guilds/#guild_id/members/#member_id/index.ts
+++ b/api/src/routes/guilds/#guild_id/members/#member_id/index.ts
@@ -28,6 +28,9 @@ router.patch("/", route({ body: "MemberChangeSchema" }), async (req: Request, re
 
 	if (body.roles) {
 		permission.hasThrow("MANAGE_ROLES");
+
+		const everyone = await Role.findOneOrFail({ guild_id: guild_id, name: "@everyone", position: 0 });
+		body.roles.push(everyone?.id);
 		member.roles = body.roles.map((x) => new Role({ id: x })); // foreign key constraint will fail if role doesn't exist
 	}
 

--- a/api/src/routes/guilds/#guild_id/members/#member_id/index.ts
+++ b/api/src/routes/guilds/#guild_id/members/#member_id/index.ts
@@ -25,16 +25,19 @@ router.patch("/", route({ body: "MemberChangeSchema" }), async (req: Request, re
 
 	const member = await Member.findOneOrFail({ where: { id: member_id, guild_id }, relations: ["roles", "user"] });
 	const permission = await getPermission(req.user_id, guild_id);
+	const everyone = await Role.findOneOrFail({ guild_id: guild_id, name: "@everyone", position: 0 });
 
 	if (body.roles) {
 		permission.hasThrow("MANAGE_ROLES");
 
-		const everyone = await Role.findOneOrFail({ guild_id: guild_id, name: "@everyone", position: 0 });
 		if (body.roles.indexOf(everyone.id) === -1) body.roles.push(everyone.id);
 		member.roles = body.roles.map((x) => new Role({ id: x })); // foreign key constraint will fail if role doesn't exist
 	}
 
 	await member.save();
+
+	member.roles = member.roles.filter((x) => x.id !== everyone.id);
+
 	// do not use promise.all as we have to first write to db before emitting the event to catch errors
 	await emitEvent({
 		event: "GUILD_MEMBER_UPDATE",


### PR DESCRIPTION
When you add or delete an user's role, you MUST always add "everyone" role to the roles map.
Also, you should never send the "everyone" role id in the api route `PATCH /guilds/{guild.id}/members/{user.id}`'s response.

- [x] Always add everyone role when modifying an user's role.
- [x] Don't send everyone's role id in the api response (`member.roles`).