### PR TITLE
Move user notes into separate table

### DIFF
--- a/api/src/routes/users/@me/notes.ts
+++ b/api/src/routes/users/@me/notes.ts
@@ -1,37 +1,54 @@
 import { Request, Response, Router } from "express";
 import { route } from "@fosscord/api";
-import { User, emitEvent } from "@fosscord/util";
+import { User, Note, emitEvent, Snowflake } from "@fosscord/util";
 
 const router: Router = Router();
 
 router.get("/:id", route({}), async (req: Request, res: Response) => {
 	const { id } = req.params;
-	const user = await User.findOneOrFail({ where: { id: req.user_id }, select: ["notes"] });
 
-	const note = user.notes[id];
+	const note = await Note.findOneOrFail({
+		where: {
+			owner: { id: req.user_id },
+			target: { id: id },
+		}
+	});
+
 	return res.json({
-		note: note,
+		note: note?.content,
 		note_user_id: id,
-		user_id: user.id,
+		user_id: req.user_id,
 	});
 });
 
 router.put("/:id", route({}), async (req: Request, res: Response) => {
 	const { id } = req.params;
-	const user = await User.findOneOrFail({ where: { id: req.user_id } });
-	const noteUser = await User.findOneOrFail({ where: { id: id }});		//if noted user does not exist throw
+	const owner = await User.findOneOrFail({ where: { id: req.user_id } });
+	const target = await User.findOneOrFail({ where: { id: id } });		//if noted user does not exist throw
 	const { note } = req.body;
 
-	await User.update({ id: req.user_id }, { notes: { ...user.notes, [noteUser.id]: note } });
+	// await User.update({ id: req.user_id }, { notes: { ...user.notes, [noteUser.id]: note } });
+
+	if (await Note.findOne({ owner: { id: owner.id }, target: { id: target.id } })) {
+		Note.update(
+			{ owner: { id: owner.id }, target: { id: target.id } },
+			{ owner, target, content: note }
+		);
+	}
+	else {
+		Note.insert(
+			{ id: Snowflake.generate(), owner, target, content: note }
+		);
+	}
 
 	await emitEvent({
 		event: "USER_NOTE_UPDATE",
 		data: {
 			note: note,
-			id: noteUser.id
+			id: target.id
 		},
-		user_id: user.id,
-	})
+		user_id: owner.id,
+	});
 
 	return res.status(204);
 });

--- a/util/src/entities/Note.ts
+++ b/util/src/entities/Note.ts
@@ -1,0 +1,18 @@
+import { Column, Entity, JoinColumn, ManyToOne, Unique } from "typeorm";
+import { BaseClass } from "./BaseClass";
+import { User } from "./User";
+
+@Entity("notes")
+@Unique(["owner", "target"])
+export class Note extends BaseClass {
+	@JoinColumn({ name: "owner_id" })
+	@ManyToOne(() => User, { onDelete: "CASCADE" })
+	owner: User;
+
+	@JoinColumn({ name: "target_id" })
+	@ManyToOne(() => User, { onDelete: "CASCADE" })
+	target: User;
+
+	@Column()
+	content: string;
+}

--- a/util/src/entities/User.ts
+++ b/util/src/entities/User.ts
@@ -5,6 +5,7 @@ import { Relationship } from "./Relationship";
 import { ConnectedAccount } from "./ConnectedAccount";
 import { Config, FieldErrors, Snowflake, trimSpecial } from "..";
 import { Member, Session } from ".";
+import { Note } from "./Note";
 
 export enum PublicUserEnum {
 	username,
@@ -167,9 +168,6 @@ export class User extends BaseClass {
 	// workaround to prevent fossord-unaware clients from deleting settings not used by them
 	@Column({ type: "simple-json", select: false })
 	extended_settings: string;
-
-	@Column({ type: "simple-json" })
-	notes: { [key: string]: string };	//key is ID of user
 
 	toPublicUser() {
 		const user: any = {};

--- a/util/src/entities/index.ts
+++ b/util/src/entities/index.ts
@@ -28,3 +28,4 @@ export * from "./User";
 export * from "./VoiceState";
 export * from "./Webhook";
 export * from "./ClientRelease";
+export * from "./Note";


### PR DESCRIPTION
Haven't written a migration because it was a bit too complicated. Would appreciate someone helping with that.

Notes table currently has an ID, which isn't super needed but it does provide when the note was first created. Maybe should also add a `modified` field?