### PR TITLE
Fix users arbitrarily editing their own User object, and disallow sending messages to certain channels ( eg categories )

### DIFF
--- a/api/assets/schemas.json
+++ b/api/assets/schemas.json
@@ -1,8149 +1,12479 @@
 {
-	"LoginSchema": {
-		"type": "object",
-		"properties": {
-			"login": {
-				"type": "string"
-			},
-			"password": {
-				"type": "string"
-			},
-			"undelete": {
-				"type": "boolean"
-			},
-			"captcha_key": {
-				"type": "string"
-			},
-			"login_source": {
-				"type": "string"
-			},
-			"gift_code_sku_id": {
-				"type": "string"
-			}
-		},
-		"required": ["login", "password"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"RegisterSchema": {
-		"type": "object",
-		"properties": {
-			"username": {
-				"minLength": 2,
-				"maxLength": 32,
-				"type": "string"
-			},
-			"password": {
-				"minLength": 1,
-				"maxLength": 72,
-				"type": "string"
-			},
-			"consent": {
-				"type": "boolean"
-			},
-			"email": {
-				"format": "email",
-				"type": "string"
-			},
-			"fingerprint": {
-				"type": "string"
-			},
-			"invite": {
-				"type": "string"
-			},
-			"date_of_birth": {
-				"type": "string"
-			},
-			"gift_code_sku_id": {
-				"type": "string"
-			},
-			"captcha_key": {
-				"type": "string"
-			}
-		},
-		"required": ["consent", "username"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"ChannelModifySchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"maxLength": 100,
-				"type": "string"
-			},
-			"type": {
-				"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-				"type": "number"
-			},
-			"topic": {
-				"type": "string"
-			},
-			"icon": {
-				"type": ["null", "string"]
-			},
-			"bitrate": {
-				"type": "integer"
-			},
-			"user_limit": {
-				"type": "integer"
-			},
-			"rate_limit_per_user": {
-				"type": "integer"
-			},
-			"position": {
-				"type": "integer"
-			},
-			"permission_overwrites": {
-				"type": "array",
-				"items": {
-					"type": "object",
-					"properties": {
-						"id": {
-							"type": "string"
-						},
-						"type": {
-							"$ref": "#/definitions/ChannelPermissionOverwriteType"
-						},
-						"allow": {
-							"type": "string"
-						},
-						"deny": {
-							"type": "string"
-						}
-					},
-					"required": ["allow", "deny", "id", "type"]
-				}
-			},
-			"parent_id": {
-				"type": "string"
-			},
-			"id": {
-				"type": "string"
-			},
-			"nsfw": {
-				"type": "boolean"
-			},
-			"rtc_region": {
-				"type": "string"
-			},
-			"default_auto_archive_duration": {
-				"type": "integer"
-			}
-		},
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verified": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verified"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"MessageCreateSchema": {
-		"type": "object",
-		"properties": {
-			"content": {
-				"type": "string"
-			},
-			"nonce": {
-				"type": "string"
-			},
-			"tts": {
-				"type": "boolean"
-			},
-			"flags": {
-				"type": "string"
-			},
-			"embeds": {
-				"type": "array",
-				"items": {
-					"$ref": "#/definitions/Embed"
-				}
-			},
-			"embed": {
-				"$ref": "#/definitions/Embed"
-			},
-			"allowed_mentions": {
-				"type": "object",
-				"properties": {
-					"parse": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						}
-					},
-					"roles": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						}
-					},
-					"users": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						}
-					},
-					"replied_user": {
-						"type": "boolean"
-					}
-				}
-			},
-			"message_reference": {
-				"type": "object",
-				"properties": {
-					"message_id": {
-						"type": "string"
-					},
-					"channel_id": {
-						"type": "string"
-					},
-					"guild_id": {
-						"type": "string"
-					},
-					"fail_if_not_exists": {
-						"type": "boolean"
-					}
-				},
-				"required": ["channel_id", "message_id"]
-			},
-			"payload_json": {
-				"type": "string"
-			},
-			"file": {},
-			"attachments": {
-				"type": "array",
-				"items": {}
-			},
-			"sticker_ids": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			}
-		},
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"InviteCreateSchema": {
-		"type": "object",
-		"properties": {
-			"target_user_id": {
-				"type": "string"
-			},
-			"target_type": {
-				"type": "string"
-			},
-			"validate": {
-				"type": "string"
-			},
-			"max_age": {
-				"type": "integer"
-			},
-			"max_uses": {
-				"type": "integer"
-			},
-			"temporary": {
-				"type": "boolean"
-			},
-			"unique": {
-				"type": "boolean"
-			},
-			"target_user": {
-				"type": "string"
-			},
-			"target_user_type": {
-				"type": "integer"
-			}
-		},
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"MessageAcknowledgeSchema": {
-		"type": "object",
-		"properties": {
-			"manual": {
-				"type": "boolean"
-			},
-			"mention_count": {
-				"type": "integer"
-			}
-		},
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"BulkDeleteSchema": {
-		"type": "object",
-		"properties": {
-			"messages": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			}
-		},
-		"required": ["messages"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"ChannelPermissionOverwriteSchema": {
-		"type": "object",
-		"properties": {
-			"allow": {
-				"type": "string"
-			},
-			"deny": {
-				"type": "string"
-			},
-			"id": {
-				"type": "string"
-			},
-			"type": {
-				"$ref": "#/definitions/ChannelPermissionOverwriteType"
-			}
-		},
-		"required": ["allow", "deny", "id", "type"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"WebhookCreateSchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"maxLength": 80,
-				"type": "string"
-			},
-			"avatar": {
-				"type": "string"
-			}
-		},
-		"required": ["avatar", "name"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"BanCreateSchema": {
-		"type": "object",
-		"properties": {
-			"delete_message_days": {
-				"type": "string"
-			},
-			"reason": {
-				"type": "string"
-			}
-		},
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"ChannelReorderSchema": {
-		"type": "array",
-		"items": {
-			"type": "object",
-			"properties": {
-				"id": {
-					"type": "string"
-				},
-				"position": {
-					"type": "integer"
-				},
-				"lock_permissions": {
-					"type": "boolean"
-				},
-				"parent_id": {
-					"type": "string"
-				}
-			},
-			"required": ["id"]
-		},
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"EmojiCreateSchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"type": "string"
-			},
-			"image": {
-				"type": "string"
-			},
-			"require_colons": {
-				"type": ["null", "boolean"]
-			},
-			"roles": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			}
-		},
-		"required": ["image"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"EmojiModifySchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"type": "string"
-			},
-			"roles": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			}
-		},
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"GuildCreateSchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"maxLength": 100,
-				"type": "string"
-			},
-			"region": {
-				"type": "string"
-			},
-			"icon": {
-				"type": ["null", "string"]
-			},
-			"channels": {
-				"type": "array",
-				"items": {
-					"$ref": "#/definitions/ChannelModifySchema"
-				}
-			},
-			"guild_template_code": {
-				"type": "string"
-			},
-			"system_channel_id": {
-				"type": "string"
-			},
-			"rules_channel_id": {
-				"type": "string"
-			}
-		},
-		"required": ["name"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"GuildUpdateSchema": {
-		"type": "object",
-		"properties": {
-			"banner": {
-				"type": ["null", "string"]
-			},
-			"splash": {
-				"type": ["null", "string"]
-			},
-			"description": {
-				"type": "string"
-			},
-			"features": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			},
-			"verification_level": {
-				"type": "integer"
-			},
-			"default_message_notifications": {
-				"type": "integer"
-			},
-			"system_channel_flags": {
-				"type": "integer"
-			},
-			"explicit_content_filter": {
-				"type": "integer"
-			},
-			"public_updates_channel_id": {
-				"type": "string"
-			},
-			"afk_timeout": {
-				"type": "integer"
-			},
-			"afk_channel_id": {
-				"type": "string"
-			},
-			"preferred_locale": {
-				"type": "string"
-			},
-			"name": {
-				"maxLength": 100,
-				"type": "string"
-			},
-			"region": {
-				"type": "string"
-			},
-			"icon": {
-				"type": ["null", "string"]
-			},
-			"guild_template_code": {
-				"type": "string"
-			},
-			"system_channel_id": {
-				"type": "string"
-			},
-			"rules_channel_id": {
-				"type": "string"
-			}
-		},
-		"required": ["name"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"MemberChangeSchema": {
-		"type": "object",
-		"properties": {
-			"roles": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			}
-		},
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"MemberNickChangeSchema": {
-		"type": "object",
-		"properties": {
-			"nick": {
-				"type": "string"
-			}
-		},
-		"required": ["nick"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"RoleModifySchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"type": "string"
-			},
-			"permissions": {
-				"type": "string"
-			},
-			"color": {
-				"type": "integer"
-			},
-			"hoist": {
-				"type": "boolean"
-			},
-			"mentionable": {
-				"type": "boolean"
-			},
-			"position": {
-				"type": "integer"
-			}
-		},
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"RolePositionUpdateSchema": {
-		"type": "array",
-		"items": {
-			"type": "object",
-			"properties": {
-				"id": {
-					"type": "string"
-				},
-				"position": {
-					"type": "integer"
-				}
-			},
-			"required": ["id", "position"]
-		},
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"ModifyGuildStickerSchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"minLength": 2,
-				"maxLength": 30,
-				"type": "string"
-			},
-			"description": {
-				"maxLength": 100,
-				"type": "string"
-			},
-			"tags": {
-				"maxLength": 200,
-				"type": "string"
-			}
-		},
-		"required": ["name", "tags"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"TemplateCreateSchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"type": "string"
-			},
-			"description": {
-				"type": "string"
-			}
-		},
-		"required": ["name"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"TemplateModifySchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"type": "string"
-			},
-			"description": {
-				"type": "string"
-			}
-		},
-		"required": ["name"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"VanityUrlSchema": {
-		"type": "object",
-		"properties": {
-			"code": {
-				"minLength": 1,
-				"maxLength": 20,
-				"type": "string"
-			}
-		},
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"VoiceStateUpdateSchema": {
-		"type": "object",
-		"properties": {
-			"channel_id": {
-				"type": "string"
-			},
-			"guild_id": {
-				"type": "string"
-			},
-			"suppress": {
-				"type": "boolean"
-			},
-			"request_to_speak_timestamp": {
-				"type": "string",
-				"format": "date-time"
-			},
-			"self_mute": {
-				"type": "boolean"
-			},
-			"self_deaf": {
-				"type": "boolean"
-			},
-			"self_video": {
-				"type": "boolean"
-			}
-		},
-		"required": ["channel_id"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"GuildUpdateWelcomeScreenSchema": {
-		"type": "object",
-		"properties": {
-			"welcome_channels": {
-				"type": "array",
-				"items": {
-					"type": "object",
-					"properties": {
-						"channel_id": {
-							"type": "string"
-						},
-						"description": {
-							"type": "string"
-						},
-						"emoji_id": {
-							"type": "string"
-						},
-						"emoji_name": {
-							"type": "string"
-						}
-					},
-					"required": ["channel_id", "description", "emoji_name"]
-				}
-			},
-			"enabled": {
-				"type": "boolean"
-			},
-			"description": {
-				"type": "string"
-			}
-		},
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"WidgetModifySchema": {
-		"type": "object",
-		"properties": {
-			"enabled": {
-				"type": "boolean"
-			},
-			"channel_id": {
-				"type": "string"
-			}
-		},
-		"required": ["channel_id", "enabled"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"GuildTemplateCreateSchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"type": "string"
-			},
-			"avatar": {
-				"type": ["null", "string"]
-			}
-		},
-		"required": ["name"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"UserProfileResponse": {
-		"type": "object",
-		"properties": {
-			"user": {
-				"$ref": "#/definitions/UserPublic"
-			},
-			"connected_accounts": {
-				"$ref": "#/definitions/PublicConnectedAccount"
-			},
-			"premium_guild_since": {
-				"type": "string",
-				"format": "date-time"
-			},
-			"premium_since": {
-				"type": "string",
-				"format": "date-time"
-			}
-		},
-		"required": ["connected_accounts", "user"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"DmChannelCreateSchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"type": "string"
-			},
-			"recipients": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			}
-		},
-		"required": ["recipients"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"UserModifySchema": {
-		"type": "object",
-		"properties": {
-			"username": {
-				"minLength": 1,
-				"maxLength": 100,
-				"type": "string"
-			},
-			"avatar": {
-				"type": ["null", "string"]
-			},
-			"bio": {
-				"maxLength": 1024,
-				"type": "string"
-			},
-			"accent_color": {
-				"type": "integer"
-			},
-			"banner": {
-				"type": ["null", "string"]
-			},
-			"password": {
-				"type": "string"
-			},
-			"new_password": {
-				"type": "string"
-			},
-			"code": {
-				"type": "string"
-			}
-		},
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"RelationshipPutSchema": {
-		"type": "object",
-		"properties": {
-			"type": {
-				"enum": [1, 2, 3, 4],
-				"type": "number"
-			}
-		},
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"RelationshipPostSchema": {
-		"type": "object",
-		"properties": {
-			"discriminator": {
-				"type": "string"
-			},
-			"username": {
-				"type": "string"
-			}
-		},
-		"required": ["discriminator", "username"],
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"UserSettingsSchema": {
-		"type": "object",
-		"properties": {
-			"afk_timeout": {
-				"type": "integer"
-			},
-			"allow_accessibility_detection": {
-				"type": "boolean"
-			},
-			"animate_emoji": {
-				"type": "boolean"
-			},
-			"animate_stickers": {
-				"type": "integer"
-			},
-			"contact_sync_enabled": {
-				"type": "boolean"
-			},
-			"convert_emoticons": {
-				"type": "boolean"
-			},
-			"custom_status": {
-				"type": "object",
-				"properties": {
-					"emoji_id": {
-						"type": "string"
-					},
-					"emoji_name": {
-						"type": "string"
-					},
-					"expires_at": {
-						"type": "integer"
-					},
-					"text": {
-						"type": "string"
-					}
-				}
-			},
-			"default_guilds_restricted": {
-				"type": "boolean"
-			},
-			"detect_platform_accounts": {
-				"type": "boolean"
-			},
-			"developer_mode": {
-				"type": "boolean"
-			},
-			"disable_games_tab": {
-				"type": "boolean"
-			},
-			"enable_tts_command": {
-				"type": "boolean"
-			},
-			"explicit_content_filter": {
-				"type": "integer"
-			},
-			"friend_source_flags": {
-				"type": "object",
-				"properties": {
-					"all": {
-						"type": "boolean"
-					}
-				},
-				"required": ["all"]
-			},
-			"gateway_connected": {
-				"type": "boolean"
-			},
-			"gif_auto_play": {
-				"type": "boolean"
-			},
-			"guild_folders": {
-				"type": "array",
-				"items": {
-					"type": "object",
-					"properties": {
-						"color": {
-							"type": "integer"
-						},
-						"guild_ids": {
-							"type": "array",
-							"items": {
-								"type": "string"
-							}
-						},
-						"id": {
-							"type": "integer"
-						},
-						"name": {
-							"type": "string"
-						}
-					},
-					"required": ["color", "guild_ids", "id", "name"]
-				}
-			},
-			"guild_positions": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			},
-			"inline_attachment_media": {
-				"type": "boolean"
-			},
-			"inline_embed_media": {
-				"type": "boolean"
-			},
-			"locale": {
-				"type": "string"
-			},
-			"message_display_compact": {
-				"type": "boolean"
-			},
-			"native_phone_integration_enabled": {
-				"type": "boolean"
-			},
-			"render_embeds": {
-				"type": "boolean"
-			},
-			"render_reactions": {
-				"type": "boolean"
-			},
-			"restricted_guilds": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			},
-			"show_current_game": {
-				"type": "boolean"
-			},
-			"status": {
-				"enum": ["dnd", "idle", "offline", "online", "invisible"],
-				"type": "string"
-			},
-			"stream_notifications_enabled": {
-				"type": "boolean"
-			},
-			"theme": {
-				"enum": ["dark", "white"],
-				"type": "string"
-			},
-			"timezone_offset": {
-				"type": "integer"
-			}
-		},
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1],
-				"type": "number"
-			},
-			"Embed": {
-				"type": "object",
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"type": {
-						"enum": ["article", "gifv", "image", "link", "rich", "video"],
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"color": {
-						"type": "integer"
-					},
-					"footer": {
-						"type": "object",
-						"properties": {
-							"text": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						},
-						"required": ["text"]
-					},
-					"image": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"thumbnail": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"video": {
-						"$ref": "#/definitions/EmbedImage"
-					},
-					"provider": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						}
-					},
-					"author": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							},
-							"icon_url": {
-								"type": "string"
-							},
-							"proxy_icon_url": {
-								"type": "string"
-							}
-						}
-					},
-					"fields": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"name": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								},
-								"inline": {
-									"type": "boolean"
-								}
-							},
-							"required": ["name", "value"]
-						}
-					}
-				}
-			},
-			"EmbedImage": {
-				"type": "object",
-				"properties": {
-					"url": {
-						"type": "string"
-					},
-					"proxy_url": {
-						"type": "string"
-					},
-					"height": {
-						"type": "integer"
-					},
-					"width": {
-						"type": "integer"
-					}
-				}
-			},
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 2, 3, 4, 5, 6],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					}
-				}
-			},
-			"UserPublic": {
-				"type": "object",
-				"properties": {
-					"username": {
-						"type": "string"
-					},
-					"discriminator": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"public_flags": {
-						"type": "integer"
-					},
-					"avatar": {
-						"type": "string"
-					},
-					"accent_color": {
-						"type": "integer"
-					},
-					"banner": {
-						"type": "string"
-					},
-					"bio": {
-						"type": "string"
-					},
-					"bot": {
-						"type": "boolean"
-					}
-				},
-				"required": ["bio", "bot", "discriminator", "id", "public_flags", "username"]
-			},
-			"PublicConnectedAccount": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					},
-					"verifie": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name", "type", "verifie"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	}
+    "LoginSchema": {
+        "type": "object",
+        "properties": {
+            "login": {
+                "type": "string"
+            },
+            "password": {
+                "type": "string"
+            },
+            "undelete": {
+                "type": "boolean"
+            },
+            "captcha_key": {
+                "type": "string"
+            },
+            "login_source": {
+                "type": "string"
+            },
+            "gift_code_sku_id": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "login",
+            "password"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "RegisterSchema": {
+        "type": "object",
+        "properties": {
+            "username": {
+                "minLength": 2,
+                "maxLength": 32,
+                "type": "string"
+            },
+            "password": {
+                "minLength": 1,
+                "maxLength": 72,
+                "type": "string"
+            },
+            "consent": {
+                "type": "boolean"
+            },
+            "email": {
+                "format": "email",
+                "type": "string"
+            },
+            "fingerprint": {
+                "type": "string"
+            },
+            "invite": {
+                "type": "string"
+            },
+            "date_of_birth": {
+                "type": "string"
+            },
+            "gift_code_sku_id": {
+                "type": "string"
+            },
+            "captcha_key": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "consent",
+            "username"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "ChannelModifySchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "maxLength": 100,
+                "type": "string"
+            },
+            "type": {
+                "enum": [
+                    0,
+                    1,
+                    10,
+                    11,
+                    12,
+                    13,
+                    2,
+                    255,
+                    3,
+                    33,
+                    34,
+                    35,
+                    4,
+                    5,
+                    6,
+                    64,
+                    7,
+                    8,
+                    9
+                ],
+                "type": "number"
+            },
+            "topic": {
+                "type": "string"
+            },
+            "icon": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "bitrate": {
+                "type": "integer"
+            },
+            "user_limit": {
+                "type": "integer"
+            },
+            "rate_limit_per_user": {
+                "type": "integer"
+            },
+            "position": {
+                "type": "integer"
+            },
+            "permission_overwrites": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                        },
+                        "allow": {
+                            "type": "string"
+                        },
+                        "deny": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "allow",
+                        "deny",
+                        "id",
+                        "type"
+                    ]
+                }
+            },
+            "parent_id": {
+                "type": "string"
+            },
+            "id": {
+                "type": "string"
+            },
+            "nsfw": {
+                "type": "boolean"
+            },
+            "rtc_region": {
+                "type": "string"
+            },
+            "default_auto_archive_duration": {
+                "type": "integer"
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "MessageCreateSchema": {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string"
+            },
+            "nonce": {
+                "type": "string"
+            },
+            "tts": {
+                "type": "boolean"
+            },
+            "flags": {
+                "type": "string"
+            },
+            "embeds": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/Embed"
+                }
+            },
+            "embed": {
+                "$ref": "#/definitions/Embed"
+            },
+            "allowed_mentions": {
+                "type": "object",
+                "properties": {
+                    "parse": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "roles": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "users": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "replied_user": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "message_reference": {
+                "type": "object",
+                "properties": {
+                    "message_id": {
+                        "type": "string"
+                    },
+                    "channel_id": {
+                        "type": "string"
+                    },
+                    "guild_id": {
+                        "type": "string"
+                    },
+                    "fail_if_not_exists": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "channel_id",
+                    "message_id"
+                ]
+            },
+            "payload_json": {
+                "type": "string"
+            },
+            "file": {},
+            "attachments": {
+                "type": "array",
+                "items": {}
+            },
+            "sticker_ids": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "InviteCreateSchema": {
+        "type": "object",
+        "properties": {
+            "target_user_id": {
+                "type": "string"
+            },
+            "target_type": {
+                "type": "string"
+            },
+            "validate": {
+                "type": "string"
+            },
+            "max_age": {
+                "type": "integer"
+            },
+            "max_uses": {
+                "type": "integer"
+            },
+            "temporary": {
+                "type": "boolean"
+            },
+            "unique": {
+                "type": "boolean"
+            },
+            "target_user": {
+                "type": "string"
+            },
+            "target_user_type": {
+                "type": "integer"
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "MessageAcknowledgeSchema": {
+        "type": "object",
+        "properties": {
+            "manual": {
+                "type": "boolean"
+            },
+            "mention_count": {
+                "type": "integer"
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "BulkDeleteSchema": {
+        "type": "object",
+        "properties": {
+            "messages": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "messages"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "ChannelPermissionOverwriteSchema": {
+        "type": "object",
+        "properties": {
+            "allow": {
+                "type": "string"
+            },
+            "deny": {
+                "type": "string"
+            },
+            "id": {
+                "type": "string"
+            },
+            "type": {
+                "$ref": "#/definitions/ChannelPermissionOverwriteType"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "allow",
+            "deny",
+            "id",
+            "type"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "WebhookCreateSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "maxLength": 80,
+                "type": "string"
+            },
+            "avatar": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "avatar",
+            "name"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "GatewayBotResponse": {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string"
+            },
+            "shards": {
+                "type": "integer"
+            },
+            "session_start_limit": {
+                "type": "object",
+                "properties": {
+                    "total": {
+                        "type": "integer"
+                    },
+                    "remaining": {
+                        "type": "integer"
+                    },
+                    "reset_after": {
+                        "type": "integer"
+                    },
+                    "max_concurrency": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "max_concurrency",
+                    "remaining",
+                    "reset_after",
+                    "total"
+                ]
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "session_start_limit",
+            "shards",
+            "url"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "GatewayResponse": {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "url"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "BanCreateSchema": {
+        "type": "object",
+        "properties": {
+            "delete_message_days": {
+                "type": "string"
+            },
+            "reason": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "BanRegistrySchema": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string"
+            },
+            "user_id": {
+                "type": "string"
+            },
+            "guild_id": {
+                "type": "string"
+            },
+            "executor_id": {
+                "type": "string"
+            },
+            "ip": {
+                "type": "string"
+            },
+            "reason": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "executor_id",
+            "guild_id",
+            "id",
+            "user_id"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "BanModeratorSchema": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string"
+            },
+            "user_id": {
+                "type": "string"
+            },
+            "guild_id": {
+                "type": "string"
+            },
+            "executor_id": {
+                "type": "string"
+            },
+            "reason": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "executor_id",
+            "guild_id",
+            "id",
+            "user_id"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "ChannelReorderSchema": {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "position": {
+                    "type": "integer"
+                },
+                "lock_permissions": {
+                    "type": "boolean"
+                },
+                "parent_id": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "id"
+            ]
+        },
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "EmojiCreateSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "image": {
+                "type": "string"
+            },
+            "require_colons": {
+                "type": [
+                    "null",
+                    "boolean"
+                ]
+            },
+            "roles": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "image"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "EmojiModifySchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "roles": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "GuildCreateSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "maxLength": 100,
+                "type": "string"
+            },
+            "region": {
+                "type": "string"
+            },
+            "icon": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "channels": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/ChannelModifySchema"
+                }
+            },
+            "guild_template_code": {
+                "type": "string"
+            },
+            "system_channel_id": {
+                "type": "string"
+            },
+            "rules_channel_id": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "GuildUpdateSchema": {
+        "type": "object",
+        "properties": {
+            "banner": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "splash": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "description": {
+                "type": "string"
+            },
+            "features": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "verification_level": {
+                "type": "integer"
+            },
+            "default_message_notifications": {
+                "type": "integer"
+            },
+            "system_channel_flags": {
+                "type": "integer"
+            },
+            "explicit_content_filter": {
+                "type": "integer"
+            },
+            "public_updates_channel_id": {
+                "type": "string"
+            },
+            "afk_timeout": {
+                "type": "integer"
+            },
+            "afk_channel_id": {
+                "type": "string"
+            },
+            "preferred_locale": {
+                "type": "string"
+            },
+            "name": {
+                "maxLength": 100,
+                "type": "string"
+            },
+            "region": {
+                "type": "string"
+            },
+            "icon": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "guild_template_code": {
+                "type": "string"
+            },
+            "system_channel_id": {
+                "type": "string"
+            },
+            "rules_channel_id": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "MemberChangeSchema": {
+        "type": "object",
+        "properties": {
+            "roles": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "MemberNickChangeSchema": {
+        "type": "object",
+        "properties": {
+            "nick": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "nick"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "PruneSchema": {
+        "type": "object",
+        "properties": {
+            "days": {
+                "type": "integer"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "days"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "RoleModifySchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "permissions": {
+                "type": "string"
+            },
+            "color": {
+                "type": "integer"
+            },
+            "hoist": {
+                "type": "boolean"
+            },
+            "mentionable": {
+                "type": "boolean"
+            },
+            "position": {
+                "type": "integer"
+            },
+            "icon": {
+                "type": "string"
+            },
+            "unicode_emoji": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "RolePositionUpdateSchema": {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "position": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "id",
+                "position"
+            ]
+        },
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "ModifyGuildStickerSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "minLength": 2,
+                "maxLength": 30,
+                "type": "string"
+            },
+            "description": {
+                "maxLength": 100,
+                "type": "string"
+            },
+            "tags": {
+                "maxLength": 200,
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name",
+            "tags"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "TemplateCreateSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "description": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "TemplateModifySchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "description": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "VanityUrlSchema": {
+        "type": "object",
+        "properties": {
+            "code": {
+                "minLength": 1,
+                "maxLength": 20,
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "VoiceStateUpdateSchema": {
+        "type": "object",
+        "properties": {
+            "channel_id": {
+                "type": "string"
+            },
+            "guild_id": {
+                "type": "string"
+            },
+            "suppress": {
+                "type": "boolean"
+            },
+            "request_to_speak_timestamp": {
+                "type": "string",
+                "format": "date-time"
+            },
+            "self_mute": {
+                "type": "boolean"
+            },
+            "self_deaf": {
+                "type": "boolean"
+            },
+            "self_video": {
+                "type": "boolean"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "channel_id"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "GuildUpdateWelcomeScreenSchema": {
+        "type": "object",
+        "properties": {
+            "welcome_channels": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "channel_id": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "emoji_id": {
+                            "type": "string"
+                        },
+                        "emoji_name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "channel_id",
+                        "description",
+                        "emoji_name"
+                    ]
+                }
+            },
+            "enabled": {
+                "type": "boolean"
+            },
+            "description": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "WidgetModifySchema": {
+        "type": "object",
+        "properties": {
+            "enabled": {
+                "type": "boolean"
+            },
+            "channel_id": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "channel_id",
+            "enabled"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "GuildTemplateCreateSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "avatar": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "UserProfileResponse": {
+        "type": "object",
+        "properties": {
+            "user": {
+                "$ref": "#/definitions/UserPublic"
+            },
+            "connected_accounts": {
+                "$ref": "#/definitions/PublicConnectedAccount"
+            },
+            "premium_guild_since": {
+                "type": "string",
+                "format": "date-time"
+            },
+            "premium_since": {
+                "type": "string",
+                "format": "date-time"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "connected_accounts",
+            "user"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "UserRelationsResponse": {
+        "type": "object",
+        "properties": {
+            "object": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "username": {
+                        "type": "string"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "object"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "DmChannelCreateSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "recipients": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "recipients"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "UserModifySchema": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+            "username": {
+                "minLength": 1,
+                "maxLength": 100,
+                "type": "string"
+            },
+            "avatar": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "bio": {
+                "maxLength": 1024,
+                "type": "string"
+            },
+            "accent_color": {
+                "type": "integer"
+            },
+            "banner": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "password": {
+                "type": "string"
+            },
+            "new_password": {
+                "type": "string"
+            },
+            "code": {
+                "type": "string"
+            }
+        },
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "RelationshipPutSchema": {
+        "type": "object",
+        "properties": {
+            "type": {
+                "enum": [
+                    1,
+                    2,
+                    3,
+                    4
+                ],
+                "type": "number"
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "RelationshipPostSchema": {
+        "type": "object",
+        "properties": {
+            "discriminator": {
+                "type": "string"
+            },
+            "username": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "discriminator",
+            "username"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "UserSettingsSchema": {
+        "type": "object",
+        "properties": {
+            "afk_timeout": {
+                "type": "integer"
+            },
+            "allow_accessibility_detection": {
+                "type": "boolean"
+            },
+            "animate_emoji": {
+                "type": "boolean"
+            },
+            "animate_stickers": {
+                "type": "integer"
+            },
+            "contact_sync_enabled": {
+                "type": "boolean"
+            },
+            "convert_emoticons": {
+                "type": "boolean"
+            },
+            "custom_status": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "emoji_id": {
+                                "type": "string"
+                            },
+                            "emoji_name": {
+                                "type": "string"
+                            },
+                            "expires_at": {
+                                "type": "integer"
+                            },
+                            "text": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "null"
+                    }
+                ]
+            },
+            "default_guilds_restricted": {
+                "type": "boolean"
+            },
+            "detect_platform_accounts": {
+                "type": "boolean"
+            },
+            "developer_mode": {
+                "type": "boolean"
+            },
+            "disable_games_tab": {
+                "type": "boolean"
+            },
+            "enable_tts_command": {
+                "type": "boolean"
+            },
+            "explicit_content_filter": {
+                "type": "integer"
+            },
+            "friend_source_flags": {
+                "type": "object",
+                "properties": {
+                    "all": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "all"
+                ]
+            },
+            "gateway_connected": {
+                "type": "boolean"
+            },
+            "gif_auto_play": {
+                "type": "boolean"
+            },
+            "guild_folders": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "color": {
+                            "type": "integer"
+                        },
+                        "guild_ids": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "id": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "color",
+                        "guild_ids",
+                        "id",
+                        "name"
+                    ]
+                }
+            },
+            "guild_positions": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "inline_attachment_media": {
+                "type": "boolean"
+            },
+            "inline_embed_media": {
+                "type": "boolean"
+            },
+            "locale": {
+                "type": "string"
+            },
+            "message_display_compact": {
+                "type": "boolean"
+            },
+            "native_phone_integration_enabled": {
+                "type": "boolean"
+            },
+            "render_embeds": {
+                "type": "boolean"
+            },
+            "render_reactions": {
+                "type": "boolean"
+            },
+            "restricted_guilds": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "show_current_game": {
+                "type": "boolean"
+            },
+            "status": {
+                "enum": [
+                    "dnd",
+                    "idle",
+                    "invisible",
+                    "offline",
+                    "online"
+                ],
+                "type": "string"
+            },
+            "stream_notifications_enabled": {
+                "type": "boolean"
+            },
+            "theme": {
+                "enum": [
+                    "dark",
+                    "white"
+                ],
+                "type": "string"
+            },
+            "timezone_offset": {
+                "type": "integer"
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    }
 }

--- a/api/scripts/generate_schema.js
+++ b/api/scripts/generate_schema.js
@@ -31,7 +31,6 @@ const Excluded = [
 ];
 
 function modify(obj) {
-	delete obj.additionalProperties;
 	for (var k in obj) {
 		if (typeof obj[k] === "object" && obj[k] !== null) {
 			modify(obj[k]);

--- a/api/src/routes/channels/#channel_id/messages/index.ts
+++ b/api/src/routes/channels/#channel_id/messages/index.ts
@@ -183,6 +183,9 @@ router.post(
 			}
 		}
 		const channel = await Channel.findOneOrFail({ where: { id: channel_id }, relations: ["recipients", "recipients.user"] });
+		if (!channel.isWritable()) {
+			throw new HTTPError(`Cannot send messages to channel of type ${channel.type}`, 400)
+		}
 
 		const embeds = body.embeds || [];
 		if (body.embed) embeds.push(body.embed);
@@ -220,6 +223,8 @@ router.post(
 				})
 			);
 		}
+
+
 	
 		//Fix for the client bug
 		delete message.member

--- a/api/src/routes/users/@me/index.ts
+++ b/api/src/routes/users/@me/index.ts
@@ -34,6 +34,7 @@ router.patch("/", route({ body: "UserModifySchema" }), async (req: Request, res:
 	if (body.banner) body.banner = await handleFile(`/banners/${req.user_id}`, body.banner as string);
 
 	const user = await User.findOneOrFail({ where: { id: req.user_id }, select: [...PrivateUserProjection, "data"] });
+	user.assign(body);
 
 	if (body.password) {
 		if (user.data?.hash) {
@@ -45,8 +46,6 @@ router.patch("/", route({ body: "UserModifySchema" }), async (req: Request, res:
 			user.data.hash = await bcrypt.hash(body.password, 12);
 		}
 	}
-
-	user.assign(body);
 
 	if (body.new_password) {
 		if (!body.password && !user.email) {

--- a/api/src/routes/users/@me/index.ts
+++ b/api/src/routes/users/@me/index.ts
@@ -34,7 +34,6 @@ router.patch("/", route({ body: "UserModifySchema" }), async (req: Request, res:
 	if (body.banner) body.banner = await handleFile(`/banners/${req.user_id}`, body.banner as string);
 
 	const user = await User.findOneOrFail({ where: { id: req.user_id }, select: [...PrivateUserProjection, "data"] });
-	user.assign(body);
 
 	if (body.password) {
 		if (user.data?.hash) {
@@ -65,6 +64,7 @@ router.patch("/", route({ body: "UserModifySchema" }), async (req: Request, res:
         }
     }
 
+	user.assign(body);
 	await user.save();
 
 	// @ts-ignore

--- a/util/src/entities/Channel.ts
+++ b/util/src/entities/Channel.ts
@@ -352,6 +352,17 @@ export class Channel extends BaseClass {
 	isDm() {
 		return this.type === ChannelType.DM || this.type === ChannelType.GROUP_DM;
 	}
+
+	// Does the channel support sending messages ( eg categories do not )
+	isWritable() {
+		const disallowedChannelTypes = [
+			ChannelType.GUILD_CATEGORY,
+			ChannelType.GUILD_VOICE,		// TODO: Remove this when clients can send messages to voice channels on discord.com
+			ChannelType.GUILD_STAGE_VOICE,
+			ChannelType.VOICELESS_WHITEBOARD,
+		];
+		return disallowedChannelTypes.indexOf(this.type) == -1;
+	}
 }
 
 export interface ChannelPermissionOverwrite {


### PR DESCRIPTION
Currently, `PATCH /users/@me` does not disallow additional parameters such as `flags` or `rights` from being passed, thus modifying the User object. This allows a user to self-promote themselves to instance operator, give themselves flags, etc. This issue also existed for all other routes, such as `PATCH /channel/:id`, but as you needed permission to use that route it less an issue.
Fixed by re-allowing `additionalProperties` to be set to `false` by the schema generation

Additionally, this PR disables sending messages to channels of type voice, stage, voiceless whiteboard/stage or category.