### PR TITLE
Use erlpack instead of @yukikaze-bot/erlpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"probe-image-size": "^7.2.3",
 				"proxy-agent": "^5.0.0",
 				"reflect-metadata": "^0.1.13",
-				"sqlite3": "^5.1.4",
+				"sqlite3": "*",
 				"ts-node": "^10.9.1",
 				"tslib": "^2.4.1",
 				"typeorm": "^0.3.10",
@@ -78,7 +78,8 @@
 				"typescript": "^4.9.4"
 			},
 			"optionalDependencies": {
-				"erlpack": "^0.1.4"
+				"erlpack": "^0.1.4",
+				"sqlite3": "^5.1.4"
 			}
 		},
 		"node_modules/@acuminous/bitsyntax": {
@@ -5481,7 +5482,8 @@
 		"node_modules/node-addon-api": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-			"integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+			"integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+			"optional": true
 		},
 		"node_modules/node-fetch": {
 			"version": "2.6.7",
@@ -6572,6 +6574,7 @@
 			"resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.4.tgz",
 			"integrity": "sha512-i0UlWAzPlzX3B5XP2cYuhWQJsTtlMD6obOa1PgeEQ4DHEXUuyJkgv50I3isqZAP5oFc2T8OFvakmDh2W6I+YpA==",
 			"hasInstallScript": true,
+			"optional": true,
 			"dependencies": {
 				"@mapbox/node-pre-gyp": "^1.0.0",
 				"node-addon-api": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
 				"cheerio": "^1.0.0-rc.12",
 				"cookie-parser": "^1.4.6",
 				"dotenv": "^16.0.2",
-				"erlpack": "^0.1.4",
 				"exif-be-gone": "^1.3.1",
 				"fast-zlib": "^2.0.1",
 				"file-type": "16.5",
@@ -77,6 +76,9 @@
 				"prettier": "^2.7.1",
 				"pretty-quick": "^3.1.3",
 				"typescript": "^4.9.4"
+			},
+			"optionalDependencies": {
+				"erlpack": "^0.1.4"
 			}
 		},
 		"node_modules/@acuminous/bitsyntax": {
@@ -2571,6 +2573,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
 			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"optional": true,
 			"dependencies": {
 				"file-uri-to-path": "1.0.0"
 			}
@@ -2578,7 +2581,8 @@
 		"node_modules/bindings/node_modules/file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"optional": true
 		},
 		"node_modules/body-parser": {
 			"version": "1.20.1",
@@ -3410,6 +3414,7 @@
 			"resolved": "https://registry.npmjs.org/erlpack/-/erlpack-0.1.4.tgz",
 			"integrity": "sha512-CJYbkEvsB5FqCCu2tLxF1eYKi28PvemC12oqzJ9oO6mDFrFO9G9G7nNJUHhiAyyL9zfXTOJx/tOcrQk+ncD65w==",
 			"hasInstallScript": true,
+			"optional": true,
 			"dependencies": {
 				"bindings": "^1.5.0",
 				"nan": "^2.15.0"
@@ -5407,7 +5412,8 @@
 		"node_modules/nan": {
 			"version": "2.17.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-			"integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+			"integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+			"optional": true
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"cheerio": "^1.0.0-rc.12",
 				"cookie-parser": "^1.4.6",
 				"dotenv": "^16.0.2",
+				"erlpack": "^0.1.4",
 				"exif-be-gone": "^1.3.1",
 				"fast-zlib": "^2.0.1",
 				"file-type": "16.5",
@@ -76,9 +77,6 @@
 				"prettier": "^2.7.1",
 				"pretty-quick": "^3.1.3",
 				"typescript": "^4.9.4"
-			},
-			"optionalDependencies": {
-				"@yukikaze-bot/erlpack": "^1.0.1"
 			}
 		},
 		"node_modules/@acuminous/bitsyntax": {
@@ -2213,17 +2211,6 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@yukikaze-bot/erlpack": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@yukikaze-bot/erlpack/-/erlpack-1.0.1.tgz",
-			"integrity": "sha512-PCJ2lGCf8DsQtrE411PY+NTsolK48l4InNn1kcBo0iUllKZYGLqeqXEWGA/INrmwanKcoYkU4pBySqUFLQDEoA==",
-			"hasInstallScript": true,
-			"optional": true,
-			"dependencies": {
-				"@mapbox/node-pre-gyp": "^1.0.5",
-				"node-addon-api": "^4.0.0"
-			}
-		},
 		"node_modules/abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -2579,6 +2566,19 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dependencies": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"node_modules/bindings/node_modules/file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"node_modules/body-parser": {
 			"version": "1.20.1",
@@ -3403,6 +3403,16 @@
 			"optional": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/erlpack": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/erlpack/-/erlpack-0.1.4.tgz",
+			"integrity": "sha512-CJYbkEvsB5FqCCu2tLxF1eYKi28PvemC12oqzJ9oO6mDFrFO9G9G7nNJUHhiAyyL9zfXTOJx/tOcrQk+ncD65w==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"bindings": "^1.5.0",
+				"nan": "^2.15.0"
 			}
 		},
 		"node_modules/err-code": {
@@ -5393,6 +5403,11 @@
 				"object-assign": "^4.0.1",
 				"thenify-all": "^1.0.0"
 			}
+		},
+		"node_modules/nan": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+			"integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
 		"cheerio": "^1.0.0-rc.12",
 		"cookie-parser": "^1.4.6",
 		"dotenv": "^16.0.2",
+		"erlpack": "^0.1.4",
 		"exif-be-gone": "^1.3.1",
 		"fast-zlib": "^2.0.1",
 		"file-type": "16.5",
@@ -104,9 +105,6 @@
 		"typeorm": "^0.3.10",
 		"typescript-json-schema": "^0.50.1",
 		"ws": "^8.9.0"
-	},
-	"optionalDependencies": {
-		"@yukikaze-bot/erlpack": "^1.0.1"
 	},
 	"_moduleAliases": {
 		"@fosscord/api": "dist/api",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
 		"cheerio": "^1.0.0-rc.12",
 		"cookie-parser": "^1.4.6",
 		"dotenv": "^16.0.2",
-		"erlpack": "^0.1.4",
 		"exif-be-gone": "^1.3.1",
 		"fast-zlib": "^2.0.1",
 		"file-type": "16.5",
@@ -111,5 +110,8 @@
 		"@fosscord/cdn": "dist/cdn",
 		"@fosscord/gateway": "dist/gateway",
 		"@fosscord/util": "dist/util"
+	},
+	"optionalDependencies": {
+		"erlpack": "^0.1.4"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
 		"probe-image-size": "^7.2.3",
 		"proxy-agent": "^5.0.0",
 		"reflect-metadata": "^0.1.13",
-		"sqlite3": "^5.1.4",
 		"ts-node": "^10.9.1",
 		"tslib": "^2.4.1",
 		"typeorm": "^0.3.10",
@@ -112,6 +111,7 @@
 		"@fosscord/util": "dist/util"
 	},
 	"optionalDependencies": {
-		"erlpack": "^0.1.4"
+		"erlpack": "^0.1.4",
+		"sqlite3": "^5.1.4"
 	}
 }

--- a/src/gateway/events/Connection.ts
+++ b/src/gateway/events/Connection.ts
@@ -28,12 +28,7 @@ import { Message } from "./Message";
 import { Deflate, Inflate } from "fast-zlib";
 import { URL } from "url";
 import { Config } from "@fosscord/util";
-let erlpack: unknown;
-try {
-	erlpack = require("@yukikaze-bot/erlpack");
-} catch (error) {
-	/* empty */
-}
+import erlpack from "erlpack";
 
 // TODO: check rate limit
 // TODO: specify rate limit in config
@@ -86,9 +81,7 @@ export async function Connection(
 		socket.encoding = searchParams.get("encoding") || "json";
 		if (!["json", "etf"].includes(socket.encoding)) {
 			if (socket.encoding === "etf" && erlpack) {
-				throw new Error(
-					"Erlpack is not installed: 'npm i @yukikaze-bot/erlpack'",
-				);
+				throw new Error("Erlpack is not installed: 'npm i erlpack'");
 			}
 			return socket.close(CLOSECODES.Decode_error);
 		}

--- a/src/gateway/events/Connection.ts
+++ b/src/gateway/events/Connection.ts
@@ -27,12 +27,11 @@ import { Close } from "./Close";
 import { Message } from "./Message";
 import { Deflate, Inflate } from "fast-zlib";
 import { URL } from "url";
-import { Config } from "@fosscord/util";
+import { Config, ErlpackType } from "@fosscord/util";
 
-import type ErlpackType from "erlpack";
-let erlpack: typeof ErlpackType | null = null;
+let erlpack: ErlpackType | null = null;
 try {
-	erlpack = require("erlpack") as typeof ErlpackType;
+	erlpack = require("erlpack") as ErlpackType;
 } catch (e) {
 	// empty
 }

--- a/src/gateway/events/Connection.ts
+++ b/src/gateway/events/Connection.ts
@@ -28,7 +28,14 @@ import { Message } from "./Message";
 import { Deflate, Inflate } from "fast-zlib";
 import { URL } from "url";
 import { Config } from "@fosscord/util";
-import erlpack from "erlpack";
+
+import type ErlpackType from "erlpack";
+let erlpack: typeof ErlpackType | null = null;
+try {
+	erlpack = require("erlpack") as typeof ErlpackType;
+} catch (e) {
+	// empty
+}
 
 // TODO: check rate limit
 // TODO: specify rate limit in config
@@ -79,12 +86,11 @@ export async function Connection(
 		const { searchParams } = new URL(`http://localhost${request.url}`);
 		// @ts-ignore
 		socket.encoding = searchParams.get("encoding") || "json";
-		if (!["json", "etf"].includes(socket.encoding)) {
-			if (socket.encoding === "etf" && erlpack) {
-				throw new Error("Erlpack is not installed: 'npm i erlpack'");
-			}
+		if (!["json", "etf"].includes(socket.encoding))
 			return socket.close(CLOSECODES.Decode_error);
-		}
+
+		if (socket.encoding === "etf" && erlpack)
+			throw new Error("Erlpack is not installed: 'npm i erlpack'");
 
 		socket.version = Number(searchParams.get("version")) || 8;
 		if (socket.version != 8)

--- a/src/gateway/events/Message.ts
+++ b/src/gateway/events/Message.ts
@@ -24,15 +24,9 @@ import { PayloadSchema } from "@fosscord/util";
 import * as Sentry from "@sentry/node";
 import BigIntJson from "json-bigint";
 import path from "path";
+import erlpack from "erlpack";
 import fs from "fs/promises";
 const bigIntJson = BigIntJson({ storeAsString: true });
-
-let erlpack: { unpack: (buffer: Buffer) => Payload };
-try {
-	erlpack = require("@yukikaze-bot/erlpack");
-} catch (error) {
-	/* empty */
-}
 
 export async function Message(this: WebSocket, buffer: WS.Data) {
 	// TODO: compression

--- a/src/gateway/events/Message.ts
+++ b/src/gateway/events/Message.ts
@@ -24,9 +24,16 @@ import { PayloadSchema } from "@fosscord/util";
 import * as Sentry from "@sentry/node";
 import BigIntJson from "json-bigint";
 import path from "path";
-import erlpack from "erlpack";
 import fs from "fs/promises";
 const bigIntJson = BigIntJson({ storeAsString: true });
+
+import type ErlpackType from "erlpack";
+let erlpack: typeof ErlpackType | null = null;
+try {
+	erlpack = require("erlpack") as typeof ErlpackType;
+} catch (e) {
+	// empty
+}
 
 export async function Message(this: WebSocket, buffer: WS.Data) {
 	// TODO: compression
@@ -46,7 +53,7 @@ export async function Message(this: WebSocket, buffer: WS.Data) {
 			}
 		}
 		data = bigIntJson.parse(buffer as string);
-	} else if (this.encoding === "etf" && buffer instanceof Buffer) {
+	} else if (this.encoding === "etf" && buffer instanceof Buffer && erlpack) {
 		try {
 			data = erlpack.unpack(buffer);
 		} catch {

--- a/src/gateway/events/Message.ts
+++ b/src/gateway/events/Message.ts
@@ -20,17 +20,16 @@ import { WebSocket, Payload, CLOSECODES, OPCODES } from "@fosscord/gateway";
 import OPCodeHandlers from "../opcodes";
 import { check } from "../opcodes/instanceOf";
 import WS from "ws";
-import { PayloadSchema } from "@fosscord/util";
+import { PayloadSchema, ErlpackType } from "@fosscord/util";
 import * as Sentry from "@sentry/node";
 import BigIntJson from "json-bigint";
 import path from "path";
 import fs from "fs/promises";
 const bigIntJson = BigIntJson({ storeAsString: true });
 
-import type ErlpackType from "erlpack";
-let erlpack: typeof ErlpackType | null = null;
+let erlpack: ErlpackType | null = null;
 try {
-	erlpack = require("erlpack") as typeof ErlpackType;
+	erlpack = require("erlpack") as ErlpackType;
 } catch (e) {
 	// empty
 }

--- a/src/gateway/util/Send.ts
+++ b/src/gateway/util/Send.ts
@@ -16,14 +16,7 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-let erlpack: { pack: (data: Payload) => Buffer };
-try {
-	erlpack = require("@yukikaze-bot/erlpack");
-} catch (error) {
-	console.log(
-		"Missing @yukikaze-bot/erlpack, electron-based desktop clients designed for discord.com will not be able to connect!",
-	);
-}
+import erlpack from "erlpack";
 import { Payload, WebSocket } from "@fosscord/gateway";
 import fs from "fs/promises";
 import path from "path";

--- a/src/gateway/util/Send.ts
+++ b/src/gateway/util/Send.ts
@@ -16,10 +16,17 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import erlpack from "erlpack";
 import { Payload, WebSocket } from "@fosscord/gateway";
 import fs from "fs/promises";
 import path from "path";
+
+import type ErlpackType from "erlpack";
+let erlpack: typeof ErlpackType | null = null;
+try {
+	erlpack = require("erlpack") as typeof ErlpackType;
+} catch (e) {
+	// empty
+}
 
 export function Send(socket: WebSocket, data: Payload) {
 	if (process.env.WS_VERBOSE)
@@ -40,7 +47,7 @@ export function Send(socket: WebSocket, data: Payload) {
 	}
 
 	let buffer: Buffer | string;
-	if (socket.encoding === "etf") buffer = erlpack.pack(data);
+	if (socket.encoding === "etf" && erlpack) buffer = erlpack.pack(data);
 	// TODO: encode circular object
 	else if (socket.encoding === "json") buffer = JSON.stringify(data);
 	else return;

--- a/src/gateway/util/Send.ts
+++ b/src/gateway/util/Send.ts
@@ -20,10 +20,10 @@ import { Payload, WebSocket } from "@fosscord/gateway";
 import fs from "fs/promises";
 import path from "path";
 
-import type ErlpackType from "erlpack";
-let erlpack: typeof ErlpackType | null = null;
+import type { ErlpackType } from "@fosscord/util";
+let erlpack: ErlpackType | null = null;
 try {
-	erlpack = require("erlpack") as typeof ErlpackType;
+	erlpack = require("erlpack") as ErlpackType;
 } catch (e) {
 	// empty
 }

--- a/src/util/imports/Erlpack.ts
+++ b/src/util/imports/Erlpack.ts
@@ -1,0 +1,12 @@
+/*
+	https://github.com/discord/erlpack/blob/master/js/index.d.ts
+	MIT License
+	Copyright (c) 2017 Discord
+*/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// @fc-license-skip
+
+export type ErlpackType = {
+	pack: (data: any) => Buffer;
+	unpack: <T = any>(data: Buffer) => T;
+};

--- a/src/util/imports/index.ts
+++ b/src/util/imports/index.ts
@@ -17,3 +17,4 @@
 */
 
 export * from "./OrmUtils";
+export * from "./Erlpack";

--- a/src/webrtc/events/Connection.ts
+++ b/src/webrtc/events/Connection.ts
@@ -23,7 +23,6 @@ import WS from "ws";
 import { VoiceOPCodes } from "../util";
 import { onClose } from "./Close";
 import { onMessage } from "./Message";
-import erlpack from "erlpack";
 
 // TODO: check rate limit
 // TODO: specify rate limit in config

--- a/src/webrtc/events/Connection.ts
+++ b/src/webrtc/events/Connection.ts
@@ -23,10 +23,7 @@ import WS from "ws";
 import { VoiceOPCodes } from "../util";
 import { onClose } from "./Close";
 import { onMessage } from "./Message";
-var erlpack: any;
-try {
-	erlpack = require("@yukikaze-bot/erlpack");
-} catch (error) {}
+import erlpack from "erlpack";
 
 // TODO: check rate limit
 // TODO: specify rate limit in config


### PR DESCRIPTION
I have a feeling the only reason why `@yukikaze-bot/erlpack` was used is because it isn't written by Discord, which is dumb.

This PR changes the dep and makes `erlpack` non-optional. If we want optional imports, we should have some util to do it better than a bad try catch statement. Although I don't think erlpack should've ever been optional.

I've used the `erlpack` package in other projects and it works fine, and has the same exports. I did test this briefly though and it worked fine.