### PR TITLE
send GUILD_CREATE after READY event

### DIFF
--- a/src/gateway/opcodes/Identify.ts
+++ b/src/gateway/opcodes/Identify.ts
@@ -141,11 +141,11 @@ export async function onIdentify(this: WebSocket, data: Payload) {
 	}) as PublicMember[][];
 	let guilds = members.map((x) => ({ ...x.guild, joined_at: x.joined_at }));
 
-	const pendingGuilds: typeof guilds = [];
+	const pending_guilds: typeof guilds = [];
 	// @ts-ignore
 	guilds = guilds.map((guild) => {
 		if (user.bot) {
-			pendingGuilds.push(guild);
+			pending_guilds.push(guild);
 			return { id: guild.id, unavailable: true };
 		}
 
@@ -308,7 +308,7 @@ export async function onIdentify(this: WebSocket, data: Payload) {
 	});
 
 	await Promise.all(
-		pendingGuilds.map((guild) =>
+		pending_guilds.map((guild) =>
 			Send(this, {
 				op: OPCODES.Dispatch,
 				t: EVENTEnum.GuildCreate,

--- a/src/gateway/opcodes/Identify.ts
+++ b/src/gateway/opcodes/Identify.ts
@@ -141,18 +141,11 @@ export async function onIdentify(this: WebSocket, data: Payload) {
 	}) as PublicMember[][];
 	let guilds = members.map((x) => ({ ...x.guild, joined_at: x.joined_at }));
 
+	const pendingGuilds: typeof guilds = [];
 	// @ts-ignore
 	guilds = guilds.map((guild) => {
 		if (user.bot) {
-			setTimeout(() => {
-				var promise = Send(this, {
-					op: OPCODES.Dispatch,
-					t: EVENTEnum.GuildCreate,
-					s: this.sequence++,
-					d: guild,
-				});
-				if (promise) promise.catch(console.error);
-			}, 500);
+			pendingGuilds.push(guild);
 			return { id: guild.id, unavailable: true };
 		}
 
@@ -313,6 +306,17 @@ export async function onIdentify(this: WebSocket, data: Payload) {
 		s: this.sequence++,
 		d,
 	});
+
+	await Promise.all(
+		pendingGuilds.map((guild) =>
+			Send(this, {
+				op: OPCODES.Dispatch,
+				t: EVENTEnum.GuildCreate,
+				s: this.sequence++,
+				d: guild,
+			})?.catch(console.error),
+		),
+	);
 
 	//TODO send READY_SUPPLEMENTAL
 	//TODO send GUILD_MEMBER_LIST_UPDATE


### PR DESCRIPTION
Some frameworks such as oceanic.js expect GUILD_CREATE to be sent after the READY event, and crash otherwise.