### PR TITLE
fix user profile not displaying correctly

### DIFF
--- a/src/api/routes/users/#id/profile.ts
+++ b/src/api/routes/users/#id/profile.ts
@@ -73,6 +73,12 @@ router.get("/", route({ test: { response: { body: "UserProfileResponse" } } }), 
 		bot: user.bot
 	};
 
+	const userProfile = {
+		bio: req.user_bot ? null : user.bio,
+		accent_color: user.accent_color,
+		banner: user.banner
+	};
+
 	const guildMemberDto = guild_member
 		? {
 				avatar: guild_member.avatar,
@@ -104,8 +110,9 @@ router.get("/", route({ test: { response: { body: "UserProfileResponse" } } }), 
 		premium_since: user.premium_since, // TODO
 		mutual_guilds: mutual_guilds, // TODO {id: "", nick: null} when ?with_mutual_guilds=true
 		user: userDto,
-		guild_member: guildMemberDto,
-		guild_member_profile: guildMemberProfile
+		user_profile: userProfile,
+		guild_member: guild_id && guildMemberDto,
+		guild_member_profile: guild_id && guildMemberProfile
 	});
 });
 


### PR DESCRIPTION
Follow up to #872 that fixes user profile not being displayed correctly.

`user_profile` is an additional object that should be present, `guild_member` and `guild_member_profile` should not be present when no guild id was specified. 