### PR TITLE
Fix youtu.be embeds

### DIFF
--- a/src/api/util/utility/EmbedHandlers.ts
+++ b/src/api/util/utility/EmbedHandlers.ts
@@ -423,9 +423,6 @@ export const EmbedHandlers: {
 	"youtu.be": (url: URL) => {
 		return EmbedHandlers["www.youtube.com"](url);
 	},
-	"www.youtu.be": (url: URL) => {
-		return EmbedHandlers["www.youtube.com"](url);
-	},
 	"youtube.com": (url: URL) => {
 		return EmbedHandlers["www.youtube.com"](url);
 	},

--- a/src/api/util/utility/EmbedHandlers.ts
+++ b/src/api/util/utility/EmbedHandlers.ts
@@ -420,7 +420,12 @@ export const EmbedHandlers: {
 			},
 		};
 	},
-
+	"youtu.be": (url: URL) => {
+		return EmbedHandlers["www.youtube.com"](url);
+	},
+	"www.youtu.be": (url: URL) => {
+		return EmbedHandlers["www.youtube.com"](url);
+	},
 	"youtube.com": (url: URL) => {
 		return EmbedHandlers["www.youtube.com"](url);
 	},


### PR DESCRIPTION
In the name, just alias youtu.be (and www.youtu.be, because I can) to the www.youtube.com embed handler