### PR TITLE
Fix right checks

### DIFF
--- a/api/src/routes/channels/#channel_id/invites.ts
+++ b/api/src/routes/channels/#channel_id/invites.ts
@@ -19,7 +19,7 @@ export interface InviteCreateSchema {
 	target_user_type?: number;
 }
 
-router.post("/", route({ body: "InviteCreateSchema", permission: "CREATE_INVITES", right: "CREATE_INSTANT_INVITE" }),
+router.post("/", route({ body: "InviteCreateSchema", permission: "CREATE_INSTANT_INVITE", right: "CREATE_INVITES" }),
 			async (req: Request, res: Response) => {
 	const { user_id } = req;
 	const { channel_id } = req.params;

--- a/api/src/routes/guilds/#guild_id/index.ts
+++ b/api/src/routes/guilds/#guild_id/index.ts
@@ -42,11 +42,11 @@ router.patch("/", route({ body: "GuildUpdateSchema"}), async (req: Request, res:
 	const { guild_id } = req.params;
 	
 	
-	const rights = await getRight(req.user_id);
+	const rights = await getRights(req.user_id);
 	const permission = await getPermission(req.user_id, guild_id);
 	
 	if (!rights.has("MANAGE_GUILDS")||!permission.has("MANAGE_GUILD"))
-		throw DiscordApiErrors.MISSING_PERMISSIONS("MANAGE_GUILD");
+		throw DiscordApiErrors.MISSING_PERMISSIONS.withParams("MANAGE_GUILD");
 	
 	// TODO: guild update check image
 


### PR DESCRIPTION
make it built again :)

fix for this error when running `npm run setup`:
```
stdout: `dist/api/src/routes/channels/#channel_id/invites.ts(22,54): error TS2322: Type '"CREATE_INVITES"' is not assignable to type 'PermissionResolvable | undefined'.\n` +
    `dist/api/src/routes/channels/#channel_id/invites.ts(22,84): error TS2322: Type '"CREATE_INSTANT_INVITE"' is not assignable to type 'RightResolvable | undefined'.\n` +
    'dist/api/src/routes/guilds/#guild_id/index.ts(49,26): error TS2349: This expression is not callable.\n' +
    "  Type 'ApiError' has no call signatures.\n"
```