### PR TITLE
Skip check for rate limit bypass if no user id is provided

### DIFF
--- a/api/src/middlewares/RateLimit.ts
+++ b/api/src/middlewares/RateLimit.ts
@@ -46,12 +46,14 @@ export default function rateLimit(opts: {
 }): any {
 	return async (req: Request, res: Response, next: NextFunction): Promise<any> => {
 		// exempt user? if so, immediately short circuit
-		const rights = await getRights(req.user_id);
-		if (rights.has("BYPASS_RATE_LIMITS")) return;
-		
+		if (req.user_id) {
+			const rights = await getRights(req.user_id);
+			if (rights.has("BYPASS_RATE_LIMITS")) return;
+		}
+
 		const bucket_id = opts.bucket || req.originalUrl.replace(API_PREFIX_TRAILING_SLASH, "");
 		var executor_id = getIpAdress(req);
-		if (!opts.onlyIp && req.user_id) executor_id = req.user_id;		
+		if (!opts.onlyIp && req.user_id) executor_id = req.user_id;
 
 		var max_hits = opts.count;
 		if (opts.bot && req.user_bot) max_hits = opts.bot;
@@ -161,7 +163,7 @@ export async function initRateLimits(app: Router) {
 	app.use("/auth/register", rateLimit({ onlyIp: true, success: true, ...routes.auth.register }));
 }
 
-async function hitRoute(opts: { executor_id: string; bucket_id: string; max_hits: number; window: number }) {
+async function hitRoute(opts: { executor_id: string; bucket_id: string; max_hits: number; window: number; }) {
 	const id = opts.executor_id + opts.bucket_id;
 	var limit = Cache.get(id);
 	if (!limit) {


### PR DESCRIPTION
If a request does not contain `user_id`, it will currently fail when rate limits are enabled. This includes logins, register, and all other requests where the client does not send `user_id` such as GET messages, etc.