### PR TITLE
fix: don't create new vanity url when there's no ALIASABLE_NAMES flag

### DIFF
--- a/src/api/routes/guilds/#guild_id/vanity-url.ts
+++ b/src/api/routes/guilds/#guild_id/vanity-url.ts
@@ -107,6 +107,12 @@ router.patch(
 			where: { guild_id, type: ChannelType.GUILD_TEXT },
 		});
 
+		if (!guild.features.includes("ALIASABLE_NAMES")) {
+			await Invite.update({ guild_id }, {
+				code: code
+			});
+		}
+
 		await Invite.create({
 			vanity_url: true,
 			code: code,

--- a/src/api/routes/guilds/#guild_id/vanity-url.ts
+++ b/src/api/routes/guilds/#guild_id/vanity-url.ts
@@ -108,9 +108,14 @@ router.patch(
 		});
 
 		if (!guild.features.includes("ALIASABLE_NAMES")) {
-			await Invite.update({ guild_id }, {
-				code: code
-			});
+			await Invite.update(
+				{ guild_id },
+				{
+					code: code,
+				},
+			);
+
+			return res.json({ code });
 		}
 
 		await Invite.create({


### PR DESCRIPTION
`ALIASABLE_NAMES` flag was checked in GET but not PATCH, so multiple vanity URLs were created even if guild didn't have the flag, this PR fixed that