### PR TITLE
Client cacher improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ files/
 assets/cache
 .env
 config.json
+assets/cacheMisses
 
 .vscode/settings.json
 


### PR DESCRIPTION
* Downloads more assets now, using Rory's DCP asset regex. Thanks!
* Can be set to only download js files, using `ONLY_CACHE_JS` env var (TODO: docs)