### PR TITLE
Expose general instance information via api /ping route

### DIFF
--- a/api/src/routes/ping.ts
+++ b/api/src/routes/ping.ts
@@ -1,10 +1,26 @@
 import { Router, Response, Request } from "express";
 import { route } from "@fosscord/api";
+import { Config } from "@fosscord/util";
 
 const router = Router();
 
 router.get("/", route({}), (req: Request, res: Response) => {
-	res.send("pong");
+	const { general } = Config.get();
+	res.send({
+		ping: "pong!",
+		instance: {
+			id: general.instanceId,
+			name: general.instanceName,
+			description: general.instanceDescription,
+			image: general.image,
+
+			correspondenceEmail: general.correspondenceEmail,
+			correspondenceUserID: general.correspondenceUserID,
+
+			frontPage: general.frontPage,
+			tosPage: general.tosPage,
+		},
+	});
 });
 
 export default router;


### PR DESCRIPTION
Mostly because I wanted some way to name instances in the client plugin. The config.general.* information is unused elsewhere, as far as I know and I think it makes sense to expose it. The /ping route is mostly useless otherwise. The only change I think could be made is that this information might be better locked behind a token?