### PR TITLE
[Refactor] Fix developer portal style

### DIFF
--- a/assets/client_test/developers.html
+++ b/assets/client_test/developers.html
@@ -5,9 +5,9 @@
 	<meta charset="utf-8" />
 	<meta content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no" name="viewport" />
 
-	<link rel="stylesheet" href="/assets/532.03aaeef88460fae60534.css" integrity="" />
-	<link rel="icon" href="/assets/07dca80a102d4149e9736d4b162cff6f.ico" />
-	<title>Discord Test Client Developer Portal</title>
+	<link rel="stylesheet" href="/assets/532.5ee4b893e126424a925a.css" integrity="" />
+	<link rel="icon" href="/assets/847541504914fd33810e70a0ea73177e.ico" />
+	<title>Fosscord Test Client Developer Portal</title>
 	<meta charset="utf-8" data-react-helmet="true" />
 </head>
 


### PR DESCRIPTION
This PR is a follow-up to #917 which fixes styling in the developer portal and changes the title to use Fosscord, to match the test client.

Style Issue:
![style issue](https://user-images.githubusercontent.com/14828766/209228448-bec6e11c-8e06-4e03-b2ea-0d7359183dc0.png)
