### PR TITLE
Fix range error in Rights check

### DIFF
--- a/util/src/entities/User.ts
+++ b/util/src/entities/User.ts
@@ -132,7 +132,7 @@ export class User extends BaseClass {
 	@Column()
 	public_flags: number;
 
-	@Column()
+	@Column({ type: "bigint" })
 	rights: string; // Rights
 
 	@OneToMany(() => Session, (session: Session) => session.user)


### PR DESCRIPTION
Resolves #715.

Rights were stored as a string, and fetched as a string. This caused the Rights.ts `getRights` function to pass a string to the `Rights` constructor, which calls `Bitfield.resolve`, which then tries to access `FLAGS[bit]` where `bit = 'right as string'`. Normally if resolve is called with a string, it's meant to be the name of the right ie `OPERATOR`, not the bitfield value `1`.