### PR TITLE
chore!: update docker scripts

### DIFF
--- a/.docker/env
+++ b/.docker/env
@@ -1,1 +1,0 @@
-MONGO_URL=mongodb://db:27017/fosscord?readPreference=secondaryPreferred

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-node_modules/
-db/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:alpine
 
 # env vars
-ENV WORK_DIR=/srv/fosscord-server
 ENV HTTP_PORT=3001
 ENV WS_PORT=3002
 ENV CDN_PORT=3003
@@ -19,5 +18,5 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 # RUN adduser -D fosscord
 # USER fosscord
 
-WORKDIR $WORK_DIR/
-ENTRYPOINT ["npm", "--prefix", "src/bundle", "run", "start:bundle"]
+WORKDIR /srv/fosscord-server/bundle
+ENTRYPOINT ["npm", "run", "start:bundle"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM node:alpine
 
 # env vars
-ENV WORK_DIR="/srv/fosscord-server"
-ENV DEV_MODE=0
+ENV WORK_DIR=/srv/fosscord-server
 ENV HTTP_PORT=3001
 ENV WS_PORT=3002
 ENV CDN_PORT=3003
@@ -13,28 +12,12 @@ ENV ADMIN_PORT=3005
 EXPOSE ${HTTP_PORT}/tcp ${WS_PORT}/tcp ${CDN_PORT}/tcp ${RTC_PORT}/tcp ${ADMIN_PORT}/tcp
 
 # install required apps
-RUN apk add --no-cache --update git python2 py-pip make build-base
+RUN apk add --no-cache --update git python3 py-pip make build-base
+RUN ln -s /usr/bin/python3 /usr/bin/python
 
-# optionl: packages for debugging/development
-RUN apk add --no-cache sqlite
+# Run as non-root user
+# RUN adduser -D fosscord
+# USER fosscord
 
-# download fosscord-server
-WORKDIR $WORK_DIR/src
-RUN git clone https://github.com/fosscord/fosscord-server.git .
-
-# setup and run
-WORKDIR $WORK_DIR/src/bundle
-RUN npm run setup
-RUN npm install @yukikaze-bot/erlpack
-# RUN npm install mysql --save
-
-# create update script
-RUN printf '#!/bin/sh\n\ngit -C $WORK_DIR/src/ checkout master\ngit -C $WORK_DIR/src/ reset --hard HEAD\ngit -C $WORK_DIR/src/ pull\ncd $WORK_DIR/src/bundle/\nnpm run setup\n' > $WORK_DIR/update.sh
-RUN chmod +x $WORK_DIR/update.sh
-
-# configure entrypoint file
-RUN printf '#!/bin/sh\n\nDEV_MODE=${DEV_MODE:-0}\n\nif [ "$DEV_MODE" -eq 1 ]; then\n    tail -f /dev/null\nelse\n    cd $WORK_DIR/src/bundle/\n    npm run start:bundle\nfi\n' > $WORK_DIR/entrypoint.sh
-RUN chmod +x $WORK_DIR/entrypoint.sh
-
-WORKDIR $WORK_DIR
-ENTRYPOINT ["./entrypoint.sh"]
+WORKDIR $WORK_DIR/
+ENTRYPOINT ["npm", "--prefix", "src/bundle", "run", "start:bundle"]

--- a/docker-compose.cfg.yml
+++ b/docker-compose.cfg.yml
@@ -1,0 +1,6 @@
+version: '3.9'
+
+services:
+
+  fosscord:
+    entrypoint: [ "npm", "run", "setup" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,17 @@
-version: '3.8'
+version: '3.9'
 
 services:
+
   fosscord:
     container_name: fosscord
     image: fosscord
     restart: on-failure:5
-    # depends_on: mariadb
     build: .
     ports:
       - '3001-3005:3001-3005'
     volumes:
-      # - ./data/:${WORK_DIR:-/srv/fosscord-server}/data/
-      - data:${WORK_DIR:-/srv/fosscord-server}/
+      - ./instance/fosscord/:/srv/fosscord-server/
     environment:
-      WORK_DIR: ${WORK_DIR:-/srv/fosscord-server}
-      DEV_MODE: ${DEV_MODE:-0}
       THREADS: ${THREADS:-1}
       DATABASE: ${DATABASE:-../../data/database.db}
       STORAGE_LOCATION: ${STORAGE_LOCATION:-../../data/files/}
@@ -23,23 +20,6 @@ services:
       CDN_PORT: 3003
       RTC_PORT: 3004
       ADMIN_PORT: 3005
-
-  # mariadb:
-  #   image: mariadb:latest
-  #   restart: on-failure:5
-  #   environment:
-  #     MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-secr3tpassw0rd}
-  #     MYSQL_DATABASE: ${MYSQL_DATABASE:-fosscord}
-  #     MYSQL_USER: ${MYSQL_USER:-fosscord}
-  #     MYSQL_PASSWORD: ${MYSQL_PASSWORD:-password1}
-  #   networks:
-  #     - default
-  #   volumes:
-  #     - mariadb:/var/lib/mysql
-
-volumes:
-  data:
-  # mariadb:
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,9 @@ services:
     ports:
       - '3001-3005:3001-3005'
     volumes:
-      - ./instance/fosscord/:/srv/fosscord-server/
+      - ./:/srv/fosscord-server/
     environment:
       THREADS: ${THREADS:-1}
-      DATABASE: ${DATABASE:-../../data/database.db}
-      STORAGE_LOCATION: ${STORAGE_LOCATION:-../../data/files/}
       HTTP_PORT: 3001
       WS_PORT: 3002
       CDN_PORT: 3003


### PR DESCRIPTION
**BREAKING CHANGE**: this new docker image no longer clones this repository. Some manual steps are required.

LIST OF BREAKING CHANGES:

- **This repository is not longer cloned**.
- **Fosscord is not longer configured automatically**.
- Removed `update.sh` script.
- Removed `entrypoint.sh`.
- Removed `DEV_MODE` env var.
- Removed `WORK_DIR` env var.
- Updated Python package to [python3](https://pkgs.alpinelinux.org/package/edge/main/x86_64/python3).
- [sqlite](https://pkgs.alpinelinux.org/package/edge/main/x86_64/sqlite) package is not longer included.

This is a minimal version of my personal docker image, the complete image and compose can be found [here](https://github.com/n0bodysec/docker-images/tree/main/fosscord).

Steps to deploy:

1. Create a `docker-compose.override.yml` file and edit it to suit your needs.
2. Setup Fosscord **inside the docker container** (see `docker-compose.cfg.yml`).
4. Run `docker compose up -d`.

TL;DR:

```sh
git clone https://github.com/fosscord/fosscord-server.git
cd fosscord-server
# optional: vi docker-compose.override.yml
docker compose -f docker-compose.yml -f docker-compose.cfg.yml up
docker compose up -d
```

(These steps should be added to [the docs](https://docs.fosscord.com/server/setup/#with-docker) since docker is now fully supported).

These changes are due to the fact that fosscord is currently under development and this repository is constantly updated. In addition, many people want to run their own version of fosscord with custom changes, so forcing a `git clone` in the container is not practical.

~~**WIP: I need to fix an issue with the `sqlite3` node package** (for some reason, in this minified version of the docker image the `sqlite` driver doesn't work well. No issues on my [personal image](https://github.com/n0bodysec/docker-images/tree/main/fosscord) though.~~

EDIT: It seems to be an issue related to `npm run setup` if executed **outside** the container.