### PR TITLE
Allow Spotify activities through schema

### DIFF
--- a/src/util/interfaces/Activity.ts
+++ b/src/util/interfaces/Activity.ts
@@ -37,7 +37,7 @@ export interface Activity {
 	id?: string;
 	sync_id?: string;
 	metadata?: {
-		context_url?: string;
+		context_uri?: string;
 		album_id?: string;
 		artist_ids?: string[];
 	},

--- a/src/util/interfaces/Activity.ts
+++ b/src/util/interfaces/Activity.ts
@@ -33,6 +33,15 @@ export interface Activity {
 	};
 	instance?: boolean;
 	flags: string; // activity flags OR d together, describes what the payload includes
+	// spotify and other rich presence data
+	id?: string;
+	sync_id?: string;
+	metadata?: {
+		context_url?: string;
+		album_id?: string;
+		artist_ids?: string[];
+	},
+	session_id?: string;
 }
 
 export enum ActivityType {

--- a/src/util/schemas/ActivitySchema.ts
+++ b/src/util/schemas/ActivitySchema.ts
@@ -42,7 +42,7 @@ export const ActivitySchema = {
 			$id: String,
 			$sync_id: String,
 			$metadata: {
-				$context_url: String,
+				$context_uri: String,
 				$album_id: String,
 				$artist_ids: [String],
 			},

--- a/src/util/schemas/ActivitySchema.ts
+++ b/src/util/schemas/ActivitySchema.ts
@@ -37,7 +37,16 @@ export const ActivitySchema = {
 				$match: String
 			},
 			$instance: Boolean,
-			$flags: String
+			$flags: String,
+			// spotify and other rich presence data
+			$id: String,
+			$sync_id: String,
+			$metadata: {
+				$context_url: String,
+				$album_id: String,
+				$artist_ids: [String],
+			},
+			$session_id: String,
 		}
 	],
 	$since: Number // unix time (in milliseconds) of when the client went idle, or null if the client is not idle


### PR DESCRIPTION
Surprisingly all you need to get most rich presence working. Works on Slowcord using the client plugin