### PR TITLE
add discriminator to user modify schema

### DIFF
--- a/api/assets/schemas.json
+++ b/api/assets/schemas.json
@@ -12499,6 +12499,11 @@
                 "maxLength": 100,
                 "type": "string"
             },
+            "discriminator": {
+                "minLength": 4,
+                "maxLength": 4,
+                "type": "string"
+            },
             "avatar": {
                 "type": [
                     "null",

--- a/api/assets/schemas.json
+++ b/api/assets/schemas.json
@@ -12500,8 +12500,6 @@
                 "type": "string"
             },
             "discriminator": {
-                "minLength": 4,
-                "maxLength": 4,
                 "type": "string"
             },
             "avatar": {

--- a/api/src/routes/users/@me/index.ts
+++ b/api/src/routes/users/@me/index.ts
@@ -11,6 +11,7 @@ export interface UserModifySchema {
 	 * @maxLength 100
 	 */
 	username?: string;
+	discriminator?: string;
 	avatar?: string | null;
 	/**
 	 * @maxLength 1024


### PR DESCRIPTION
trying to change user profile will result in an error `must NOT have additional properties` due to the discriminator. this PR adds the discriminator to the user update schema fixing this problem and allowing users to edit their profile.