### PR TITLE
generate:schema - exclude Ajv types, force include util types

### DIFF
--- a/api/assets/schemas.json
+++ b/api/assets/schemas.json
@@ -1,181 +1,95 @@
 {
-    "LoginSchema": {
+    "MessageCreateSchema": {
         "type": "object",
         "properties": {
-            "login": {
+            "content": {
                 "type": "string"
             },
-            "password": {
+            "nonce": {
                 "type": "string"
             },
-            "undelete": {
+            "tts": {
                 "type": "boolean"
             },
-            "captcha_key": {
+            "flags": {
                 "type": "string"
             },
-            "login_source": {
-                "type": "string"
-            },
-            "gift_code_sku_id": {
-                "type": "string"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "login",
-            "password"
-        ],
-        "$schema": "http://json-schema.org/draft-07/schema#"
-    },
-    "RegisterSchema": {
-        "type": "object",
-        "properties": {
-            "username": {
-                "minLength": 2,
-                "maxLength": 32,
-                "type": "string"
-            },
-            "password": {
-                "minLength": 1,
-                "maxLength": 72,
-                "type": "string"
-            },
-            "consent": {
-                "type": "boolean"
-            },
-            "email": {
-                "format": "email",
-                "type": "string"
-            },
-            "fingerprint": {
-                "type": "string"
-            },
-            "invite": {
-                "type": "string"
-            },
-            "date_of_birth": {
-                "type": "string"
-            },
-            "gift_code_sku_id": {
-                "type": "string"
-            },
-            "captcha_key": {
-                "type": "string"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "consent",
-            "username"
-        ],
-        "$schema": "http://json-schema.org/draft-07/schema#"
-    },
-    "ChannelModifySchema": {
-        "type": "object",
-        "properties": {
-            "name": {
-                "maxLength": 100,
-                "type": "string"
-            },
-            "type": {
-                "enum": [
-                    0,
-                    1,
-                    10,
-                    11,
-                    12,
-                    13,
-                    2,
-                    255,
-                    3,
-                    33,
-                    34,
-                    35,
-                    4,
-                    5,
-                    6,
-                    64,
-                    7,
-                    8,
-                    9
-                ],
-                "type": "number"
-            },
-            "topic": {
-                "type": "string"
-            },
-            "icon": {
-                "type": [
-                    "null",
-                    "string"
-                ]
-            },
-            "bitrate": {
-                "type": "integer"
-            },
-            "user_limit": {
-                "type": "integer"
-            },
-            "rate_limit_per_user": {
-                "type": "integer"
-            },
-            "position": {
-                "type": "integer"
-            },
-            "permission_overwrites": {
+            "embeds": {
                 "type": "array",
                 "items": {
-                    "type": "object",
-                    "properties": {
-                        "id": {
-                            "type": "string"
-                        },
-                        "type": {
-                            "$ref": "#/definitions/ChannelPermissionOverwriteType"
-                        },
-                        "allow": {
-                            "type": "string"
-                        },
-                        "deny": {
+                    "$ref": "#/definitions/Embed"
+                }
+            },
+            "embed": {
+                "$ref": "#/definitions/Embed"
+            },
+            "allowed_mentions": {
+                "type": "object",
+                "properties": {
+                    "parse": {
+                        "type": "array",
+                        "items": {
                             "type": "string"
                         }
                     },
-                    "additionalProperties": false,
-                    "required": [
-                        "allow",
-                        "deny",
-                        "id",
-                        "type"
-                    ]
+                    "roles": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "users": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "replied_user": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "message_reference": {
+                "type": "object",
+                "properties": {
+                    "message_id": {
+                        "type": "string"
+                    },
+                    "channel_id": {
+                        "type": "string"
+                    },
+                    "guild_id": {
+                        "type": "string"
+                    },
+                    "fail_if_not_exists": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "channel_id",
+                    "message_id"
+                ]
+            },
+            "payload_json": {
+                "type": "string"
+            },
+            "file": {},
+            "attachments": {
+                "description": "TODO: we should create an interface for attachments\nTODO: OpenWAAO<-->attachment-style metadata conversion",
+                "type": "array",
+                "items": {}
+            },
+            "sticker_ids": {
+                "type": "array",
+                "items": {
+                    "type": "string"
                 }
-            },
-            "parent_id": {
-                "type": "string"
-            },
-            "id": {
-                "type": "string"
-            },
-            "nsfw": {
-                "type": "boolean"
-            },
-            "rtc_region": {
-                "type": "string"
-            },
-            "default_auto_archive_duration": {
-                "type": "integer"
             }
         },
         "additionalProperties": false,
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -306,6 +220,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -321,6 +247,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -472,104 +400,24 @@
         },
         "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "MessageCreateSchema": {
+    "RouteResponse": {
         "type": "object",
         "properties": {
-            "content": {
-                "type": "string"
+            "status": {
+                "type": "integer"
             },
-            "nonce": {
-                "type": "string"
-            },
-            "tts": {
-                "type": "boolean"
-            },
-            "flags": {
-                "type": "string"
-            },
-            "embeds": {
-                "type": "array",
-                "items": {
-                    "$ref": "#/definitions/Embed"
-                }
-            },
-            "embed": {
-                "$ref": "#/definitions/Embed"
-            },
-            "allowed_mentions": {
-                "type": "object",
-                "properties": {
-                    "parse": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "roles": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "users": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "replied_user": {
-                        "type": "boolean"
-                    }
-                },
-                "additionalProperties": false
-            },
-            "message_reference": {
-                "type": "object",
-                "properties": {
-                    "message_id": {
-                        "type": "string"
-                    },
-                    "channel_id": {
-                        "type": "string"
-                    },
-                    "guild_id": {
-                        "type": "string"
-                    },
-                    "fail_if_not_exists": {
-                        "type": "boolean"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "channel_id",
-                    "message_id"
-                ]
-            },
-            "payload_json": {
-                "type": "string"
-            },
-            "file": {},
-            "attachments": {
-                "type": "array",
-                "items": {}
-            },
-            "sticker_ids": {
+            "body": {
                 "type": "array",
                 "items": {
                     "type": "string"
                 }
+            },
+            "headers": {
+                "$ref": "#/definitions/Record<string,string>"
             }
         },
         "additionalProperties": false,
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -700,6 +548,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -715,6 +575,1107 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "LoginSchema": {
+        "type": "object",
+        "properties": {
+            "login": {
+                "type": "string"
+            },
+            "password": {
+                "type": "string"
+            },
+            "undelete": {
+                "type": "boolean"
+            },
+            "captcha_key": {
+                "type": "string"
+            },
+            "login_source": {
+                "type": "string"
+            },
+            "gift_code_sku_id": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "login",
+            "password"
+        ],
+        "definitions": {
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "RegisterSchema": {
+        "type": "object",
+        "properties": {
+            "username": {
+                "minLength": 2,
+                "maxLength": 32,
+                "type": "string"
+            },
+            "password": {
+                "minLength": 1,
+                "maxLength": 72,
+                "type": "string"
+            },
+            "consent": {
+                "type": "boolean"
+            },
+            "email": {
+                "format": "email",
+                "type": "string"
+            },
+            "fingerprint": {
+                "type": "string"
+            },
+            "invite": {
+                "type": "string"
+            },
+            "date_of_birth": {
+                "type": "string"
+            },
+            "gift_code_sku_id": {
+                "type": "string"
+            },
+            "captcha_key": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "consent",
+            "username"
+        ],
+        "definitions": {
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "ChannelModifySchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "maxLength": 100,
+                "type": "string"
+            },
+            "type": {
+                "enum": [
+                    0,
+                    1,
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15,
+                    2,
+                    255,
+                    3,
+                    33,
+                    34,
+                    35,
+                    4,
+                    5,
+                    6,
+                    64,
+                    7,
+                    8,
+                    9
+                ],
+                "type": "number"
+            },
+            "topic": {
+                "type": "string"
+            },
+            "icon": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "bitrate": {
+                "type": "integer"
+            },
+            "user_limit": {
+                "type": "integer"
+            },
+            "rate_limit_per_user": {
+                "type": "integer"
+            },
+            "position": {
+                "type": "integer"
+            },
+            "permission_overwrites": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                        },
+                        "allow": {
+                            "type": "string"
+                        },
+                        "deny": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "allow",
+                        "deny",
+                        "id",
+                        "type"
+                    ]
+                }
+            },
+            "parent_id": {
+                "type": "string"
+            },
+            "id": {
+                "type": "string"
+            },
+            "nsfw": {
+                "type": "boolean"
+            },
+            "rtc_region": {
+                "type": "string"
+            },
+            "default_auto_archive_duration": {
+                "type": "integer"
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -899,14 +1860,6 @@
         },
         "additionalProperties": false,
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -1037,6 +1990,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -1052,6 +2017,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -1215,14 +2182,6 @@
         },
         "additionalProperties": false,
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -1353,6 +2312,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -1368,6 +2339,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -1534,14 +2507,6 @@
             "messages"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -1672,6 +2637,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -1687,6 +2664,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -1862,14 +2841,6 @@
             "type"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -2000,6 +2971,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -2015,6 +2998,334 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "UserPublic": {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "public_flags",
+                    "username"
+                ]
+            },
+            "PublicConnectedAccount": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "verified": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "type",
+                    "verified"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "PurgeSchema": {
+        "type": "object",
+        "properties": {
+            "before": {
+                "type": "string"
+            },
+            "after": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "after",
+            "before"
+        ],
+        "definitions": {
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -2183,14 +3494,6 @@
             "name"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -2321,6 +3624,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -2336,6 +3651,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -2528,14 +3845,6 @@
             "url"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -2666,6 +3975,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -2681,6 +4002,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -2844,14 +4167,6 @@
             "url"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -2982,6 +4297,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -2997,6 +4324,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -3160,14 +4489,6 @@
         },
         "additionalProperties": false,
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -3298,6 +4619,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -3313,6 +4646,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -3494,14 +4829,6 @@
             "user_id"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -3632,6 +4959,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -3647,6 +4986,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -3825,14 +5166,6 @@
             "user_id"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -3963,6 +5296,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -3978,6 +5323,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -4153,14 +5500,6 @@
             ]
         },
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -4291,6 +5630,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -4306,6 +5657,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -4484,14 +5837,6 @@
             "image"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -4622,6 +5967,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -4637,6 +5994,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -4803,14 +6162,6 @@
         },
         "additionalProperties": false,
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -4941,6 +6292,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -4956,6 +6319,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -5144,14 +6509,6 @@
             "name"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -5282,6 +6639,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -5297,6 +6666,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -5524,14 +6895,6 @@
             "name"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -5662,6 +7025,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -5677,6 +7052,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -5840,14 +7217,6 @@
         },
         "additionalProperties": false,
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -5978,6 +7347,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -5993,6 +7374,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -6156,14 +7539,6 @@
             "nick"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -6294,6 +7669,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -6309,6 +7696,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -6472,14 +7861,6 @@
             "days"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -6610,6 +7991,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -6625,6 +8018,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -6806,14 +8201,6 @@
         },
         "additionalProperties": false,
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -6944,6 +8331,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -6959,6 +8358,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -7129,14 +8530,6 @@
             ]
         },
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -7267,6 +8660,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -7282,6 +8687,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -7456,14 +8863,6 @@
             "tags"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -7594,6 +8993,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -7609,6 +9020,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -7775,14 +9188,6 @@
             "name"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -7913,6 +9318,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -7928,6 +9345,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -8094,14 +9513,6 @@
             "name"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -8232,6 +9643,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -8247,6 +9670,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -8409,14 +9834,6 @@
         },
         "additionalProperties": false,
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -8547,6 +9964,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -8562,6 +9991,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -8744,14 +10175,6 @@
             "channel_id"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -8882,6 +10305,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -8897,6 +10332,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -9086,14 +10523,6 @@
         },
         "additionalProperties": false,
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -9224,6 +10653,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -9239,6 +10680,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -9406,14 +10849,6 @@
             "enabled"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -9544,6 +10979,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -9559,6 +11006,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -9728,14 +11177,6 @@
             "name"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -9866,6 +11307,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -9881,6 +11334,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -10056,14 +11511,6 @@
             "user"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -10194,6 +11641,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -10209,6 +11668,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -10390,14 +11851,6 @@
             "object"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -10528,6 +11981,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -10543,6 +12008,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -10712,14 +12179,6 @@
             "recipients"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -10850,6 +12309,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -10865,6 +12336,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -11017,7 +12490,6 @@
         "$schema": "http://json-schema.org/draft-07/schema#"
     },
     "UserModifySchema": {
-        "additionalProperties": false,
         "type": "object",
         "properties": {
             "username": {
@@ -11054,15 +12526,8 @@
                 "type": "string"
             }
         },
+        "additionalProperties": false,
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -11193,6 +12658,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -11208,6 +12685,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -11374,14 +12853,6 @@
         },
         "additionalProperties": false,
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -11512,6 +12983,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -11527,6 +13010,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -11694,14 +13179,6 @@
             "username"
         ],
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -11832,6 +13309,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -11847,6 +13336,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,
@@ -12172,14 +13663,6 @@
         },
         "additionalProperties": false,
         "definitions": {
-            "ChannelPermissionOverwriteType": {
-                "enum": [
-                    0,
-                    1,
-                    2
-                ],
-                "type": "number"
-            },
             "Embed": {
                 "type": "object",
                 "properties": {
@@ -12310,6 +13793,18 @@
                 },
                 "additionalProperties": false
             },
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            },
             "ChannelModifySchema": {
                 "type": "object",
                 "properties": {
@@ -12325,6 +13820,8 @@
                             11,
                             12,
                             13,
+                            14,
+                            15,
                             2,
                             255,
                             3,

--- a/api/scripts/generate_schema.js
+++ b/api/scripts/generate_schema.js
@@ -27,7 +27,16 @@ const Excluded = [
 	"Response",
 	"e.Response",
 	"request.Response",
-	"supertest.Response"
+	"supertest.Response",
+
+	// TODO: Figure out how to exclude schemas from node_modules?
+	"SomeJSONSchema",
+	"UncheckedPartialSchema",
+	"PartialSchema",
+	"UncheckedPropertiesSchema",
+	"PropertiesSchema",
+	"AsyncSchema",
+	"AnySchema",
 ];
 
 function modify(obj) {
@@ -39,11 +48,18 @@ function modify(obj) {
 }
 
 function main() {
-	const program = TJS.getProgramFromFiles(walk(path.join(__dirname, "..", "src", "routes")), compilerOptions);
+	const files = 		[
+		...walk(path.join(__dirname, "..", "src", "routes")),
+		...walk(path.join(__dirname, "..", "..", "util", "src")),
+	];
+	const program = TJS.getProgramFromFiles(
+		files,
+		compilerOptions
+	);
 	const generator = TJS.buildGenerator(program, settings);
 	if (!generator || !program) return;
 
-	const schemas = generator.getUserSymbols().filter((x) => (x.endsWith("Schema") || x.endsWith("Response")) && !Excluded.includes(x));
+	let schemas = generator.getUserSymbols().filter((x) => (x.endsWith("Schema") || x.endsWith("Response")) && !Excluded.includes(x));
 	console.log(schemas);
 
 	var definitions = {};

--- a/api/src/routes/channels/#channel_id/permissions.ts
+++ b/api/src/routes/channels/#channel_id/permissions.ts
@@ -16,14 +16,7 @@ const router: Router = Router();
 
 // TODO: Only permissions your bot has in the guild or channel can be allowed/denied (unless your bot has a MANAGE_ROLES overwrite in the channel)
 
-// export interface ChannelPermissionOverwriteSchema extends ChannelPermissionOverwrite {}
-// TODO: typescript-json-schema does not like extending types
-export interface ChannelPermissionOverwriteSchema {
-	allow: string;
-	deny: string;
-	id: string;
-	type: ChannelPermissionOverwriteType;
-}
+export interface ChannelPermissionOverwriteSchema extends ChannelPermissionOverwrite {}
 
 router.put(
 	"/:overwrite_id",

--- a/api/src/routes/channels/#channel_id/permissions.ts
+++ b/api/src/routes/channels/#channel_id/permissions.ts
@@ -16,7 +16,14 @@ const router: Router = Router();
 
 // TODO: Only permissions your bot has in the guild or channel can be allowed/denied (unless your bot has a MANAGE_ROLES overwrite in the channel)
 
-export interface ChannelPermissionOverwriteSchema extends ChannelPermissionOverwrite {}
+// export interface ChannelPermissionOverwriteSchema extends ChannelPermissionOverwrite {}
+// TODO: typescript-json-schema does not like extending types
+export interface ChannelPermissionOverwriteSchema {
+	allow: string;
+	deny: string;
+	id: string;
+	type: ChannelPermissionOverwriteType;
+}
 
 router.put(
 	"/:overwrite_id",


### PR DESCRIPTION
Previously, `generate:schema` would crawl all symbols in api ( including imported ones ), and then filter out everything not defined within api. This includes symbols defined in util, which leaves schemas such as `ChannelPermissionOverwriteSchema` ( which just extends a type from util ) completely empty in the generated schema.

Excluding types from Ajv is done because on my machine ( and 1 other, that I know of ) certain Ajv types cause the `generate:schema` script to run indefinitely.

A better solution would be, rather than manually excluding these types, to somehow exclude all types defined from `node_modules`. However, typescript-json-schema doesn't have any options for this, and I couldn't get other methods to work.