### PR TITLE
feat: change default rights to discord defaults

### DIFF
--- a/util/src/entities/User.ts
+++ b/util/src/entities/User.ts
@@ -268,7 +268,7 @@ export class User extends BaseClass {
 			disabled: false,
 			deleted: false,
 			email: email,
-			rights: "0", // TODO: grant rights correctly, as 0 actually stands for no rights at all
+			rights: "648540060672", // TODO: grant rights correctly, as 0 actually stands for no rights at all
 			nsfw_allowed: true, // TODO: depending on age
 			public_flags: "0",
 			flags: "0", // TODO: generate


### PR DESCRIPTION
this should allow new instance hosters to create a new guild without having to edit the source code, therefore i think of this to be a saner default than just having 0 / no rights as a new user on the instance. The discord user default rights on the discord instance can be found documented in: https://docs.fosscord.com/api/rights/