### PR TITLE
[Refactor] Disable QR Login in Test client

### DIFF
--- a/scripts/client.js
+++ b/scripts/client.js
@@ -135,6 +135,9 @@ const doPatch = (content) => {
 		"e.isFastConnect=t; if (t !== undefined) e._doResumeOrIdentify();"
 	);
 
+	// disable qr code login
+	content = content.replaceAll(/\w\?\(\d,\w\.jsx\)\(\w*\,{authTokenCallback:this\.handleAuthToken}\):null/g, "null");
+
 	return content;
 };
 


### PR DESCRIPTION
This adds a client patch to completely disable rendering of the qr login component, doing it this way rather than in css will also prevent the console being spammed with error messages.

Before:
![image](https://user-images.githubusercontent.com/14828766/209068260-c697f393-cce8-43c8-8f8f-e6448e8677ec.png)
After:
![image](https://user-images.githubusercontent.com/14828766/209068019-96f70c16-d62d-4b69-9739-23886ca3631e.png)
