### PR TITLE
Refactor(Docker): add working Docker scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,40 @@
-FROM node:14
-WORKDIR /usr/src/fosscord-server/
-COPY . .
-WORKDIR /usr/src/fosscord-server/bundle
+FROM node:alpine
+
+# env vars
+ENV WORK_DIR="/srv/fosscord-server"
+ENV DEV_MODE=0
+ENV HTTP_PORT=3001
+ENV WS_PORT=3002
+ENV CDN_PORT=3003
+ENV RTC_PORT=3004
+ENV ADMIN_PORT=3005
+
+# exposed ports (only for reference, see https://docs.docker.com/engine/reference/builder/#expose)
+EXPOSE ${HTTP_PORT}/tcp ${WS_PORT}/tcp ${CDN_PORT}/tcp ${RTC_PORT}/tcp ${ADMIN_PORT}/tcp
+
+# install required apps
+RUN apk add --no-cache --update git python2 py-pip make build-base
+
+# optionl: packages for debugging/development
+RUN apk add --no-cache sqlite
+
+# download fosscord-server
+WORKDIR $WORK_DIR/src
+RUN git clone https://github.com/fosscord/fosscord-server.git .
+
+# setup and run
+WORKDIR $WORK_DIR/src/bundle
 RUN npm run setup
-EXPOSE 3001
-CMD [ "npm", "run", "start:bundle" ]
+RUN npm install @yukikaze-bot/erlpack
+# RUN npm install mysql --save
+
+# create update script
+RUN printf '#!/bin/sh\n\ngit -C $WORK_DIR/src/ checkout master\ngit -C $WORK_DIR/src/ reset --hard HEAD\ngit -C $WORK_DIR/src/ pull\ncd $WORK_DIR/src/bundle/\nnpm run setup\n' > $WORK_DIR/update.sh
+RUN chmod +x $WORK_DIR/update.sh
+
+# configure entrypoint file
+RUN printf '#!/bin/sh\n\nDEV_MODE=${DEV_MODE:-0}\n\nif [ "$DEV_MODE" -eq 1 ]; then\n    tail -f /dev/null\nelse\n    cd $WORK_DIR/src/bundle/\n    npm run start:bundle\nfi\n' > $WORK_DIR/entrypoint.sh
+RUN chmod +x $WORK_DIR/entrypoint.sh
+
+WORKDIR $WORK_DIR
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,47 @@
-version: "3"
+version: '3.8'
+
 services:
-  server:
-    image: fosscord/server
+  fosscord:
+    container_name: fosscord
+    image: fosscord
+    restart: on-failure:5
+    # depends_on: mariadb
     build: .
     ports:
-      - 3001:3001
+      - '3001-3005:3001-3005'
+    volumes:
+      # - ./data/:${WORK_DIR:-/srv/fosscord-server}/data/
+      - data:${WORK_DIR:-/srv/fosscord-server}/
+    environment:
+      WORK_DIR: ${WORK_DIR:-/srv/fosscord-server}
+      DEV_MODE: ${DEV_MODE:-0}
+      THREADS: ${THREADS:-1}
+      DATABASE: ${DATABASE:-../../data/database.db}
+      STORAGE_LOCATION: ${STORAGE_LOCATION:-../../data/files/}
+      HTTP_PORT: 3001
+      WS_PORT: 3002
+      CDN_PORT: 3003
+      RTC_PORT: 3004
+      ADMIN_PORT: 3005
+
+  # mariadb:
+  #   image: mariadb:latest
+  #   restart: on-failure:5
+  #   environment:
+  #     MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-secr3tpassw0rd}
+  #     MYSQL_DATABASE: ${MYSQL_DATABASE:-fosscord}
+  #     MYSQL_USER: ${MYSQL_USER:-fosscord}
+  #     MYSQL_PASSWORD: ${MYSQL_PASSWORD:-password1}
+  #   networks:
+  #     - default
+  #   volumes:
+  #     - mariadb:/var/lib/mysql
+
+volumes:
+  data:
+  # mariadb:
+
+networks:
+  default:
+    name: fosscord
+    driver: bridge


### PR DESCRIPTION
This PR adds working docker scripts (Dockerfile & docker-compose.yml) with few new env vars.

- `DEV_MODE` — Default init of the docker container (0: automatic fosscord init | 1: manual fosscord init).
- `WORK_DIR` — Docker image's workdir.

The `docker-compose.yml` uses `named volumes`, so the container has persistence for fosscord src and data! Because of this, you can update fosscord as usual.