### PR TITLE
fix: route file regex

### DIFF
--- a/src/util/util/TraverseDirectory.ts
+++ b/src/util/util/TraverseDirectory.ts
@@ -22,7 +22,7 @@ import { Server, traverseDirectory } from "lambert-server";
 const extension =
 	Symbol.for("ts-node.register.instance") in process ? "ts" : "js";
 
-const DEFAULT_FILTER = new RegExp("^([^.].*)(?<!.d).(" + extension + ")$");
+const DEFAULT_FILTER = new RegExp("^([^.].*)(?<!\.d).(" + extension + ")$");
 
 export function registerRoutes(server: Server, root: string) {
 	return traverseDirectory(


### PR DESCRIPTION
The current regex for filtering route files ignores any route that ends in a `d`. the intention was to ignore `.d.ts` files but is missing an escaped `.` which this PR fixes.