### PR TITLE
Feat: Auto add bot users to new apps

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -5994,6 +5994,9 @@
                     },
                     "suppress": {
                         "type": "boolean"
+                    },
+                    "flags": {
+                        "type": "integer"
                     }
                 },
                 "required": [
@@ -7190,9 +7193,14 @@
                     },
                     "instanceId": {
                         "type": "string"
+                    },
+                    "autoCreateBotUsers": {
+                        "type": "boolean",
+                        "default": false
                     }
                 },
                 "required": [
+                    "autoCreateBotUsers",
                     "correspondenceEmail",
                     "correspondenceUserID",
                     "frontPage",

--- a/src/api/routes/applications/#id/bot/index.ts
+++ b/src/api/routes/applications/#id/bot/index.ts
@@ -22,6 +22,7 @@ import {
 	BotModifySchema,
 	DiscordApiErrors,
 	User,
+	createAppBotUser,
 	generateToken,
 	handleFile,
 } from "@spacebar/util";
@@ -52,23 +53,7 @@ router.post(
 		if (app.owner.id != req.user_id)
 			throw DiscordApiErrors.ACTION_NOT_AUTHORIZED_ON_APPLICATION;
 
-		const user = await User.register({
-			username: app.name,
-			password: undefined,
-			id: app.id,
-			req,
-		});
-
-		user.id = app.id;
-		user.premium_since = new Date();
-		user.bot = true;
-
-		await user.save();
-
-		// flags is NaN here?
-		app.assign({ bot: user, flags: app.flags || 0 });
-
-		await app.save();
+		const user = await createAppBotUser(app, req);
 
 		res.send({
 			token: await generateToken(user.id),

--- a/src/api/routes/applications/index.ts
+++ b/src/api/routes/applications/index.ts
@@ -22,6 +22,7 @@ import {
 	ApplicationCreateSchema,
 	Config,
 	User,
+	createAppBotUser,
 	trimSpecial,
 } from "@spacebar/util";
 import { Request, Response, Router } from "express";
@@ -72,24 +73,8 @@ router.post(
 		// april 14, 2023: discord made bot users be automatically added to all new apps
 		const { autoCreateBotUsers } = Config.get().general;
 		if (autoCreateBotUsers) {
-			const user = await User.register({
-				username: app.name,
-				password: undefined,
-				id: app.id,
-				req,
-			});
-
-			user.id = app.id;
-			user.premium_since = new Date();
-			user.bot = true;
-
-			await user.save();
-
-			// flags is NaN here?
-			app.assign({ bot: user, flags: app.flags || 0 });
-		}
-
-		await app.save();
+			await createAppBotUser(app, req);
+		} else await app.save();
 
 		res.json(app);
 	},

--- a/src/util/config/types/GeneralConfiguration.ts
+++ b/src/util/config/types/GeneralConfiguration.ts
@@ -28,4 +28,5 @@ export class GeneralConfiguration {
 	correspondenceUserID: string | null = null;
 	image: string | null = null;
 	instanceId: string = Snowflake.generate();
+	autoCreateBotUsers: boolean = false;
 }

--- a/src/util/util/Application.ts
+++ b/src/util/util/Application.ts
@@ -1,0 +1,24 @@
+import { Request } from "express";
+import { Application, User } from "../entities";
+
+export async function createAppBotUser(app: Application, req: Request) {
+	const user = await User.register({
+		username: app.name,
+		password: undefined,
+		id: app.id,
+		req,
+	});
+
+	user.id = app.id;
+	user.premium_since = new Date();
+	user.bot = true;
+
+	await user.save();
+
+	// flags is NaN here?
+	app.assign({ bot: user, flags: app.flags || 0 });
+
+	await app.save();
+
+	return user;
+}

--- a/src/util/util/index.ts
+++ b/src/util/util/index.ts
@@ -18,7 +18,6 @@
 
 export * from "./ApiError";
 export * from "./Array";
-export * from "./Application";
 export * from "./BitField";
 //export * from "./Categories";
 export * from "./cdn";
@@ -43,3 +42,4 @@ export * from "./Token";
 export * from "./TraverseDirectory";
 export * from "./WebAuthn";
 export * from "./Gifs";
+export * from "./Application";

--- a/src/util/util/index.ts
+++ b/src/util/util/index.ts
@@ -18,6 +18,7 @@
 
 export * from "./ApiError";
 export * from "./Array";
+export * from "./Application";
 export * from "./BitField";
 //export * from "./Categories";
 export * from "./cdn";


### PR DESCRIPTION
On April 14, 2023, Discord made new apps automatically have a bot user created, this PR adds an option to allow this same behavior to be enabled.

https://canary.discord.com/developers/docs/change-log#bot-users-added-to-all-new-apps