### PR TITLE
fix totp using wrong settings key

### DIFF
--- a/src/api/routes/auth/mfa/totp.ts
+++ b/src/api/routes/auth/mfa/totp.ts
@@ -63,7 +63,7 @@ router.post(
 
 		return res.json({
 			token: await generateToken(user.id),
-			user_settings: user.settings,
+			settings: { ...user.settings, index: undefined },
 		});
 	},
 );


### PR DESCRIPTION
Login route returns `{token, settings}` while the TOTP route returns `{token, user_settings}`. Discord uses `settings` so I've updated the TOTP route to follow Login.