### PR TITLE
Add mobile_network_type to message create schema

### DIFF
--- a/src/util/schemas/MessageCreateSchema.ts
+++ b/src/util/schemas/MessageCreateSchema.ts
@@ -26,6 +26,7 @@ type Attachment = {
 export interface MessageCreateSchema {
 	type?: number;
 	content?: string;
+	mobile_network_type?: string;
 	nonce?: string;
 	channel_id?: string;
 	tts?: boolean;


### PR DESCRIPTION
Apparently discord's latest client sends this while creating a message