### PR TITLE
Send guild name and icon of guild through Identify gateway opcode

### DIFF
--- a/src/gateway/opcodes/Identify.ts
+++ b/src/gateway/opcodes/Identify.ts
@@ -295,6 +295,8 @@ export async function onIdentify(this: WebSocket, data: Payload) {
 				...new ReadyGuildDTO(x).toJSON(),
 				guild_hashes: {},
 				joined_at: x.joined_at,
+				name: x.name,
+				icon: x.icon,
 			};
 		}),
 		guild_experiments: [], // TODO


### PR DESCRIPTION
These properties are mandatory as per the documentation: https://discord.com/developers/docs/resources/guild#guild-object