### PR TITLE
Patch body-parser to use json-bigint, like gateway

### DIFF
--- a/assets/schemas.json
+++ b/assets/schemas.json
@@ -12064,6 +12064,22 @@
             },
             "bio": {
                 "type": "string"
+            },
+            "pronouns": {
+                "type": "string"
+            },
+            "theme_colors": {
+                "type": "array",
+                "items": [
+                    {
+                        "type": "integer"
+                    },
+                    {
+                        "type": "integer"
+                    }
+                ],
+                "minItems": 2,
+                "maxItems": 2
             }
         },
         "additionalProperties": false,
@@ -19567,6 +19583,22 @@
                     "null",
                     "string"
                 ]
+            },
+            "pronouns": {
+                "type": "string"
+            },
+            "theme_colors": {
+                "type": "array",
+                "items": [
+                    {
+                        "type": "integer"
+                    },
+                    {
+                        "type": "integer"
+                    }
+                ],
+                "minItems": 2,
+                "maxItems": 2
             }
         },
         "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"ajv-formats": "2.1.1",
 				"amqplib": "^0.10.3",
 				"bcrypt": "^5.0.1",
-				"body-parser": "^1.20.1",
+				"body-parser": "1.20.1",
 				"cheerio": "^1.0.0-rc.12",
 				"cookie-parser": "^1.4.6",
 				"dotenv": "^16.0.2",
@@ -243,16 +243,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-s3": {
-			"version": "3.238.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.238.0.tgz",
-			"integrity": "sha512-gK8JzwsprnwNjKBUc5/K2dVWQQNK6Dxyhh1IIsJbzj6uurW2K61/mkNNV1h33SAKTubsJYPkq6VwcTrBKtpabg==",
+			"version": "3.241.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.241.0.tgz",
+			"integrity": "sha512-GxkiX4f+FUW2Lr3PySc1wuYlfU8QV2nx6KlBY8L8yf2txtajEL0/hhfo5Pbo4Uw1ZZlTv4iPHUOiTrm2R9Rhyg==",
 			"dependencies": {
 				"@aws-crypto/sha1-browser": "2.0.0",
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.238.0",
+				"@aws-sdk/client-sts": "3.241.0",
 				"@aws-sdk/config-resolver": "3.234.0",
-				"@aws-sdk/credential-provider-node": "3.238.0",
+				"@aws-sdk/credential-provider-node": "3.241.0",
 				"@aws-sdk/eventstream-serde-browser": "3.226.0",
 				"@aws-sdk/eventstream-serde-config-resolver": "3.226.0",
 				"@aws-sdk/eventstream-serde-node": "3.226.0",
@@ -290,7 +290,7 @@
 				"@aws-sdk/util-body-length-node": "3.208.0",
 				"@aws-sdk/util-defaults-mode-browser": "3.234.0",
 				"@aws-sdk/util-defaults-mode-node": "3.234.0",
-				"@aws-sdk/util-endpoints": "3.226.0",
+				"@aws-sdk/util-endpoints": "3.241.0",
 				"@aws-sdk/util-retry": "3.229.0",
 				"@aws-sdk/util-stream-browser": "3.226.0",
 				"@aws-sdk/util-stream-node": "3.226.0",
@@ -308,9 +308,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.238.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.238.0.tgz",
-			"integrity": "sha512-KHJJWP7hBDa9KLYiU5+hOb+3AAba93PhWebXkpKyQ/Bs+e7ECCreyLCwuME6uWTV01NDuFDpwZ6zUMpyNIcP6Q==",
+			"version": "3.241.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
+			"integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
@@ -338,7 +338,7 @@
 				"@aws-sdk/util-body-length-node": "3.208.0",
 				"@aws-sdk/util-defaults-mode-browser": "3.234.0",
 				"@aws-sdk/util-defaults-mode-node": "3.234.0",
-				"@aws-sdk/util-endpoints": "3.226.0",
+				"@aws-sdk/util-endpoints": "3.241.0",
 				"@aws-sdk/util-retry": "3.229.0",
 				"@aws-sdk/util-user-agent-browser": "3.226.0",
 				"@aws-sdk/util-user-agent-node": "3.226.0",
@@ -351,9 +351,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sso-oidc": {
-			"version": "3.238.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.238.0.tgz",
-			"integrity": "sha512-kazcA2Kp+cXQRtaZi5/T5YFfU9J3nzu1tXJsh0xAm+J3S9LS1ertY1bSX6KBed2xuxx2mfum8JRqli0TJad/pA==",
+			"version": "3.241.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
+			"integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
@@ -381,7 +381,7 @@
 				"@aws-sdk/util-body-length-node": "3.208.0",
 				"@aws-sdk/util-defaults-mode-browser": "3.234.0",
 				"@aws-sdk/util-defaults-mode-node": "3.234.0",
-				"@aws-sdk/util-endpoints": "3.226.0",
+				"@aws-sdk/util-endpoints": "3.241.0",
 				"@aws-sdk/util-retry": "3.229.0",
 				"@aws-sdk/util-user-agent-browser": "3.226.0",
 				"@aws-sdk/util-user-agent-node": "3.226.0",
@@ -394,14 +394,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sts": {
-			"version": "3.238.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.238.0.tgz",
-			"integrity": "sha512-jQNwHqxWUGvWCN4o8KUFYQES8r41Oobu7x1KZOMrPhPxy27FUcDjBq/h85VoD2/AZlETSCZLiCnKV3KBh5pT5w==",
+			"version": "3.241.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
+			"integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
 				"@aws-sdk/config-resolver": "3.234.0",
-				"@aws-sdk/credential-provider-node": "3.238.0",
+				"@aws-sdk/credential-provider-node": "3.241.0",
 				"@aws-sdk/fetch-http-handler": "3.226.0",
 				"@aws-sdk/hash-node": "3.226.0",
 				"@aws-sdk/invalid-dependency": "3.226.0",
@@ -427,7 +427,7 @@
 				"@aws-sdk/util-body-length-node": "3.208.0",
 				"@aws-sdk/util-defaults-mode-browser": "3.234.0",
 				"@aws-sdk/util-defaults-mode-node": "3.234.0",
-				"@aws-sdk/util-endpoints": "3.226.0",
+				"@aws-sdk/util-endpoints": "3.241.0",
 				"@aws-sdk/util-retry": "3.229.0",
 				"@aws-sdk/util-user-agent-browser": "3.226.0",
 				"@aws-sdk/util-user-agent-node": "3.226.0",
@@ -484,14 +484,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.238.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.238.0.tgz",
-			"integrity": "sha512-WmPNtIYyUasjV7VQxvPNq7ihmx0vFsiKAtjNjjakdrt5TPoma4nUYb9tIG9SuG+kcp4DJIgRLJAgZtXbCcVimg==",
+			"version": "3.241.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
+			"integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
 			"dependencies": {
 				"@aws-sdk/credential-provider-env": "3.226.0",
 				"@aws-sdk/credential-provider-imds": "3.226.0",
 				"@aws-sdk/credential-provider-process": "3.226.0",
-				"@aws-sdk/credential-provider-sso": "3.238.0",
+				"@aws-sdk/credential-provider-sso": "3.241.0",
 				"@aws-sdk/credential-provider-web-identity": "3.226.0",
 				"@aws-sdk/property-provider": "3.226.0",
 				"@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -503,15 +503,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.238.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.238.0.tgz",
-			"integrity": "sha512-/RN5EyGfgdIIJdFzv+O0nSaHX1/F3anQjTIBeVg8GJ+82m+bDxMdALsG+NzkYnLilN9Uhc1lSNjLBCoPa5DSEg==",
+			"version": "3.241.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
+			"integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
 			"dependencies": {
 				"@aws-sdk/credential-provider-env": "3.226.0",
 				"@aws-sdk/credential-provider-imds": "3.226.0",
-				"@aws-sdk/credential-provider-ini": "3.238.0",
+				"@aws-sdk/credential-provider-ini": "3.241.0",
 				"@aws-sdk/credential-provider-process": "3.226.0",
-				"@aws-sdk/credential-provider-sso": "3.238.0",
+				"@aws-sdk/credential-provider-sso": "3.241.0",
 				"@aws-sdk/credential-provider-web-identity": "3.226.0",
 				"@aws-sdk/property-provider": "3.226.0",
 				"@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -537,14 +537,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.238.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.238.0.tgz",
-			"integrity": "sha512-i70V4bFlCVYey3QARJ6XxKEg/4YuoFRnePV2oK37UHOGpEn49uXKwVZqLjzJgFHln7BPlC06cWDqrHUQIMvYrQ==",
+			"version": "3.241.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
+			"integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.238.0",
+				"@aws-sdk/client-sso": "3.241.0",
 				"@aws-sdk/property-provider": "3.226.0",
 				"@aws-sdk/shared-ini-file-loader": "3.226.0",
-				"@aws-sdk/token-providers": "3.238.0",
+				"@aws-sdk/token-providers": "3.241.0",
 				"@aws-sdk/types": "3.226.0",
 				"tslib": "^2.3.1"
 			},
@@ -1093,11 +1093,11 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.238.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.238.0.tgz",
-			"integrity": "sha512-vYUwmy0kTzA99mJCVvad+/5RDlWve/xxnppT8DJK3JIdAgskp+rULY+joVnq2NSl489UAioUnFGs57vUxi8Pog==",
+			"version": "3.241.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
+			"integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
 			"dependencies": {
-				"@aws-sdk/client-sso-oidc": "3.238.0",
+				"@aws-sdk/client-sso-oidc": "3.241.0",
 				"@aws-sdk/property-provider": "3.226.0",
 				"@aws-sdk/shared-ini-file-loader": "3.226.0",
 				"@aws-sdk/types": "3.226.0",
@@ -1224,9 +1224,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
-			"integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+			"version": "3.241.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
+			"integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
 			"dependencies": {
 				"@aws-sdk/types": "3.226.0",
 				"tslib": "^2.3.1"
@@ -1870,9 +1870,9 @@
 			}
 		},
 		"node_modules/@types/ws": {
-			"version": "8.5.3",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
-			"integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+			"version": "8.5.4",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
+			"integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"ajv-formats": "2.1.1",
 		"amqplib": "^0.10.3",
 		"bcrypt": "^5.0.1",
-		"body-parser": "^1.20.1",
+		"body-parser": "1.20.1",
 		"cheerio": "^1.0.0-rc.12",
 		"cookie-parser": "^1.4.6",
 		"dotenv": "^16.0.2",

--- a/patches/body-parser+1.20.1.patch
+++ b/patches/body-parser+1.20.1.patch
@@ -1,0 +1,30 @@
+diff --git a/node_modules/body-parser/lib/types/json.js b/node_modules/body-parser/lib/types/json.js
+index c2745be..7104cfa 100644
+--- a/node_modules/body-parser/lib/types/json.js
++++ b/node_modules/body-parser/lib/types/json.js
+@@ -18,6 +18,7 @@ var createError = require('http-errors')
+ var debug = require('debug')('body-parser:json')
+ var read = require('../read')
+ var typeis = require('type-is')
++var JSONbig = require("json-bigint");
+ 
+ /**
+  * Module exports.
+@@ -86,7 +87,7 @@ function json (options) {
+ 
+     try {
+       debug('parse json')
+-      return JSON.parse(body, reviver)
++      return JSONbig.parse(body, reviver)
+     } catch (e) {
+       throw normalizeJsonSyntaxError(e, {
+         message: e.message,
+@@ -157,7 +158,7 @@ function createStrictSyntaxError (str, char) {
+     : ''
+ 
+   try {
+-    JSON.parse(partial); /* istanbul ignore next */ throw new SyntaxError('strict violation')
++    JSONbig.parse(partial); /* istanbul ignore next */ throw new SyntaxError('strict violation')
+   } catch (e) {
+     return normalizeJsonSyntaxError(e, {
+       message: e.message.replace('#', char),

--- a/src/api/routes/users/#id/profile.ts
+++ b/src/api/routes/users/#id/profile.ts
@@ -92,7 +92,9 @@ router.get(
 	const userProfile = {
 		bio: req.user_bot ? null : user.bio,
 		accent_color: user.accent_color,
-		banner: user.banner
+		banner: user.banner,
+		pronouns: user.pronouns,
+		theme_colors: user.theme_colors,
 	};
 
 	const guildMemberDto = guild_member
@@ -126,6 +128,8 @@ router.get(
 		premium_since: user.premium_since, // TODO
 		mutual_guilds: mutual_guilds, // TODO {id: "", nick: null} when ?with_mutual_guilds=true
 		user: userDto,
+		premium_type: user.premium_type,
+		profile_themes_experiment_bucket: 4,	// TODO: This doesn't make it available, for some reason?
 		user_profile: userProfile,
 		guild_member: guild_id && guildMemberDto,
 		guild_member_profile: guild_id && guildMemberProfile
@@ -154,7 +158,9 @@ router.patch("/", route({ body: "UserProfileModifySchema" }), async (req: Reques
 	res.json({
 		accent_color: user.accent_color,
 		bio: user.bio,
-		banner: user.banner
+		banner: user.banner,
+		theme_colors: user.theme_colors,
+		pronouns: user.pronouns,
 	});
 });
 

--- a/src/gateway/opcodes/Identify.ts
+++ b/src/gateway/opcodes/Identify.ts
@@ -198,6 +198,7 @@ export async function onIdentify(this: WebSocket, data: Payload) {
 			bot: related_user.bot,
 			bio: related_user.bio,
 			premium_since: user.premium_since,
+			premium_type: user.premium_type,
 			accent_color: related_user.accent_color,
 		};
 		users.push(public_related_user);

--- a/src/util/config/types/subconfigurations/defaults/UserDefaults.ts
+++ b/src/util/config/types/subconfigurations/defaults/UserDefaults.ts
@@ -1,5 +1,5 @@
 export class UserDefaults {
-    premium: boolean = false;
-    premium_type: number = 2;
+    premium: boolean = true;
+    premiumType: number = 2;
     verified: boolean = true;
 }

--- a/src/util/entities/Member.ts
+++ b/src/util/entities/Member.ts
@@ -125,6 +125,12 @@ export class Member extends BaseClassWithoutId {
 
 	@Column()
 	bio: string;
+	
+	@Column({ nullable: true, type: "simple-array" })
+	theme_colors?: number[];	// TODO: Separate `User` and `UserProfile` models
+
+	@Column({ nullable: true })
+	pronouns?: string;
 
 	@Column({ nullable: true })
 	communication_disabled_until: Date;

--- a/src/util/entities/User.ts
+++ b/src/util/entities/User.ts
@@ -34,6 +34,9 @@ export enum PublicUserEnum {
 	bio,
 	bot,
 	premium_since,
+	premium_type,
+	theme_colors,
+	pronouns,
 }
 export type PublicUserKeys = keyof typeof PublicUserEnum;
 
@@ -87,6 +90,12 @@ export class User extends BaseClass {
 
 	@Column({ nullable: true })
 	banner?: string; // hash of the user banner
+
+	@Column({ nullable: true, type: "simple-array" })
+	theme_colors?: number[];	// TODO: Separate `User` and `UserProfile` models
+
+	@Column({ nullable: true })
+	pronouns?: string;
 
 	@Column({ nullable: true, select: false })
 	phone?: string; // phone number of the user
@@ -351,7 +360,7 @@ export class User extends BaseClass {
 				valid_tokens_since: new Date(),
 			},
 			extended_settings: "{}",
-			premium_type: Config.get().defaults.user.premium_type,
+			premium_type: Config.get().defaults.user.premiumType,
 			premium: Config.get().defaults.user.premium,
 			verified: Config.get().defaults.user.verified,
 			settings: settings,

--- a/src/util/schemas/MemberChangeProfileSchema.ts
+++ b/src/util/schemas/MemberChangeProfileSchema.ts
@@ -2,4 +2,10 @@ export interface MemberChangeProfileSchema {
 	banner?: string | null;
 	nick?: string;
 	bio?: string;
+	pronouns?: string;
+
+	/*
+	* @items.type integer
+	*/
+	theme_colors?: [number, number];
 }

--- a/src/util/schemas/UserProfileModifySchema.ts
+++ b/src/util/schemas/UserProfileModifySchema.ts
@@ -2,4 +2,10 @@ export interface UserProfileModifySchema {
 	bio?: string;
 	accent_color?: number | null;
 	banner?: string | null;
+	pronouns?: string;
+
+	/*
+	* @items.type integer
+	*/
+	theme_colors?: [number, number]
 }


### PR DESCRIPTION
Adds a patch file for body-parser, which replaces usage of `JSON.parse` with [`json-bigint`](https://www.npmjs.com/package/json-bigint), as was done with the gateway and it's usage of `JSON.parse` for incoming messages.
Addresses #696, and would fix mobile client replies, and dsharpplus support as notable examples.

Making this a PR so it's more visible for testers. I'm not very pleased with having to patch body-parser. I also haven't tested this yet with dsharpplus or the mobile client themselves, just through curl mimicking the requests.