### PR TITLE
Make member.premium_since ISO8601 timestamp

### DIFF
--- a/util/src/entities/Member.ts
+++ b/util/src/entities/Member.ts
@@ -85,8 +85,8 @@ export class Member extends BaseClassWithoutId {
 	@Column()
 	joined_at: Date;
 
-	@Column({ type: "bigint", nullable: true })
-	premium_since?: number;
+	@Column()
+	premium_since?: Date;
 
 	@Column()
 	deaf: boolean;
@@ -245,7 +245,7 @@ export class Member extends BaseClassWithoutId {
 			nick: undefined,
 			roles: [guild_id], // @everyone role
 			joined_at: new Date(),
-			premium_since: (new Date()).getTime(),
+			premium_since: new Date(),
 			deaf: false,
 			mute: false,
 			pending: false,


### PR DESCRIPTION
Per [Discord's Guild Member schema](https://discord.com/developers/docs/resources/guild#guild-member-object), `premium_since` is an ISO8601 timestamp. Currently it is of type `number`.
```json
{
  "member": {
    "index": 1,
    "id": "954027619232784409",
    "guild_id": "954027701865324570",
    "nick": null,
    "joined_at": "2022-03-17T14:45:29.999Z",
    "premium_since": 1647528329999,
    "deaf": false,
    "mute": false,
    "pending": false,
    "last_message_id": "954944967251099688",
    "roles": [
      "954027701865324570"
    ],
	...
}