### PR TITLE
Add support for Discord's new endpoints to update roles

### DIFF
--- a/src/api/routes/guilds/#guild_id/roles/#role_id/member-ids.ts
+++ b/src/api/routes/guilds/#guild_id/roles/#role_id/member-ids.ts
@@ -23,16 +23,18 @@ import { route } from "@spacebar/api";
 const router = Router();
 
 router.get("/", route({}), async (req: Request, res: Response) => {
-    const { guild_id, role_id } = req.params;
-    await Member.IsInGuildOrFail(req.user_id, guild_id);
-    const members = await Member.find({
-        select: ["id"],
-        relations: ["roles"],
-    });
-    const member_ids = members.filter((member) => {
-        return member.roles.map((role) => role.id).includes(role_id);
-    }).map((member) => member.id);
-    return res.json(member_ids);
+	const { guild_id, role_id } = req.params;
+	await Member.IsInGuildOrFail(req.user_id, guild_id);
+	const members = await Member.find({
+		select: ["id"],
+		relations: ["roles"],
+	});
+	const member_ids = members
+		.filter((member) => {
+			return member.roles.map((role) => role.id).includes(role_id);
+		})
+		.map((member) => member.id);
+	return res.json(member_ids);
 });
 
 export default router;

--- a/src/api/routes/guilds/#guild_id/roles/#role_id/member-ids.ts
+++ b/src/api/routes/guilds/#guild_id/roles/#role_id/member-ids.ts
@@ -24,17 +24,19 @@ const router = Router();
 
 router.get("/", route({}), async (req: Request, res: Response) => {
 	const { guild_id, role_id } = req.params;
-	await Member.IsInGuildOrFail(req.user_id, guild_id);
+
+	// TODO: Is this route really not paginated?
 	const members = await Member.find({
 		select: ["id"],
-		relations: ["roles"],
+		where: {
+			roles: {
+				id: role_id,
+			},
+			guild_id,
+		},
 	});
-	const member_ids = members
-		.filter((member) => {
-			return member.roles.map((role) => role.id).includes(role_id);
-		})
-		.map((member) => member.id);
-	return res.json(member_ids);
+
+	return res.json(members.map((x) => x.id));
 });
 
 export default router;

--- a/src/api/routes/guilds/#guild_id/roles/#role_id/member-ids.ts
+++ b/src/api/routes/guilds/#guild_id/roles/#role_id/member-ids.ts
@@ -1,0 +1,38 @@
+/*
+	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
+	Copyright (C) 2023 Spacebar and Spacebar Contributors
+	
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+	
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Router, Request, Response } from "express";
+import { Member } from "@spacebar/util";
+import { route } from "@spacebar/api";
+
+const router = Router();
+
+router.get("/", route({}), async (req: Request, res: Response) => {
+    const { guild_id, role_id } = req.params;
+    await Member.IsInGuildOrFail(req.user_id, guild_id);
+    const members = await Member.find({
+        select: ["id"],
+        relations: ["roles"],
+    });
+    const member_ids = members.filter((member) => {
+        return member.roles.map((role) => role.id).includes(role_id);
+    }).map((member) => member.id);
+    return res.json(member_ids);
+});
+
+export default router;

--- a/src/api/routes/guilds/#guild_id/roles/#role_id/members.ts
+++ b/src/api/routes/guilds/#guild_id/roles/#role_id/members.ts
@@ -23,31 +23,37 @@ import { route } from "@spacebar/api";
 const router = Router();
 
 router.patch(
-    "/",
-    route({ permission: "MANAGE_ROLES" }),
-    async (req: Request, res: Response) => {
-        // Payload is JSON containing a list of member_ids, the new list of members to have the role
-        const { guild_id, role_id } = req.params;
-        const { member_ids } = req.body;
-        await Member.IsInGuildOrFail(req.user_id, guild_id);
-        const members = await Member.find({
-            where: { guild_id },
-            relations: ["roles"],
-        });
-        const members_to_add = members.filter((member) => {
-            return member_ids.includes(member.id) && !member.roles.map((role) => role.id).includes(role_id);
-        });
-        const members_to_remove = members.filter((member) => {
-            return !member_ids.includes(member.id) && member.roles.map((role) => role.id).includes(role_id);
-        });
-        for (const member of members_to_add) {
-            Member.addRole(member.id, guild_id, role_id);
-        }
-        for (const member of members_to_remove) {
-            Member.removeRole(member.id, guild_id, role_id);
-        }
-        res.sendStatus(204);
-    }
+	"/",
+	route({ permission: "MANAGE_ROLES" }),
+	async (req: Request, res: Response) => {
+		// Payload is JSON containing a list of member_ids, the new list of members to have the role
+		const { guild_id, role_id } = req.params;
+		const { member_ids } = req.body;
+		await Member.IsInGuildOrFail(req.user_id, guild_id);
+		const members = await Member.find({
+			where: { guild_id },
+			relations: ["roles"],
+		});
+		const members_to_add = members.filter((member) => {
+			return (
+				member_ids.includes(member.id) &&
+				!member.roles.map((role) => role.id).includes(role_id)
+			);
+		});
+		const members_to_remove = members.filter((member) => {
+			return (
+				!member_ids.includes(member.id) &&
+				member.roles.map((role) => role.id).includes(role_id)
+			);
+		});
+		for (const member of members_to_add) {
+			Member.addRole(member.id, guild_id, role_id);
+		}
+		for (const member of members_to_remove) {
+			Member.removeRole(member.id, guild_id, role_id);
+		}
+		res.sendStatus(204);
+	},
 );
 
 export default router;

--- a/src/api/routes/guilds/#guild_id/roles/#role_id/members.ts
+++ b/src/api/routes/guilds/#guild_id/roles/#role_id/members.ts
@@ -46,7 +46,7 @@ router.patch(
         for (const member of members_to_remove) {
             Member.removeRole(member.id, guild_id, role_id);
         }
-		res.sendStatus(204);
+        res.sendStatus(204);
     }
 );
 

--- a/src/api/routes/guilds/#guild_id/roles/#role_id/members.ts
+++ b/src/api/routes/guilds/#guild_id/roles/#role_id/members.ts
@@ -1,0 +1,53 @@
+/*
+	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
+	Copyright (C) 2023 Spacebar and Spacebar Contributors
+	
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+	
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Router, Request, Response } from "express";
+import { Member } from "@spacebar/util";
+import { route } from "@spacebar/api";
+
+const router = Router();
+
+router.patch(
+    "/",
+    route({ permission: "MANAGE_ROLES" }),
+    async (req: Request, res: Response) => {
+        // Payload is JSON containing a list of member_ids, the new list of members to have the role
+        const { guild_id, role_id } = req.params;
+        const { member_ids } = req.body;
+        await Member.IsInGuildOrFail(req.user_id, guild_id);
+        const members = await Member.find({
+            where: { guild_id },
+            relations: ["roles"],
+        });
+        const members_to_add = members.filter((member) => {
+            return member_ids.includes(member.id) && !member.roles.map((role) => role.id).includes(role_id);
+        });
+        const members_to_remove = members.filter((member) => {
+            return !member_ids.includes(member.id) && member.roles.map((role) => role.id).includes(role_id);
+        });
+        for (const member of members_to_add) {
+            Member.addRole(member.id, guild_id, role_id);
+        }
+        for (const member of members_to_remove) {
+            Member.removeRole(member.id, guild_id, role_id);
+        }
+		res.sendStatus(204);
+    }
+);
+
+export default router;

--- a/src/api/routes/guilds/#guild_id/roles/#role_id/members.ts
+++ b/src/api/routes/guilds/#guild_id/roles/#role_id/members.ts
@@ -42,6 +42,7 @@ router.patch(
 				!member.roles.map((role) => role.id).includes(role_id),
 		);
 
+		// TODO (erkin): have a bulk add/remove function that adds the roles in a single txn
 		await Promise.all([
 			...add.map((member) =>
 				Member.addRole(member.id, guild_id, role_id),

--- a/src/api/routes/guilds/#guild_id/roles/#role_id/members.ts
+++ b/src/api/routes/guilds/#guild_id/roles/#role_id/members.ts
@@ -29,11 +29,12 @@ router.patch(
 		// Payload is JSON containing a list of member_ids, the new list of members to have the role
 		const { guild_id, role_id } = req.params;
 		const { member_ids } = req.body;
-		await Member.IsInGuildOrFail(req.user_id, guild_id);
+
 		const members = await Member.find({
 			where: { guild_id },
 			relations: ["roles"],
 		});
+
 		const members_to_add = members.filter((member) => {
 			return (
 				member_ids.includes(member.id) &&
@@ -46,12 +47,15 @@ router.patch(
 				member.roles.map((role) => role.id).includes(role_id)
 			);
 		});
+
 		for (const member of members_to_add) {
-			Member.addRole(member.id, guild_id, role_id);
+			await Member.addRole(member.id, guild_id, role_id);
 		}
+
 		for (const member of members_to_remove) {
-			Member.removeRole(member.id, guild_id, role_id);
+			await Member.removeRole(member.id, guild_id, role_id);
 		}
+
 		res.sendStatus(204);
 	},
 );

--- a/src/api/routes/guilds/#guild_id/roles/member-counts.ts
+++ b/src/api/routes/guilds/#guild_id/roles/member-counts.ts
@@ -1,0 +1,39 @@
+/*
+	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
+	Copyright (C) 2023 Spacebar and Spacebar Contributors
+	
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+	
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Request, Response, Router } from "express";
+import { Role, Member } from "@spacebar/util";
+import { route } from "@spacebar/api";
+import {} from "typeorm";
+
+const router: Router = Router();
+
+router.get("/", route({}), async (req: Request, res: Response) => {
+	const { guild_id } = req.params;
+	await Member.IsInGuildOrFail(req.user_id, guild_id);
+
+	const role_ids = await Role.find({ where: { guild_id }, select: ["id"] });
+	const counts: { [id: string]: number } = {};
+	for (const { id } of role_ids) {
+		counts[id] = await Member.count({ where: { roles: { id }, guild_id } });
+	}
+
+	return res.json(counts);
+});
+
+export default router;

--- a/src/gateway/opcodes/LazyRequest.ts
+++ b/src/gateway/opcodes/LazyRequest.ts
@@ -26,6 +26,7 @@ import {
 	LazyRequestSchema,
 	User,
 	Presence,
+	partition,
 } from "@spacebar/util";
 import {
 	WebSocket,
@@ -301,12 +302,4 @@ export async function onLazyRequest(this: WebSocket, { d }: Payload) {
 			groups,
 		},
 	});
-}
-
-/* https://stackoverflow.com/a/50636286 */
-function partition<T>(array: T[], filter: (elem: T) => boolean) {
-	const pass: T[] = [],
-		fail: T[] = [];
-	array.forEach((e) => (filter(e) ? pass : fail).push(e));
-	return [pass, fail];
 }

--- a/src/util/util/Array.ts
+++ b/src/util/util/Array.ts
@@ -21,3 +21,11 @@
 export function containsAll(arr: unknown[], target: unknown[]) {
 	return target.every((v) => arr.includes(v));
 }
+
+/* https://stackoverflow.com/a/50636286 */
+export function partition<T>(array: T[], filter: (elem: T) => boolean) {
+	const pass: T[] = [],
+		fail: T[] = [];
+	array.forEach((e) => (filter(e) ? pass : fail).push(e));
+	return [pass, fail];
+}


### PR DESCRIPTION
Although not officially documented on the API docs, these endpoints were reversed through the menu:

![Screenshot_20230409_123303](https://user-images.githubusercontent.com/59662605/230790701-07b1e83c-2e96-417a-ba70-f05e6b7254d6.png)
