### PR TITLE
Fix guild modify resulting in 400 when enabling community

### DIFF
--- a/api/assets/schemas.json
+++ b/api/assets/schemas.json
@@ -6828,6 +6828,9 @@
     "GuildUpdateSchema": {
         "type": "object",
         "properties": {
+            "name": {
+                "type": "string"
+            },
             "banner": {
                 "type": [
                     "null",
@@ -6873,10 +6876,6 @@
             "preferred_locale": {
                 "type": "string"
             },
-            "name": {
-                "maxLength": 100,
-                "type": "string"
-            },
             "region": {
                 "type": "string"
             },
@@ -6897,9 +6896,6 @@
             }
         },
         "additionalProperties": false,
-        "required": [
-            "name"
-        ],
         "definitions": {
             "Embed": {
                 "type": "object",

--- a/api/src/routes/guilds/#guild_id/index.ts
+++ b/api/src/routes/guilds/#guild_id/index.ts
@@ -7,7 +7,8 @@ import { GuildCreateSchema } from "../index";
 
 const router = Router();
 
-export interface GuildUpdateSchema extends Omit<GuildCreateSchema, "channels"> {
+export interface GuildUpdateSchema extends Omit<GuildCreateSchema, "channels" | "name"> {
+	name?: string;
 	banner?: string | null;
 	splash?: string | null;
 	description?: string;


### PR DESCRIPTION
Trying to enable community will result in a 400 error with `must have required property 'name'`. 
This PR makes the name property not required for guild modify so that enabling community works.