### PR TITLE
auto create channels for community setup

### DIFF
--- a/api/src/routes/guilds/#guild_id/index.ts
+++ b/api/src/routes/guilds/#guild_id/index.ts
@@ -1,5 +1,5 @@
 import { Request, Response, Router } from "express";
-import { Channel, DiscordApiErrors, emitEvent, getPermission, getRights, Guild, GuildUpdateEvent, handleFile, Member } from "@fosscord/util";
+import { Channel, Config, DiscordApiErrors, emitEvent, getPermission, getRights, Guild, GuildUpdateEvent, handleFile, Member } from "@fosscord/util";
 import { HTTPError } from "lambert-server";
 import { route } from "@fosscord/api";
 import "missing-native-js-functions";
@@ -62,34 +62,20 @@ router.patch("/", route({ body: "GuildUpdateSchema"}), async (req: Request, res:
 	
 	if (body.public_updates_channel_id && body.public_updates_channel_id === "1") {
 		const publicUpdatesChannel = await Channel.createChannel({
-			name: "moderator-only",
+			name: Config.get().guild.community.defaultPublicUpdatesChannelName,
 			type: 0,
 			guild_id,
-			permission_overwrites: [
-				{
-					id: guild_id,
-					allow: "0",
-					deny: "1024",
-					type: 0
-				}
-			]
+			permission_overwrites: Config.get().guild.community.defaultPublicUpdatesChannelPermissionOverrides.map(x => ({...x, id: x.id.replace("@everyone", guild_id)}))
 		}, req.user_id);
 		body.public_updates_channel_id = publicUpdatesChannel.id;
 	}
 
 	if (body.rules_channel_id && body.rules_channel_id === "1") {
 		const rulesChannel = await Channel.createChannel({
-			name: "rules",
+			name: Config.get().guild.community.defaultRulesChannelName,
 			type: 0,
 			guild_id,
-			permission_overwrites: [
-				{
-					id: guild_id,
-					allow: "0",
-					deny: "2048",
-					type: 0
-				}
-			]
+			permission_overwrites: Config.get().guild.community.defaultRulesChannelPermissionOverrides.map(x => ({...x, id: x.id.replace("@everyone", guild_id)}))
 		}, req.user_id);
 		body.rules_channel_id = rulesChannel.id;
 	}

--- a/util/src/entities/Config.ts
+++ b/util/src/entities/Config.ts
@@ -2,7 +2,7 @@ import { Column, Entity } from "typeorm";
 import { BaseClassWithoutId, PrimaryIdColumn } from "./BaseClass";
 import crypto from "crypto";
 import { Snowflake } from "../util/Snowflake";
-import { SessionsReplace } from "..";
+import { ChannelPermissionOverwrite, SessionsReplace } from "..";
 import { hostname } from "os";
 
 @Entity("config")
@@ -168,6 +168,12 @@ export interface ConfigValue {
 			enabled: boolean;
 			guilds: string[];
 			canLeave: boolean;
+		};
+		community: {
+			defaultRulesChannelName: string;
+			defaultPublicUpdatesChannelName: string;
+			defaultRulesChannelPermissionOverrides: ChannelPermissionOverwrite[];
+			defaultPublicUpdatesChannelPermissionOverrides: ChannelPermissionOverwrite[];
 		};
 	};
 	gif: {
@@ -369,6 +375,26 @@ export const DefaultConfigOptions: ConfigValue = {
 			enabled: true,
 			canLeave: true,
 			guilds: [],
+		},
+		community: {
+			defaultRulesChannelName: "rules",
+			defaultPublicUpdatesChannelName: "moderator-only",
+			defaultRulesChannelPermissionOverrides: [
+				{
+					allow: "0",
+					deny: "2048",
+					type: 0,
+					id: "@everyone",
+				},
+			],
+			defaultPublicUpdatesChannelPermissionOverrides: [
+				{
+					allow: "0",
+					deny: "1024",
+					type: 0,
+					id: "@everyone",
+				},
+			],
 		},
 	},
 	gif: {


### PR DESCRIPTION
Allows the "create one for me" option when selecting channels during Community setup to work. 