### PR TITLE
chore: update docker scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM node:alpine
 
 # args 
 ARG WAIT_FOR_VERSION=4df3f9262d84cab0039c07bf861045fbb3c20ab7
+ARG PUID=1000
+ARG PGID=1000
+
+# setup non-root user
+RUN deluser --remove-home node && addgroup -S node -g ${PGID} && adduser -S -G node -u ${PUID} node
 
 # install required apps
 RUN apk add --no-cache --update git python3 py-pip make build-base cairo-dev pango-dev jpeg-dev giflib-dev librsvg-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,6 @@ FROM node:alpine
 ENV HTTP_PORT=3001
 ENV WS_PORT=3002
 ENV CDN_PORT=3003
-ENV RTC_PORT=3004
-ENV ADMIN_PORT=3005
-
-# exposed ports (only for reference, see https://docs.docker.com/engine/reference/builder/#expose)
-EXPOSE ${HTTP_PORT}/tcp ${WS_PORT}/tcp ${CDN_PORT}/tcp ${RTC_PORT}/tcp ${ADMIN_PORT}/tcp
 
 # install required apps
 RUN apk add --no-cache --update git python3 py-pip make build-base
@@ -18,5 +13,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 # RUN adduser -D fosscord
 # USER fosscord
 
-WORKDIR /srv/fosscord-server/bundle
-ENTRYPOINT ["npm", "run", "start:bundle"]
+EXPOSE ${HTTP_PORT} ${WS_PORT} ${CDN_PORT}
+
+WORKDIR /srv/fosscord-server/
+CMD ["npm", "run", "start:bundle"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,14 @@
 FROM node:alpine
 
-# build args
-ARG HTTP_PORT=3001
-ARG WS_PORT=3002
-ARG CDN_PORT=3003
-
 # install required apps
 RUN apk add --no-cache --update git python3 py-pip make build-base
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Run as non-root user
-# RUN adduser -D fosscord
-# USER fosscord
+USER node
+RUN git config --global --add safe.directory /srv/fosscord-server/
 
-EXPOSE ${HTTP_PORT} ${WS_PORT} ${CDN_PORT}
+EXPOSE 3001 3002 3003
 
 WORKDIR /srv/fosscord-server/
 CMD ["npm", "run", "start:bundle"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,22 @@
 FROM node:alpine
 
+# args 
+ARG WAIT_FOR_VERSION=4df3f9262d84cab0039c07bf861045fbb3c20ab7
+
 # install required apps
 RUN apk add --no-cache --update git python3 py-pip make build-base cairo-dev pango-dev jpeg-dev giflib-dev librsvg-dev
+
+# add symlinks
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN ln -s /bin/grep /usr/bin/grep
+
+# download wait-for
+RUN wget -O /usr/local/bin/wait-for https://raw.githubusercontent.com/eficode/wait-for/${WAIT_FOR_VERSION}/wait-for \
+	&& chmod +x /usr/local/bin/wait-for
 
 # Run as non-root user
 USER node
 RUN git config --global --add safe.directory /srv/fosscord-server/
-
-EXPOSE 3001 3002 3003
 
 WORKDIR /srv/fosscord-server/
 CMD ["npm", "run", "start:bundle"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:alpine
 
-# env vars
-ENV HTTP_PORT=3001
-ENV WS_PORT=3002
-ENV CDN_PORT=3003
+# build args
+ARG HTTP_PORT=3001
+ARG WS_PORT=3002
+ARG CDN_PORT=3003
 
 # install required apps
 RUN apk add --no-cache --update git python3 py-pip make build-base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:alpine
 
 # install required apps
-RUN apk add --no-cache --update git python3 py-pip make build-base
+RUN apk add --no-cache --update git python3 py-pip make build-base cairo-dev pango-dev jpeg-dev giflib-dev librsvg-dev
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Run as non-root user

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 # Run as non-root user
 USER node
 RUN git config --global --add safe.directory /srv/fosscord-server/
+RUN ln -s /bin/grep /usr/bin/grep
 
 EXPOSE 3001 3002 3003
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM node:alpine
 # install required apps
 RUN apk add --no-cache --update git python3 py-pip make build-base cairo-dev pango-dev jpeg-dev giflib-dev librsvg-dev
 RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN ln -s /bin/grep /usr/bin/grep
 
 # Run as non-root user
 USER node
 RUN git config --global --add safe.directory /srv/fosscord-server/
-RUN ln -s /bin/grep /usr/bin/grep
 
 EXPOSE 3001 3002 3003
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,1 +1,0 @@
-The Docker image is coming with the dashboard. The planned release date is 2022-12-24.

--- a/docker-compose.cfg.yml
+++ b/docker-compose.cfg.yml
@@ -1,5 +1,0 @@
-version: "3.9"
-
-services:
-    fosscord:
-        entrypoint: ["npm", "run", "setup"]

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,0 +1,13 @@
+version: '3.9'
+
+services:
+  fosscord:
+    depends_on: [ 'postgres' ]
+    command: sh -c 'wait-for postgres:5432 -- npm run start:bundle'
+
+  postgres:
+    image: postgres:latest
+    restart: unless-stopped
+    # ports: [ '5432:5432' ]
+    env_file: [ '.env' ]
+    volumes: [ './db/:/var/lib/postgresql/data' ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,4 @@ services:
     build: .
     ports: [ '3001-3003:3001-3003' ]
     volumes: [ './:/srv/fosscord-server/' ]
-    environment:
-      THREADS: ${THREADS:-1}
-      HTTP_PORT: 3001
-      WS_PORT: 3002
-      CDN_PORT: 3003
+    env_file: [ '.env' ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,14 @@
-version: "3.9"
+version: '3.9'
 
 services:
-    fosscord:
-        container_name: fosscord
-        image: fosscord
-        restart: on-failure:5
-        build: .
-        ports:
-            - "3001-3005:3001-3005"
-        volumes:
-            - ./:/srv/fosscord-server/
-        environment:
-            THREADS: ${THREADS:-1}
-            HTTP_PORT: 3001
-            WS_PORT: 3002
-            CDN_PORT: 3003
-            RTC_PORT: 3004
-            ADMIN_PORT: 3005
-
-networks:
-    default:
-        name: fosscord
-        driver: bridge
+  fosscord:
+    image: fosscord
+    restart: unless-stopped
+    build: .
+    ports: [ '3001-3003:3001-3003' ]
+    volumes: [ './:/srv/fosscord-server/' ]
+    environment:
+      THREADS: ${THREADS:-1}
+      HTTP_PORT: 3001
+      WS_PORT: 3002
+      CDN_PORT: 3003

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,5 @@ services:
     restart: unless-stopped
     build: .
     ports: [ '3001-3003:3001-3003' ]
-    volumes: [ './:/srv/fosscord-server/' ]
     env_file: [ '.env' ]
+    volumes: [ './:/srv/fosscord-server/' ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,11 @@ services:
   fosscord:
     image: fosscord
     restart: unless-stopped
-    build: .
+    build:
+      context: .
+      args:
+        PUID: ${PUID:-1000}
+        PGID: ${PGID:-1000}
     ports: [ '3001-3003:3001-3003' ]
     env_file: [ '.env' ]
     volumes: [ './:/srv/fosscord-server/' ]


### PR DESCRIPTION
Docker scripts have been updated to fosscord staging.

Steps to deploy:

```sh
docker compose run fosscord node scripts/first_setup.js
docker compose up -d

# or if you want to use postgresql
docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d
```

## Notes

- You can always run the setup script outside the container, so the first command is optional.  
- Running `COPY` or `git clone` commands inside the `Dockerfile` **is not recommended** because you may want to run your own modified version of Fosscord. Please note that `git clone` or `COPY` commands may be added **ONLY IF** you want to publish a prebuilt image in any Docker Registry. In this case, user-made customizations can be supported through git patches.
- `canvas` and `bcrypt` packages are fully supported.
- Fosscord will run as **non-root** user. You can override this behavior by editing the `Dockerfile`¹ or the `docker-compose.yml`² file. ([1](https://docs.docker.com/engine/reference/builder/#user), [2](https://docs.docker.com/compose/compose-file/#user)).
- You can set a custom userid/groupid for the non-root user (**build-time only**).
- PostgreSQL is fully supported.
- Partial MariaDB support can be found [here](https://github.com/n0bodysec/docker-images/blob/main/fosscord/docker-compose.mariadb.yml).

## Example `.env` file for SQLite, PostgreSQL and MariaDB.

```env
# SQLite example
DATABASE=database.db

# PostgreSQL example (POSTGRES_USER and POSTGRES_DB are optional)
DATABASE=postgres://user:password@postgres/dbname
POSTGRES_USER=postgres
POSTGRES_DB=postgres
POSTGRES_PASSWORD=password

# MariaDB example
DATABASE=mariadb://user:password@mariadb/dbname
MARIADB_ROOT_PASSWORD=secr3tpassw0rd
MARIADB_DATABASE=fosscord
MARIADB_USER=fosscord
MARIADB_PASSWORD=password
```

\
Since Docker is fully supported, it should be added to [the docs](https://docs.fosscord.com/server/setup/#with-docker).