### PR TITLE
LazyRequest: Session sorting, invis members, bugs

### DIFF
--- a/src/gateway/opcodes/LazyRequest.ts
+++ b/src/gateway/opcodes/LazyRequest.ts
@@ -94,8 +94,8 @@ async function getMembers(guild_id: string, range: [number, number]) {
 					}
 				}
 			};
-
-			if (!session || session.status == "invisible") {
+		
+			if (!session || session.status == "invisible" || session.status == "offline") {
 				item.member.presence.status = "offline";
 				item.member.presence.activities = [];
 				offlineItems.push(item);

--- a/src/gateway/opcodes/LazyRequest.ts
+++ b/src/gateway/opcodes/LazyRequest.ts
@@ -76,7 +76,6 @@ async function getMembers(guild_id: string, range: [number, number]) {
 			});
 			const session = sessions.first();
 
-			// TODO: properly mock/hide offline/invisible status
 			const item = {
 				member: {
 					...member,
@@ -166,7 +165,7 @@ export async function onLazyRequest(this: WebSocket, { d }: Payload) {
 				range: x.range
 			})),
 			// remove offline members from count
-			online_count: member_count - (groups.find(x => x.id == "ofline")?.count ?? 0),
+			online_count: member_count - (groups.find(x => x.id == "offline")?.count ?? 0),
 			member_count,
 			id: "everyone",
 			guild_id,

--- a/src/gateway/opcodes/LazyRequest.ts
+++ b/src/gateway/opcodes/LazyRequest.ts
@@ -38,12 +38,19 @@ async function getMembers(guild_id: string, range: [number, number]) {
 		.map((m) => m.roles)
 		.flat()
 		.unique((r: Role) => r.id);
+	// add online role
+	member_roles.push(
+		member_roles.splice(
+			member_roles.findIndex((x => x.id == x.guild_id)),
+			1
+		)[0]
+	);
 
 	const offlineItems = [];
 
 	for (const role of member_roles) {
 		// @ts-ignore
-		const [role_members, other_members] = partition(members, (m: Member) => m.roles.find((r) => r.id === role.id));
+		const [role_members, other_members]: Member[][] = partition(members, (m: Member) => m.roles.find((r) => r.id === role.id));
 		const group = {
 			count: role_members.length,
 			id: role.id === guild_id ? "online" : role.id
@@ -55,7 +62,19 @@ async function getMembers(guild_id: string, range: [number, number]) {
 		for (const member of role_members) {
 			const roles = member.roles.filter((x: Role) => x.id !== guild_id).map((x: Role) => x.id);
 
-			const session = member.user.sessions.first();
+			const statusPriority = {
+				"online": 0,
+				"idle": 1,
+				"dnd": 2,
+				"invisible": 3,
+				"offline": 4,	// for ts, will never be accessed
+			};
+			const sessions = member.user.sessions.sort((a, b) => {
+				// activities are higher priority than status
+				return (statusPriority[a.status] - statusPriority[b.status])
+					+ ((a.activities.length - b.activities.length) * 2);
+			});
+			const session = sessions.first();
 
 			// TODO: properly mock/hide offline/invisible status
 			const item = {
@@ -71,7 +90,9 @@ async function getMembers(guild_id: string, range: [number, number]) {
 				}
 			};
 
-			if (!member?.user?.sessions || !member.user.sessions.length) {
+			if (!session || session.status == "invisible") {
+				item.member.presence.status = "offline";
+				item.member.presence.activities = [];
 				offlineItems.push(item);
 				group.count--;
 				continue;
@@ -122,11 +143,17 @@ export async function onLazyRequest(this: WebSocket, { d }: Payload) {
 
 	ops.forEach((op) => {
 		op.members.forEach(async (member) => {
+			if (!member) return;
 			if (this.events[member.user.id]) return; // already subscribed as friend
 			if (this.member_events[member.user.id]) return; // already subscribed in member list
 			this.member_events[member.user.id] = await listenEvent(member.user.id, handlePresenceUpdate.bind(this), this.listen_options);
 		});
 	});
+
+	const groups = ops
+		.map((x) => x.groups)
+		.flat()
+		.unique();
 
 	return Send(this, {
 		op: OPCODES.Dispatch,
@@ -138,14 +165,12 @@ export async function onLazyRequest(this: WebSocket, { d }: Payload) {
 				op: "SYNC",
 				range: x.range
 			})),
-			online_count: member_count,
+			// remove offline members from count
+			online_count: member_count - (groups.find(x => x.id == "ofline")?.count ?? 0),
 			member_count,
 			id: "everyone",
 			guild_id,
-			groups: ops
-				.map((x) => x.groups)
-				.flat()
-				.unique()
+			groups,
 		}
 	});
 }


### PR DESCRIPTION
* Sends the 'most relevant' session in LazyRequest - currently, the one with an active activity or the one with the lowest status ( from "online" highest to "offline" lowest ).
* Handles invisible members in member list.
* Fixes a bug related to members without roles not being sent.
* More properly sends the offline_count of the range

Has been running on Slowcord for a longg time. Although granted, Slowcord isn't on staging.
Marked as draft because its 1am and I need to do more testing on staging just in case. Feel free to do this for me