### PR TITLE
properly track reactions

### DIFF
--- a/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
+++ b/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
@@ -248,7 +248,8 @@ router.delete(
 		already_added.count--;
 
 		if (already_added.count <= 0) message.reactions.remove(already_added);
-		else already_added.user_ids.splice(already_added.user_ids.indexOf(user_id), 1);
+		else
+			already_added.user_ids.splice(already_added.user_ids.indexOf(user_id), 1);
 
 		await message.save();
 

--- a/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
+++ b/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
@@ -180,6 +180,7 @@ router.put(
 			if (already_added.user_ids.includes(req.user_id))
 				return res.sendStatus(204); // Do not throw an error ¯\_(ツ)_/¯ as discord also doesn't throw any error
 			already_added.count++;
+			already_added.user_ids.push(req.user_id);
 		} else
 			message.reactions.push({
 				count: 1,
@@ -247,6 +248,7 @@ router.delete(
 		already_added.count--;
 
 		if (already_added.count <= 0) message.reactions.remove(already_added);
+		else already_added.user_ids.splice(already_added.user_ids.indexOf(user_id), 1);
 
 		await message.save();
 

--- a/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
+++ b/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
@@ -28,6 +28,7 @@ import {
 	MessageReactionRemoveEmojiEvent,
 	MessageReactionRemoveEvent,
 	PartialEmoji,
+	PublicMemberProjection,
 	PublicUserProjection,
 	User,
 } from "@spacebar/util";
@@ -192,7 +193,12 @@ router.put(
 
 		const member =
 			channel.guild_id &&
-			(await Member.findOneOrFail({ where: { id: req.user_id } }));
+			(
+				await Member.findOneOrFail({
+					where: { id: req.user_id },
+					select: PublicMemberProjection,
+				})
+			).toPublicMember();
 
 		await emitEvent({
 			event: "MESSAGE_REACTION_ADD",
@@ -249,7 +255,10 @@ router.delete(
 
 		if (already_added.count <= 0) message.reactions.remove(already_added);
 		else
-			already_added.user_ids.splice(already_added.user_ids.indexOf(user_id), 1);
+			already_added.user_ids.splice(
+				already_added.user_ids.indexOf(user_id),
+				1,
+			);
 
 		await message.save();
 

--- a/src/util/entities/Member.ts
+++ b/src/util/entities/Member.ts
@@ -440,6 +440,15 @@ export class Member extends BaseClassWithoutId {
 			]);
 		}
 	}
+
+	toPublicMember() {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const member: any = {};
+		PublicMemberProjection.forEach((x) => {
+			member[x] = this[x];
+		});
+		return member as PublicMember;
+	}
 }
 
 export interface ChannelOverride {


### PR DESCRIPTION
This PR makes it so that reactions track all user ids, making it possible for users to remove their own reactions and admins to remove other users' reactions one-by-one. Previously, only the user id of the first user to react with that emoji to that message was tracked, so only the first user to react was able to remove their own reaction or have their reaction removed. Before this change, a user could react an infinite amount of times on the same message as long as another user had already reacted with that emoji and get the reaction count arbitrarily high.