### PR TITLE
Fix guilds not able to be created

### DIFF
--- a/util/src/entities/Member.ts
+++ b/util/src/entities/Member.ts
@@ -85,7 +85,7 @@ export class Member extends BaseClassWithoutId {
 	@Column()
 	joined_at: Date;
 
-	@Column({ nullable: true })
+	@Column({ type: "bigint", nullable: true })
 	premium_since?: number;
 
 	@Column()
@@ -245,7 +245,7 @@ export class Member extends BaseClassWithoutId {
 			nick: undefined,
 			roles: [guild_id], // @everyone role
 			joined_at: new Date(),
-			premium_since: new Date(),
+			premium_since: (new Date()).getTime(),
 			deaf: false,
 			mute: false,
 			pending: false,


### PR DESCRIPTION
Due to https://github.com/fosscord/fosscord-server/pull/669, guild creation was made impossible. Changing the type of premium_since to bigint solves this.

Credit to @ImAaronFR 