### PR TITLE
Use tsconfig in genschemas

### DIFF
--- a/assets/schemas.json
+++ b/assets/schemas.json
@@ -1,1258 +1,2249 @@
 {
-	"ActivitySchema": {
-		"type": "object",
-		"properties": {
-			"afk": {
-				"type": "boolean"
-			},
-			"status": {},
-			"activities": {
-				"type": "array",
-				"items": {}
-			},
-			"since": {
-				"type": "integer"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["afk", "status"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"BackupCodesChallengeSchema": {
-		"type": "object",
-		"properties": {
-			"password": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["password"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"BanCreateSchema": {
-		"type": "object",
-		"properties": {
-			"delete_message_days": {
-				"type": "string"
-			},
-			"reason": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"BanModeratorSchema": {
-		"type": "object",
-		"properties": {
-			"id": {
-				"type": "string"
-			},
-			"user_id": {
-				"type": "string"
-			},
-			"guild_id": {
-				"type": "string"
-			},
-			"executor_id": {
-				"type": "string"
-			},
-			"reason": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["executor_id", "guild_id", "id", "user_id"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"BanRegistrySchema": {
-		"type": "object",
-		"properties": {
-			"id": {
-				"type": "string"
-			},
-			"user_id": {
-				"type": "string"
-			},
-			"guild_id": {
-				"type": "string"
-			},
-			"executor_id": {
-				"type": "string"
-			},
-			"ip": {
-				"type": "string"
-			},
-			"reason": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["executor_id", "guild_id", "id", "user_id"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"BulkDeleteSchema": {
-		"type": "object",
-		"properties": {
-			"messages": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			}
-		},
-		"additionalProperties": false,
-		"required": ["messages"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"ChannelPermissionOverwriteSchema": {
-		"type": "object",
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"ChannelReorderSchema": {
-		"type": "array",
-		"items": {
-			"type": "object",
-			"properties": {
-				"id": {
-					"type": "string"
-				},
-				"position": {
-					"type": "integer"
-				},
-				"lock_permissions": {
-					"type": "boolean"
-				},
-				"parent_id": {
-					"type": "string"
-				}
-			},
-			"additionalProperties": false,
-			"required": ["id"]
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"CodesVerificationSchema": {
-		"type": "object",
-		"properties": {
-			"key": {
-				"type": "string"
-			},
-			"nonce": {
-				"type": "string"
-			},
-			"regenerate": {
-				"type": "boolean"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["key", "nonce"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"DmChannelCreateSchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"type": "string"
-			},
-			"recipients": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			}
-		},
-		"additionalProperties": false,
-		"required": ["recipients"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"EmojiCreateSchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"type": "string"
-			},
-			"image": {
-				"type": "string"
-			},
-			"require_colons": {
-				"type": ["null", "boolean"]
-			},
-			"roles": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			}
-		},
-		"additionalProperties": false,
-		"required": ["image"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"EmojiModifySchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"type": "string"
-			},
-			"roles": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			}
-		},
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"GuildCreateSchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"maxLength": 100,
-				"type": "string"
-			},
-			"region": {
-				"type": "string"
-			},
-			"icon": {
-				"type": ["null", "string"]
-			},
-			"channels": {
-				"type": "array",
-				"items": {
-					"$ref": "#/definitions/ChannelModifySchema"
-				}
-			},
-			"guild_template_code": {
-				"type": "string"
-			},
-			"system_channel_id": {
-				"type": "string"
-			},
-			"rules_channel_id": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["name"],
-		"definitions": {
-			"ChannelModifySchema": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"maxLength": 100,
-						"type": "string"
-					},
-					"type": {
-						"enum": [0, 1, 10, 11, 12, 13, 14, 15, 2, 255, 3, 33, 34, 35, 4, 5, 6, 64, 7, 8, 9],
-						"type": "number"
-					},
-					"topic": {
-						"type": "string"
-					},
-					"icon": {
-						"type": ["null", "string"]
-					},
-					"bitrate": {
-						"type": "integer"
-					},
-					"user_limit": {
-						"type": "integer"
-					},
-					"rate_limit_per_user": {
-						"type": "integer"
-					},
-					"position": {
-						"type": "integer"
-					},
-					"permission_overwrites": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "string"
-								},
-								"type": {
-									"$ref": "#/definitions/ChannelPermissionOverwriteType"
-								},
-								"allow": {
-									"type": "string"
-								},
-								"deny": {
-									"type": "string"
-								}
-							},
-							"additionalProperties": false,
-							"required": ["allow", "deny", "id", "type"]
-						}
-					},
-					"parent_id": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					},
-					"nsfw": {
-						"type": "boolean"
-					},
-					"rtc_region": {
-						"type": "string"
-					},
-					"default_auto_archive_duration": {
-						"type": "integer"
-					},
-					"flags": {
-						"type": "integer"
-					},
-					"default_thread_rate_limit_per_user": {
-						"type": "integer"
-					}
-				},
-				"additionalProperties": false
-			},
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1, 2],
-				"type": "number"
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"GuildTemplateCreateSchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"type": "string"
-			},
-			"avatar": {
-				"type": ["null", "string"]
-			}
-		},
-		"additionalProperties": false,
-		"required": ["name"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"GuildUpdateSchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"type": "string"
-			},
-			"banner": {
-				"type": ["null", "string"]
-			},
-			"splash": {
-				"type": ["null", "string"]
-			},
-			"description": {
-				"type": "string"
-			},
-			"features": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			},
-			"verification_level": {
-				"type": "integer"
-			},
-			"default_message_notifications": {
-				"type": "integer"
-			},
-			"system_channel_flags": {
-				"type": "integer"
-			},
-			"explicit_content_filter": {
-				"type": "integer"
-			},
-			"public_updates_channel_id": {
-				"type": "string"
-			},
-			"afk_timeout": {
-				"type": "integer"
-			},
-			"afk_channel_id": {
-				"type": "string"
-			},
-			"preferred_locale": {
-				"type": "string"
-			},
-			"premium_progress_bar_enabled": {
-				"type": "boolean"
-			},
-			"region": {
-				"type": "string"
-			},
-			"icon": {
-				"type": ["null", "string"]
-			},
-			"guild_template_code": {
-				"type": "string"
-			},
-			"system_channel_id": {
-				"type": "string"
-			},
-			"rules_channel_id": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"GuildUpdateWelcomeScreenSchema": {
-		"type": "object",
-		"properties": {
-			"welcome_channels": {
-				"type": "array",
-				"items": {
-					"type": "object",
-					"properties": {
-						"channel_id": {
-							"type": "string"
-						},
-						"description": {
-							"type": "string"
-						},
-						"emoji_id": {
-							"type": "string"
-						},
-						"emoji_name": {
-							"type": "string"
-						}
-					},
-					"additionalProperties": false,
-					"required": ["channel_id", "description", "emoji_name"]
-				}
-			},
-			"enabled": {
-				"type": "boolean"
-			},
-			"description": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"IdentifySchema": {
-		"type": "object",
-		"properties": {
-			"token": {
-				"type": "string"
-			},
-			"properties": {
-				"type": "object",
-				"properties": {
-					"os": {
-						"type": "string"
-					},
-					"os_atch": {
-						"type": "string"
-					},
-					"browser": {
-						"type": "string"
-					},
-					"device": {
-						"type": "string"
-					},
-					"$os": {
-						"type": "string"
-					},
-					"$browser": {
-						"type": "string"
-					},
-					"$device": {
-						"type": "string"
-					},
-					"browser_user_agent": {
-						"type": "string"
-					},
-					"browser_version": {
-						"type": "string"
-					},
-					"os_version": {
-						"type": "string"
-					},
-					"referrer": {
-						"type": "string"
-					},
-					"referring_domain": {
-						"type": "string"
-					},
-					"referrer_current": {
-						"type": "string"
-					},
-					"referring_domain_current": {
-						"type": "string"
-					},
-					"release_channel": {
-						"enum": ["canary", "dev", "ptb", "stable"],
-						"type": "string"
-					},
-					"client_build_number": {
-						"type": "integer"
-					},
-					"client_event_source": {},
-					"client_version": {
-						"type": "string"
-					},
-					"system_locale": {
-						"type": "string"
-					}
-				},
-				"additionalProperties": false
-			},
-			"intents": {
-				"type": "string"
-			},
-			"presence": {
-				"$ref": "#/definitions/ActivitySchema"
-			},
-			"compress": {
-				"type": "boolean"
-			},
-			"large_threshold": {
-				"type": "integer"
-			},
-			"shard": {
-				"type": "array",
-				"items": [
-					{
-						"type": "integer"
-					},
-					{
-						"type": "integer"
-					}
-				],
-				"minItems": 2,
-				"maxItems": 2
-			},
-			"guild_subscriptions": {
-				"type": "boolean"
-			},
-			"capabilities": {
-				"type": "integer"
-			},
-			"client_state": {
-				"type": "object",
-				"properties": {
-					"guild_hashes": {},
-					"highest_last_message_id": {
-						"type": "string"
-					},
-					"read_state_version": {
-						"type": "integer"
-					},
-					"user_guild_settings_version": {
-						"type": "integer"
-					},
-					"user_settings_version": {
-						"type": "integer"
-					}
-				},
-				"additionalProperties": false
-			},
-			"v": {
-				"type": "integer"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["properties", "token"],
-		"definitions": {
-			"ActivitySchema": {
-				"type": "object",
-				"properties": {
-					"afk": {
-						"type": "boolean"
-					},
-					"status": {},
-					"activities": {
-						"type": "array",
-						"items": {}
-					},
-					"since": {
-						"type": "integer"
-					}
-				},
-				"additionalProperties": false,
-				"required": ["afk", "status"]
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"InviteCreateSchema": {
-		"type": "object",
-		"properties": {
-			"target_user_id": {
-				"type": "string"
-			},
-			"target_type": {
-				"type": "string"
-			},
-			"validate": {
-				"type": "string"
-			},
-			"max_age": {
-				"type": "integer"
-			},
-			"max_uses": {
-				"type": "integer"
-			},
-			"temporary": {
-				"type": "boolean"
-			},
-			"unique": {
-				"type": "boolean"
-			},
-			"target_user": {
-				"type": "string"
-			},
-			"target_user_type": {
-				"type": "integer"
-			}
-		},
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"LoginSchema": {
-		"type": "object",
-		"properties": {
-			"login": {
-				"type": "string"
-			},
-			"password": {
-				"type": "string"
-			},
-			"undelete": {
-				"type": "boolean"
-			},
-			"captcha_key": {
-				"type": "string"
-			},
-			"login_source": {
-				"type": "string"
-			},
-			"gift_code_sku_id": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["login", "password"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"MemberChangeProfileSchema": {
-		"type": "object",
-		"properties": {
-			"banner": {
-				"type": ["null", "string"]
-			},
-			"nick": {
-				"type": "string"
-			},
-			"bio": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"MemberChangeSchema": {
-		"type": "object",
-		"properties": {
-			"roles": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			},
-			"nick": {
-				"type": "string"
-			},
-			"avatar": {
-				"type": ["null", "string"]
-			}
-		},
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"MemberNickChangeSchema": {
-		"type": "object",
-		"properties": {
-			"nick": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["nick"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"MessageAcknowledgeSchema": {
-		"type": "object",
-		"properties": {
-			"manual": {
-				"type": "boolean"
-			},
-			"mention_count": {
-				"type": "integer"
-			}
-		},
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"MessageCreateSchema": {
-		"type": "object",
-		"properties": {
-			"type": {
-				"type": "integer"
-			},
-			"content": {
-				"type": "string"
-			},
-			"nonce": {
-				"type": "string"
-			},
-			"channel_id": {
-				"type": "string"
-			},
-			"tts": {
-				"type": "boolean"
-			},
-			"flags": {
-				"type": "string"
-			},
-			"embeds": {
-				"type": "array",
-				"items": {}
-			},
-			"embed": {},
-			"allowed_mentions": {
-				"type": "object",
-				"properties": {
-					"parse": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						}
-					},
-					"roles": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						}
-					},
-					"users": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						}
-					},
-					"replied_user": {
-						"type": "boolean"
-					}
-				},
-				"additionalProperties": false
-			},
-			"message_reference": {
-				"type": "object",
-				"properties": {
-					"message_id": {
-						"type": "string"
-					},
-					"channel_id": {
-						"type": "string"
-					},
-					"guild_id": {
-						"type": "string"
-					},
-					"fail_if_not_exists": {
-						"type": "boolean"
-					}
-				},
-				"additionalProperties": false,
-				"required": ["channel_id", "message_id"]
-			},
-			"payload_json": {
-				"type": "string"
-			},
-			"file": {},
-			"attachments": {
-				"description": "TODO: we should create an interface for attachments\nTODO: OpenWAAO<-->attachment-style metadata conversion",
-				"type": "array",
-				"items": {}
-			},
-			"sticker_ids": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
-			}
-		},
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"MfaCodesSchema": {
-		"type": "object",
-		"properties": {
-			"password": {
-				"type": "string"
-			},
-			"regenerate": {
-				"type": "boolean"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["password"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"ModifyGuildStickerSchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"minLength": 2,
-				"maxLength": 30,
-				"type": "string"
-			},
-			"description": {
-				"maxLength": 100,
-				"type": "string"
-			},
-			"tags": {
-				"maxLength": 200,
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["name", "tags"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"PruneSchema": {
-		"type": "object",
-		"properties": {
-			"days": {
-				"type": "integer"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["days"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"PurgeSchema": {
-		"type": "object",
-		"properties": {
-			"before": {
-				"type": "string"
-			},
-			"after": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["after", "before"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"RegisterSchema": {
-		"type": "object",
-		"properties": {
-			"username": {
-				"minLength": 2,
-				"maxLength": 32,
-				"type": "string"
-			},
-			"password": {
-				"minLength": 1,
-				"maxLength": 72,
-				"type": "string"
-			},
-			"consent": {
-				"type": "boolean"
-			},
-			"email": {
-				"format": "email",
-				"type": "string"
-			},
-			"fingerprint": {
-				"type": "string"
-			},
-			"invite": {
-				"type": "string"
-			},
-			"date_of_birth": {
-				"type": "string"
-			},
-			"gift_code_sku_id": {
-				"type": "string"
-			},
-			"captcha_key": {
-				"type": "string"
-			},
-			"promotional_email_opt_in": {
-				"type": "boolean"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["consent", "username"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"RelationshipPostSchema": {
-		"type": "object",
-		"properties": {
-			"discriminator": {
-				"type": "string"
-			},
-			"username": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["discriminator", "username"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"RelationshipPutSchema": {
-		"type": "object",
-		"properties": {
-			"type": {}
-		},
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"RoleModifySchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"type": "string"
-			},
-			"permissions": {
-				"type": "string"
-			},
-			"color": {
-				"type": "integer"
-			},
-			"hoist": {
-				"type": "boolean"
-			},
-			"mentionable": {
-				"type": "boolean"
-			},
-			"position": {
-				"type": "integer"
-			},
-			"icon": {
-				"type": "string"
-			},
-			"unicode_emoji": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"RolePositionUpdateSchema": {
-		"type": "array",
-		"items": {
-			"type": "object",
-			"properties": {
-				"id": {
-					"type": "string"
-				},
-				"position": {
-					"type": "integer"
-				}
-			},
-			"additionalProperties": false,
-			"required": ["id", "position"]
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"TemplateCreateSchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"type": "string"
-			},
-			"description": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["name"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"TemplateModifySchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"type": "string"
-			},
-			"description": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["name"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"TotpDisableSchema": {
-		"type": "object",
-		"properties": {
-			"code": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["code"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"TotpEnableSchema": {
-		"type": "object",
-		"properties": {
-			"password": {
-				"type": "string"
-			},
-			"code": {
-				"type": "string"
-			},
-			"secret": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["password"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"TotpSchema": {
-		"type": "object",
-		"properties": {
-			"code": {
-				"type": "string"
-			},
-			"ticket": {
-				"type": "string"
-			},
-			"gift_code_sku_id": {
-				"type": ["null", "string"]
-			},
-			"login_source": {
-				"type": ["null", "string"]
-			}
-		},
-		"additionalProperties": false,
-		"required": ["code", "ticket"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"UserModifySchema": {
-		"type": "object",
-		"properties": {
-			"username": {
-				"minLength": 1,
-				"maxLength": 100,
-				"type": "string"
-			},
-			"discriminator": {
-				"type": "string"
-			},
-			"avatar": {
-				"type": ["null", "string"]
-			},
-			"bio": {
-				"maxLength": 1024,
-				"type": "string"
-			},
-			"accent_color": {
-				"type": "integer"
-			},
-			"banner": {
-				"type": ["null", "string"]
-			},
-			"password": {
-				"type": "string"
-			},
-			"new_password": {
-				"type": "string"
-			},
-			"code": {
-				"type": "string"
-			},
-			"email": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"UserProfileModifySchema": {
-		"type": "object",
-		"properties": {
-			"bio": {
-				"type": "string"
-			},
-			"accent_color": {
-				"type": ["null", "integer"]
-			},
-			"banner": {
-				"type": ["null", "string"]
-			}
-		},
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"UserSettingsSchema": {
-		"type": "object",
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"VanityUrlSchema": {
-		"type": "object",
-		"properties": {
-			"code": {
-				"minLength": 1,
-				"maxLength": 20,
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"VoiceStateUpdateSchema": {
-		"type": "object",
-		"properties": {
-			"channel_id": {
-				"type": "string"
-			},
-			"guild_id": {
-				"type": "string"
-			},
-			"suppress": {
-				"type": "boolean"
-			},
-			"request_to_speak_timestamp": {
-				"type": "string",
-				"format": "date-time"
-			},
-			"self_mute": {
-				"type": "boolean"
-			},
-			"self_deaf": {
-				"type": "boolean"
-			},
-			"self_video": {
-				"type": "boolean"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["channel_id"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"WebhookCreateSchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"maxLength": 80,
-				"type": "string"
-			},
-			"avatar": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["name"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"WidgetModifySchema": {
-		"type": "object",
-		"properties": {
-			"enabled": {
-				"type": "boolean"
-			},
-			"channel_id": {
-				"type": "string"
-			}
-		},
-		"additionalProperties": false,
-		"required": ["channel_id", "enabled"],
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	},
-	"ChannelModifySchema": {
-		"type": "object",
-		"properties": {
-			"name": {
-				"maxLength": 100,
-				"type": "string"
-			},
-			"type": {
-				"enum": [0, 1, 10, 11, 12, 13, 14, 15, 2, 255, 3, 33, 34, 35, 4, 5, 6, 64, 7, 8, 9],
-				"type": "number"
-			},
-			"topic": {
-				"type": "string"
-			},
-			"icon": {
-				"type": ["null", "string"]
-			},
-			"bitrate": {
-				"type": "integer"
-			},
-			"user_limit": {
-				"type": "integer"
-			},
-			"rate_limit_per_user": {
-				"type": "integer"
-			},
-			"position": {
-				"type": "integer"
-			},
-			"permission_overwrites": {
-				"type": "array",
-				"items": {
-					"type": "object",
-					"properties": {
-						"id": {
-							"type": "string"
-						},
-						"type": {
-							"$ref": "#/definitions/ChannelPermissionOverwriteType"
-						},
-						"allow": {
-							"type": "string"
-						},
-						"deny": {
-							"type": "string"
-						}
-					},
-					"additionalProperties": false,
-					"required": ["allow", "deny", "id", "type"]
-				}
-			},
-			"parent_id": {
-				"type": "string"
-			},
-			"id": {
-				"type": "string"
-			},
-			"nsfw": {
-				"type": "boolean"
-			},
-			"rtc_region": {
-				"type": "string"
-			},
-			"default_auto_archive_duration": {
-				"type": "integer"
-			},
-			"flags": {
-				"type": "integer"
-			},
-			"default_thread_rate_limit_per_user": {
-				"type": "integer"
-			}
-		},
-		"additionalProperties": false,
-		"definitions": {
-			"ChannelPermissionOverwriteType": {
-				"enum": [0, 1, 2],
-				"type": "number"
-			}
-		},
-		"$schema": "http://json-schema.org/draft-07/schema#"
-	}
+    "RouteResponse": {
+        "type": "object",
+        "properties": {
+            "status": {
+                "type": "integer"
+            },
+            "body": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "headers": {
+                "$ref": "#/definitions/Record<string,string>"
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "Record<string,string>": {
+                "type": "object",
+                "additionalProperties": false
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "hcaptchaResponse": {
+        "type": "object",
+        "properties": {
+            "success": {
+                "type": "boolean"
+            },
+            "challenge_ts": {
+                "type": "string"
+            },
+            "hostname": {
+                "type": "string"
+            },
+            "credit": {
+                "type": "boolean"
+            },
+            "error-codes": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "score": {
+                "type": "integer"
+            },
+            "score_reason": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "challenge_ts",
+            "credit",
+            "error-codes",
+            "hostname",
+            "score",
+            "score_reason",
+            "success"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "recaptchaResponse": {
+        "type": "object",
+        "properties": {
+            "success": {
+                "type": "boolean"
+            },
+            "score": {
+                "type": "integer"
+            },
+            "action": {
+                "type": "string"
+            },
+            "challenge_ts": {
+                "type": "string"
+            },
+            "hostname": {
+                "type": "string"
+            },
+            "error-codes": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "action",
+            "challenge_ts",
+            "hostname",
+            "score",
+            "success"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "BackupCodesChallengeSchema": {
+        "type": "object",
+        "properties": {
+            "password": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "password"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "BanCreateSchema": {
+        "type": "object",
+        "properties": {
+            "delete_message_days": {
+                "type": "string"
+            },
+            "reason": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "BanModeratorSchema": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string"
+            },
+            "user_id": {
+                "type": "string"
+            },
+            "guild_id": {
+                "type": "string"
+            },
+            "executor_id": {
+                "type": "string"
+            },
+            "reason": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "executor_id",
+            "guild_id",
+            "id",
+            "user_id"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "BanRegistrySchema": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string"
+            },
+            "user_id": {
+                "type": "string"
+            },
+            "guild_id": {
+                "type": "string"
+            },
+            "executor_id": {
+                "type": "string"
+            },
+            "ip": {
+                "type": "string"
+            },
+            "reason": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "executor_id",
+            "guild_id",
+            "id",
+            "user_id"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "BulkDeleteSchema": {
+        "type": "object",
+        "properties": {
+            "messages": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "messages"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "ChannelModifySchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "maxLength": 100,
+                "type": "string"
+            },
+            "type": {
+                "enum": [
+                    0,
+                    1,
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15,
+                    2,
+                    255,
+                    3,
+                    33,
+                    34,
+                    35,
+                    4,
+                    5,
+                    6,
+                    64,
+                    7,
+                    8,
+                    9
+                ],
+                "type": "number"
+            },
+            "topic": {
+                "type": "string"
+            },
+            "icon": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "bitrate": {
+                "type": "integer"
+            },
+            "user_limit": {
+                "type": "integer"
+            },
+            "rate_limit_per_user": {
+                "type": "integer"
+            },
+            "position": {
+                "type": "integer"
+            },
+            "permission_overwrites": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                        },
+                        "allow": {
+                            "type": "string"
+                        },
+                        "deny": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "allow",
+                        "deny",
+                        "id",
+                        "type"
+                    ]
+                }
+            },
+            "parent_id": {
+                "type": "string"
+            },
+            "id": {
+                "type": "string"
+            },
+            "nsfw": {
+                "type": "boolean"
+            },
+            "rtc_region": {
+                "type": "string"
+            },
+            "default_auto_archive_duration": {
+                "type": "integer"
+            },
+            "flags": {
+                "type": "integer"
+            },
+            "default_thread_rate_limit_per_user": {
+                "type": "integer"
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "ChannelPermissionOverwriteSchema": {
+        "type": "object",
+        "properties": {
+            "allow": {
+                "type": "string"
+            },
+            "deny": {
+                "type": "string"
+            },
+            "id": {
+                "type": "string"
+            },
+            "type": {
+                "$ref": "#/definitions/ChannelPermissionOverwriteType"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "allow",
+            "deny",
+            "id",
+            "type"
+        ],
+        "definitions": {
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "ChannelReorderSchema": {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "position": {
+                    "type": "integer"
+                },
+                "lock_permissions": {
+                    "type": "boolean"
+                },
+                "parent_id": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "id"
+            ]
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "CodesVerificationSchema": {
+        "type": "object",
+        "properties": {
+            "key": {
+                "type": "string"
+            },
+            "nonce": {
+                "type": "string"
+            },
+            "regenerate": {
+                "type": "boolean"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "key",
+            "nonce"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "DmChannelCreateSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "recipients": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "recipients"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "EmojiCreateSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "image": {
+                "type": "string"
+            },
+            "require_colons": {
+                "type": [
+                    "null",
+                    "boolean"
+                ]
+            },
+            "roles": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "image"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "EmojiModifySchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "roles": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "GuildCreateSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "maxLength": 100,
+                "type": "string"
+            },
+            "region": {
+                "type": "string"
+            },
+            "icon": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "channels": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/ChannelModifySchema"
+                }
+            },
+            "guild_template_code": {
+                "type": "string"
+            },
+            "system_channel_id": {
+                "type": "string"
+            },
+            "rules_channel_id": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name"
+        ],
+        "definitions": {
+            "ChannelModifySchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 100,
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            0,
+                            1,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
+                            2,
+                            255,
+                            3,
+                            33,
+                            34,
+                            35,
+                            4,
+                            5,
+                            6,
+                            64,
+                            7,
+                            8,
+                            9
+                        ],
+                        "type": "number"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "bitrate": {
+                        "type": "integer"
+                    },
+                    "user_limit": {
+                        "type": "integer"
+                    },
+                    "rate_limit_per_user": {
+                        "type": "integer"
+                    },
+                    "position": {
+                        "type": "integer"
+                    },
+                    "permission_overwrites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/ChannelPermissionOverwriteType"
+                                },
+                                "allow": {
+                                    "type": "string"
+                                },
+                                "deny": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "allow",
+                                "deny",
+                                "id",
+                                "type"
+                            ]
+                        }
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "nsfw": {
+                        "type": "boolean"
+                    },
+                    "rtc_region": {
+                        "type": "string"
+                    },
+                    "default_auto_archive_duration": {
+                        "type": "integer"
+                    },
+                    "flags": {
+                        "type": "integer"
+                    },
+                    "default_thread_rate_limit_per_user": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ChannelPermissionOverwriteType": {
+                "enum": [
+                    0,
+                    1,
+                    2
+                ],
+                "type": "number"
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "GuildTemplateCreateSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "avatar": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "GuildUpdateSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "banner": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "splash": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "description": {
+                "type": "string"
+            },
+            "features": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "verification_level": {
+                "type": "integer"
+            },
+            "default_message_notifications": {
+                "type": "integer"
+            },
+            "system_channel_flags": {
+                "type": "integer"
+            },
+            "explicit_content_filter": {
+                "type": "integer"
+            },
+            "public_updates_channel_id": {
+                "type": "string"
+            },
+            "afk_timeout": {
+                "type": "integer"
+            },
+            "afk_channel_id": {
+                "type": "string"
+            },
+            "preferred_locale": {
+                "type": "string"
+            },
+            "premium_progress_bar_enabled": {
+                "type": "boolean"
+            },
+            "region": {
+                "type": "string"
+            },
+            "icon": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "guild_template_code": {
+                "type": "string"
+            },
+            "system_channel_id": {
+                "type": "string"
+            },
+            "rules_channel_id": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "GuildUpdateWelcomeScreenSchema": {
+        "type": "object",
+        "properties": {
+            "welcome_channels": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "channel_id": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "emoji_id": {
+                            "type": "string"
+                        },
+                        "emoji_name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "channel_id",
+                        "description",
+                        "emoji_name"
+                    ]
+                }
+            },
+            "enabled": {
+                "type": "boolean"
+            },
+            "description": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "IdentifySchema": {
+        "type": "object",
+        "properties": {
+            "token": {
+                "type": "string"
+            },
+            "properties": {
+                "type": "object",
+                "properties": {
+                    "os": {
+                        "type": "string"
+                    },
+                    "os_atch": {
+                        "type": "string"
+                    },
+                    "browser": {
+                        "type": "string"
+                    },
+                    "device": {
+                        "type": "string"
+                    },
+                    "$os": {
+                        "type": "string"
+                    },
+                    "$browser": {
+                        "type": "string"
+                    },
+                    "$device": {
+                        "type": "string"
+                    },
+                    "browser_user_agent": {
+                        "type": "string"
+                    },
+                    "browser_version": {
+                        "type": "string"
+                    },
+                    "os_version": {
+                        "type": "string"
+                    },
+                    "referrer": {
+                        "type": "string"
+                    },
+                    "referring_domain": {
+                        "type": "string"
+                    },
+                    "referrer_current": {
+                        "type": "string"
+                    },
+                    "referring_domain_current": {
+                        "type": "string"
+                    },
+                    "release_channel": {
+                        "enum": [
+                            "canary",
+                            "dev",
+                            "ptb",
+                            "stable"
+                        ],
+                        "type": "string"
+                    },
+                    "client_build_number": {
+                        "type": "integer"
+                    },
+                    "client_event_source": {},
+                    "client_version": {
+                        "type": "string"
+                    },
+                    "system_locale": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "intents": {
+                "type": "string"
+            },
+            "presence": {
+                "$ref": "#/definitions/ActivitySchema"
+            },
+            "compress": {
+                "type": "boolean"
+            },
+            "large_threshold": {
+                "type": "integer"
+            },
+            "shard": {
+                "type": "array",
+                "items": [
+                    {
+                        "type": "integer"
+                    },
+                    {
+                        "type": "integer"
+                    }
+                ],
+                "minItems": 2,
+                "maxItems": 2
+            },
+            "guild_subscriptions": {
+                "type": "boolean"
+            },
+            "capabilities": {
+                "type": "integer"
+            },
+            "client_state": {
+                "type": "object",
+                "properties": {
+                    "guild_hashes": {},
+                    "highest_last_message_id": {
+                        "type": "string"
+                    },
+                    "read_state_version": {
+                        "type": "integer"
+                    },
+                    "user_guild_settings_version": {
+                        "type": "integer"
+                    },
+                    "user_settings_version": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "v": {
+                "type": "integer"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "properties",
+            "token"
+        ],
+        "definitions": {
+            "ActivitySchema": {
+                "type": "object",
+                "properties": {
+                    "afk": {
+                        "type": "boolean"
+                    },
+                    "status": {
+                        "$ref": "#/definitions/Status"
+                    },
+                    "activities": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/Activity"
+                        }
+                    },
+                    "since": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "afk",
+                    "status"
+                ]
+            },
+            "Status": {
+                "enum": [
+                    "dnd",
+                    "idle",
+                    "invisible",
+                    "offline",
+                    "online"
+                ],
+                "type": "string"
+            },
+            "Activity": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/definitions/ActivityType"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "type": "integer"
+                    },
+                    "timestamps": {
+                        "type": "object",
+                        "properties": {
+                            "start": {
+                                "type": "integer"
+                            },
+                            "end": {
+                                "type": "integer"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "end",
+                            "start"
+                        ]
+                    },
+                    "application_id": {
+                        "type": "string"
+                    },
+                    "details": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "emoji": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "animated": {
+                                "type": "boolean"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "animated",
+                            "name"
+                        ]
+                    },
+                    "party": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "size": {
+                                "type": "array",
+                                "items": [
+                                    {
+                                        "type": "integer"
+                                    }
+                                ],
+                                "minItems": 1,
+                                "maxItems": 1
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "assets": {
+                        "type": "object",
+                        "properties": {
+                            "large_image": {
+                                "type": "string"
+                            },
+                            "large_text": {
+                                "type": "string"
+                            },
+                            "small_image": {
+                                "type": "string"
+                            },
+                            "small_text": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "secrets": {
+                        "type": "object",
+                        "properties": {
+                            "join": {
+                                "type": "string"
+                            },
+                            "spectate": {
+                                "type": "string"
+                            },
+                            "match": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "instance": {
+                        "type": "boolean"
+                    },
+                    "flags": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "flags",
+                    "name",
+                    "type"
+                ]
+            },
+            "ActivityType": {
+                "enum": [
+                    0,
+                    1,
+                    2,
+                    4,
+                    5
+                ],
+                "type": "number"
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "InviteCreateSchema": {
+        "type": "object",
+        "properties": {
+            "target_user_id": {
+                "type": "string"
+            },
+            "target_type": {
+                "type": "string"
+            },
+            "validate": {
+                "type": "string"
+            },
+            "max_age": {
+                "type": "integer"
+            },
+            "max_uses": {
+                "type": "integer"
+            },
+            "temporary": {
+                "type": "boolean"
+            },
+            "unique": {
+                "type": "boolean"
+            },
+            "target_user": {
+                "type": "string"
+            },
+            "target_user_type": {
+                "type": "integer"
+            }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "LoginSchema": {
+        "type": "object",
+        "properties": {
+            "login": {
+                "type": "string"
+            },
+            "password": {
+                "type": "string"
+            },
+            "undelete": {
+                "type": "boolean"
+            },
+            "captcha_key": {
+                "type": "string"
+            },
+            "login_source": {
+                "type": "string"
+            },
+            "gift_code_sku_id": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "login",
+            "password"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "MemberChangeProfileSchema": {
+        "type": "object",
+        "properties": {
+            "banner": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "nick": {
+                "type": "string"
+            },
+            "bio": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "MemberChangeSchema": {
+        "type": "object",
+        "properties": {
+            "roles": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "nick": {
+                "type": "string"
+            },
+            "avatar": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "MemberNickChangeSchema": {
+        "type": "object",
+        "properties": {
+            "nick": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "nick"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "MessageAcknowledgeSchema": {
+        "type": "object",
+        "properties": {
+            "manual": {
+                "type": "boolean"
+            },
+            "mention_count": {
+                "type": "integer"
+            }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "MessageCreateSchema": {
+        "type": "object",
+        "properties": {
+            "type": {
+                "type": "integer"
+            },
+            "content": {
+                "type": "string"
+            },
+            "nonce": {
+                "type": "string"
+            },
+            "channel_id": {
+                "type": "string"
+            },
+            "tts": {
+                "type": "boolean"
+            },
+            "flags": {
+                "type": "string"
+            },
+            "embeds": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/Embed"
+                }
+            },
+            "embed": {
+                "$ref": "#/definitions/Embed"
+            },
+            "allowed_mentions": {
+                "type": "object",
+                "properties": {
+                    "parse": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "roles": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "users": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "replied_user": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "message_reference": {
+                "type": "object",
+                "properties": {
+                    "message_id": {
+                        "type": "string"
+                    },
+                    "channel_id": {
+                        "type": "string"
+                    },
+                    "guild_id": {
+                        "type": "string"
+                    },
+                    "fail_if_not_exists": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "channel_id",
+                    "message_id"
+                ]
+            },
+            "payload_json": {
+                "type": "string"
+            },
+            "file": {},
+            "attachments": {
+                "description": "TODO: we should create an interface for attachments\nTODO: OpenWAAO<-->attachment-style metadata conversion",
+                "type": "array",
+                "items": {}
+            },
+            "sticker_ids": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "Embed": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "article",
+                            "gifv",
+                            "image",
+                            "link",
+                            "rich",
+                            "video"
+                        ],
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "color": {
+                        "type": "integer"
+                    },
+                    "footer": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "text"
+                        ]
+                    },
+                    "image": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "thumbnail": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "video": {
+                        "$ref": "#/definitions/EmbedImage"
+                    },
+                    "provider": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "author": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "icon_url": {
+                                "type": "string"
+                            },
+                            "proxy_icon_url": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "inline": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "EmbedImage": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "proxy_url": {
+                        "type": "string"
+                    },
+                    "height": {
+                        "type": "integer"
+                    },
+                    "width": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "MfaCodesSchema": {
+        "type": "object",
+        "properties": {
+            "password": {
+                "type": "string"
+            },
+            "regenerate": {
+                "type": "boolean"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "password"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "ModifyGuildStickerSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "minLength": 2,
+                "maxLength": 30,
+                "type": "string"
+            },
+            "description": {
+                "maxLength": 100,
+                "type": "string"
+            },
+            "tags": {
+                "maxLength": 200,
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name",
+            "tags"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "PruneSchema": {
+        "type": "object",
+        "properties": {
+            "days": {
+                "type": "integer"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "days"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "PurgeSchema": {
+        "type": "object",
+        "properties": {
+            "before": {
+                "type": "string"
+            },
+            "after": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "after",
+            "before"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "RegisterSchema": {
+        "type": "object",
+        "properties": {
+            "username": {
+                "minLength": 2,
+                "maxLength": 32,
+                "type": "string"
+            },
+            "password": {
+                "minLength": 1,
+                "maxLength": 72,
+                "type": "string"
+            },
+            "consent": {
+                "type": "boolean"
+            },
+            "email": {
+                "format": "email",
+                "type": "string"
+            },
+            "fingerprint": {
+                "type": "string"
+            },
+            "invite": {
+                "type": "string"
+            },
+            "date_of_birth": {
+                "type": "string"
+            },
+            "gift_code_sku_id": {
+                "type": "string"
+            },
+            "captcha_key": {
+                "type": "string"
+            },
+            "promotional_email_opt_in": {
+                "type": "boolean"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "consent",
+            "username"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "RelationshipPostSchema": {
+        "type": "object",
+        "properties": {
+            "discriminator": {
+                "type": "string"
+            },
+            "username": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "discriminator",
+            "username"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "RelationshipPutSchema": {
+        "type": "object",
+        "properties": {
+            "type": {
+                "enum": [
+                    1,
+                    2,
+                    3,
+                    4
+                ],
+                "type": "number"
+            }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "RoleModifySchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "permissions": {
+                "type": "string"
+            },
+            "color": {
+                "type": "integer"
+            },
+            "hoist": {
+                "type": "boolean"
+            },
+            "mentionable": {
+                "type": "boolean"
+            },
+            "position": {
+                "type": "integer"
+            },
+            "icon": {
+                "type": "string"
+            },
+            "unicode_emoji": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "RolePositionUpdateSchema": {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "position": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "id",
+                "position"
+            ]
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "TemplateCreateSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "description": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "TemplateModifySchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "description": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "TotpDisableSchema": {
+        "type": "object",
+        "properties": {
+            "code": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "code"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "TotpEnableSchema": {
+        "type": "object",
+        "properties": {
+            "password": {
+                "type": "string"
+            },
+            "code": {
+                "type": "string"
+            },
+            "secret": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "password"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "TotpSchema": {
+        "type": "object",
+        "properties": {
+            "code": {
+                "type": "string"
+            },
+            "ticket": {
+                "type": "string"
+            },
+            "gift_code_sku_id": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "login_source": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "code",
+            "ticket"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "UserModifySchema": {
+        "type": "object",
+        "properties": {
+            "username": {
+                "minLength": 1,
+                "maxLength": 100,
+                "type": "string"
+            },
+            "discriminator": {
+                "type": "string"
+            },
+            "avatar": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "bio": {
+                "maxLength": 1024,
+                "type": "string"
+            },
+            "accent_color": {
+                "type": "integer"
+            },
+            "banner": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "password": {
+                "type": "string"
+            },
+            "new_password": {
+                "type": "string"
+            },
+            "code": {
+                "type": "string"
+            },
+            "email": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "UserProfileModifySchema": {
+        "type": "object",
+        "properties": {
+            "bio": {
+                "type": "string"
+            },
+            "accent_color": {
+                "type": [
+                    "null",
+                    "integer"
+                ]
+            },
+            "banner": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "UserSettingsSchema": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string"
+            },
+            "afk_timeout": {
+                "type": "integer"
+            },
+            "allow_accessibility_detection": {
+                "type": "boolean"
+            },
+            "animate_emoji": {
+                "type": "boolean"
+            },
+            "animate_stickers": {
+                "type": "integer"
+            },
+            "contact_sync_enabled": {
+                "type": "boolean"
+            },
+            "convert_emoticons": {
+                "type": "boolean"
+            },
+            "custom_status": {
+                "anyOf": [
+                    {
+                        "$ref": "#/definitions/CustomStatus"
+                    },
+                    {
+                        "type": "null"
+                    }
+                ]
+            },
+            "default_guilds_restricted": {
+                "type": "boolean"
+            },
+            "detect_platform_accounts": {
+                "type": "boolean"
+            },
+            "developer_mode": {
+                "type": "boolean"
+            },
+            "disable_games_tab": {
+                "type": "boolean"
+            },
+            "enable_tts_command": {
+                "type": "boolean"
+            },
+            "explicit_content_filter": {
+                "type": "integer"
+            },
+            "friend_source_flags": {
+                "$ref": "#/definitions/FriendSourceFlags"
+            },
+            "gateway_connected": {
+                "type": "boolean"
+            },
+            "gif_auto_play": {
+                "type": "boolean"
+            },
+            "guild_folders": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/GuildFolder"
+                }
+            },
+            "guild_positions": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "inline_attachment_media": {
+                "type": "boolean"
+            },
+            "inline_embed_media": {
+                "type": "boolean"
+            },
+            "locale": {
+                "type": "string"
+            },
+            "message_display_compact": {
+                "type": "boolean"
+            },
+            "native_phone_integration_enabled": {
+                "type": "boolean"
+            },
+            "render_embeds": {
+                "type": "boolean"
+            },
+            "render_reactions": {
+                "type": "boolean"
+            },
+            "restricted_guilds": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "show_current_game": {
+                "type": "boolean"
+            },
+            "status": {
+                "enum": [
+                    "dnd",
+                    "idle",
+                    "invisible",
+                    "offline",
+                    "online"
+                ],
+                "type": "string"
+            },
+            "stream_notifications_enabled": {
+                "type": "boolean"
+            },
+            "theme": {
+                "enum": [
+                    "dark",
+                    "white"
+                ],
+                "type": "string"
+            },
+            "timezone_offset": {
+                "type": "integer"
+            },
+            "hasId": {
+                "description": "Checks if entity has an id.\nIf entity composite compose ids, it will check them all.",
+                "type": "object",
+                "additionalProperties": false
+            },
+            "save": {
+                "description": "Saves current entity in the database.\nIf entity does not exist in the database then inserts, otherwise updates.",
+                "type": "object",
+                "additionalProperties": false
+            },
+            "remove": {
+                "description": "Removes current entity from the database.",
+                "type": "object",
+                "additionalProperties": false
+            },
+            "softRemove": {
+                "description": "Records the delete date of current entity.",
+                "type": "object",
+                "additionalProperties": false
+            },
+            "recover": {
+                "description": "Recovers a given entity in the database.",
+                "type": "object",
+                "additionalProperties": false
+            },
+            "reload": {
+                "description": "Reloads entity data from the database.",
+                "type": "object",
+                "additionalProperties": false
+            }
+        },
+        "additionalProperties": false,
+        "definitions": {
+            "CustomStatus": {
+                "type": "object",
+                "properties": {
+                    "emoji_id": {
+                        "type": "string"
+                    },
+                    "emoji_name": {
+                        "type": "string"
+                    },
+                    "expires_at": {
+                        "type": "integer"
+                    },
+                    "text": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "FriendSourceFlags": {
+                "type": "object",
+                "properties": {
+                    "all": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "all"
+                ]
+            },
+            "GuildFolder": {
+                "type": "object",
+                "properties": {
+                    "color": {
+                        "type": "integer"
+                    },
+                    "guild_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "color",
+                    "guild_ids",
+                    "id",
+                    "name"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "VanityUrlSchema": {
+        "type": "object",
+        "properties": {
+            "code": {
+                "minLength": 1,
+                "maxLength": 20,
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "VoiceStateUpdateSchema": {
+        "type": "object",
+        "properties": {
+            "channel_id": {
+                "type": "string"
+            },
+            "guild_id": {
+                "type": "string"
+            },
+            "suppress": {
+                "type": "boolean"
+            },
+            "request_to_speak_timestamp": {
+                "type": "string",
+                "format": "date-time"
+            },
+            "self_mute": {
+                "type": "boolean"
+            },
+            "self_deaf": {
+                "type": "boolean"
+            },
+            "self_video": {
+                "type": "boolean"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "channel_id"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "WebhookCreateSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "maxLength": 80,
+                "type": "string"
+            },
+            "avatar": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "WidgetModifySchema": {
+        "type": "object",
+        "properties": {
+            "enabled": {
+                "type": "boolean"
+            },
+            "channel_id": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "channel_id",
+            "enabled"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "ActivitySchema": {
+        "type": "object",
+        "properties": {
+            "afk": {
+                "type": "boolean"
+            },
+            "status": {
+                "$ref": "#/definitions/Status"
+            },
+            "activities": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/Activity"
+                }
+            },
+            "since": {
+                "type": "integer"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "afk",
+            "status"
+        ],
+        "definitions": {
+            "Status": {
+                "enum": [
+                    "dnd",
+                    "idle",
+                    "invisible",
+                    "offline",
+                    "online"
+                ],
+                "type": "string"
+            },
+            "Activity": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/definitions/ActivityType"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "type": "integer"
+                    },
+                    "timestamps": {
+                        "type": "object",
+                        "properties": {
+                            "start": {
+                                "type": "integer"
+                            },
+                            "end": {
+                                "type": "integer"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "end",
+                            "start"
+                        ]
+                    },
+                    "application_id": {
+                        "type": "string"
+                    },
+                    "details": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "emoji": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "animated": {
+                                "type": "boolean"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "animated",
+                            "name"
+                        ]
+                    },
+                    "party": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "size": {
+                                "type": "array",
+                                "items": [
+                                    {
+                                        "type": "integer"
+                                    }
+                                ],
+                                "minItems": 1,
+                                "maxItems": 1
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "assets": {
+                        "type": "object",
+                        "properties": {
+                            "large_image": {
+                                "type": "string"
+                            },
+                            "large_text": {
+                                "type": "string"
+                            },
+                            "small_image": {
+                                "type": "string"
+                            },
+                            "small_text": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "secrets": {
+                        "type": "object",
+                        "properties": {
+                            "join": {
+                                "type": "string"
+                            },
+                            "spectate": {
+                                "type": "string"
+                            },
+                            "match": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "instance": {
+                        "type": "boolean"
+                    },
+                    "flags": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "flags",
+                    "name",
+                    "type"
+                ]
+            },
+            "ActivityType": {
+                "enum": [
+                    0,
+                    1,
+                    2,
+                    4,
+                    5
+                ],
+                "type": "number"
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    }
 }

--- a/scripts/generate_schema.js
+++ b/scripts/generate_schema.js
@@ -49,7 +49,7 @@ function modify(obj) {
 
 function main() {
 	const files = [...walk(path.join(__dirname, "..", "src", "util", "schemas"))];
-	const program = TJS.getProgramFromFiles(files, compilerOptions);
+	const program = TJS.programFromConfig(path.join(__dirname, "..", "tsconfig.json"), files);
 	const generator = TJS.buildGenerator(program, settings);
 	if (!generator || !program) return;
 


### PR DESCRIPTION
Fixes schemas which extend from others, such as ChannelPermissionOverwriteSchema being empty.
I think this was caused by the import from `@fosscord/util` rather than a relative path, which the generator didn't know about.
Using the tsconfig gives the generator this information and thus fixes the issue