### PR TITLE
Impl member lazy request

### DIFF
--- a/src/util/schemas/LazyRequestSchema.ts
+++ b/src/util/schemas/LazyRequestSchema.ts
@@ -22,7 +22,7 @@ export interface LazyRequestSchema {
 	activities?: boolean;
 	threads?: boolean;
 	typing?: true;
-	members?: unknown[];
+	members?: string[];
 	thread_member_lists?: unknown[];
 }
 
@@ -32,6 +32,6 @@ export const LazyRequestSchema = {
 	$channels: Object,
 	$typing: Boolean,
 	$threads: Boolean,
-	$members: [] as unknown[],
+	$members: [] as string[],
 	$thread_member_lists: [] as unknown[],
 };


### PR DESCRIPTION
Newer client versions send a `members` prop to lazy request, sometimes with no other props, in order to request PRESENCE_UPDATE for those members. Currently we just crash the socket