### PR TITLE
Respect register_dateOfBirth_required = false

### DIFF
--- a/api/src/routes/auth/register.ts
+++ b/api/src/routes/auth/register.ts
@@ -128,7 +128,7 @@ router.post("/", route({ body: "RegisterSchema" }), async (req: Request, res: Re
 		throw FieldErrors({
 			date_of_birth: { code: "BASE_TYPE_REQUIRED", message: req.t("common:field.BASE_TYPE_REQUIRED") }
 		});
-	} else if (register.dateOfBirth.minimum) {
+	} else if (register.dateOfBirth.required && register.dateOfBirth.minimum) {
 		const minimum = new Date();
 		minimum.setFullYear(minimum.getFullYear() - register.dateOfBirth.minimum);
 		body.date_of_birth = new Date(body.date_of_birth as Date);

--- a/util/src/entities/Config.ts
+++ b/util/src/entities/Config.ts
@@ -324,7 +324,7 @@ export const DefaultConfigOptions: ConfigValue = {
 			// domains: fs.readFileSync(__dirname + "/blockedEmailDomains.txt", { encoding: "utf8" }).split("\n"),
 		},
 		dateOfBirth: {
-			required: false,
+			required: true,
 			minimum: 13,
 		},
 		disabled: false,


### PR DESCRIPTION
If `register_dateOfBirth_required` is set to false, only the check for if the date of birth field was passed is skipped. It still tries to *use* the field. This PR fixes that ( also changes the default value from false -> true )