### PR TITLE
Add /users/:id/delete

### DIFF
--- a/src/api/routes/users/#id/delete.ts
+++ b/src/api/routes/users/#id/delete.ts
@@ -15,8 +15,7 @@ router.post(
 	"/",
 	route({ right: "MANAGE_USERS" }),
 	async (req: Request, res: Response) => {
-		const body = req.body as UserDeleteSchema;
-
+		
 		let user = await User.findOneOrFail({
 			where: { id: req.params.id },
 			select: [...PrivateUserProjection, "data"],

--- a/src/api/routes/users/#id/delete.ts
+++ b/src/api/routes/users/#id/delete.ts
@@ -35,3 +35,5 @@ router.post(
 		res.sendStatus(204);
 	},
 );
+
+export default router;

--- a/src/api/routes/users/#id/delete.ts
+++ b/src/api/routes/users/#id/delete.ts
@@ -1,0 +1,38 @@
+import { route } from "@fosscord/api";
+import {
+	emitEvent,
+	Member,
+	PrivateUserProjection,
+	User,
+	UserDeleteEvent,
+	UserDeleteSchema,
+} from "@fosscord/util";
+import { Request, Response, Router } from "express";
+
+const router = Router();
+
+router.post(
+	"/",
+	route({ right: "MANAGE_USERS" }),
+	async (req: Request, res: Response) => {
+		const body = req.body as UserDeleteSchema;
+
+		let user = await User.findOneOrFail({
+			where: { id: req.params.id },
+			select: [...PrivateUserProjection, "data"],
+		});
+		await Promise.all([
+			Member.delete({ id: req.params.id }),
+			User.delete({ id: req.params.id }),
+		]);
+
+		// TODO: respect intents as USER_DELETE has potential to cause privacy issues
+		await emitEvent({
+			event: "USER_DELETE",
+			user_id: req.user_id,
+			data: { user_id: req.params.id },
+		} as UserDeleteEvent);
+
+		res.sendStatus(204);
+	},
+);

--- a/src/util/interfaces/Event.ts
+++ b/src/util/interfaces/Event.ts
@@ -393,6 +393,13 @@ export interface UserUpdateEvent extends Event {
 	data: User;
 }
 
+export interface UserDeleteEvent extends Event {
+	event: "USER_DELETE";
+	data: {
+		user_id: string;
+	};
+}
+
 export interface VoiceStateUpdateEvent extends Event {
 	event: "VOICE_STATE_UPDATE";
 	data: VoiceState & {
@@ -533,6 +540,7 @@ export type EventData =
 	| PresenceUpdateEvent
 	| TypingStartEvent
 	| UserUpdateEvent
+	| UserDeleteEvent
 	| VoiceStateUpdateEvent
 	| VoiceServerUpdateEvent
 	| WebhooksUpdateEvent
@@ -583,6 +591,7 @@ export enum EVENTEnum {
 	PresenceUpdate = "PRESENCE_UPDATE",
 	TypingStart = "TYPING_START",
 	UserUpdate = "USER_UPDATE",
+	UserDelete = "USER_DELETE",
 	WebhooksUpdate = "WEBHOOKS_UPDATE",
 	InteractionCreate = "INTERACTION_CREATE",
 	VoiceStateUpdate = "VOICE_STATE_UPDATE",
@@ -633,6 +642,7 @@ export type EVENT =
 	| "PRESENCE_UPDATE"
 	| "TYPING_START"
 	| "USER_UPDATE"
+	| "USER_DELETE"
 	| "USER_NOTE_UPDATE"
 	| "WEBHOOKS_UPDATE"
 	| "INTERACTION_CREATE"

--- a/src/util/schemas/UserDeleteSchema.ts
+++ b/src/util/schemas/UserDeleteSchema.ts
@@ -1,0 +1,3 @@
+export interface UserDeleteSchema {
+	user_id: string;
+}

--- a/src/util/schemas/index.ts
+++ b/src/util/schemas/index.ts
@@ -40,6 +40,7 @@ export * from "./TotpDisableSchema";
 export * from "./TotpEnableSchema";
 export * from "./VoiceIdentifySchema";
 export * from "./TotpSchema";
+export * from "./UserDeleteSchema";
 export * from "./UserModifySchema";
 export * from "./UserProfileModifySchema";
 export * from "./UserSettingsSchema";


### PR DESCRIPTION
Allows admins to delete users without needing a direct access to the database.
Signed-off-by: Erkin Alp Güney <erkinalp9035@gmail.com>