### PR TITLE
Fixes for bot libs

### DIFF
--- a/src/api/routes/oauth2/applications/@me.ts
+++ b/src/api/routes/oauth2/applications/@me.ts
@@ -1,0 +1,59 @@
+/*
+	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
+	Copyright (C) 2023 Spacebar and Spacebar Contributors
+	
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+	
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { route } from "@spacebar/api";
+import {
+	Application,
+	DiscordApiErrors,
+	PublicUserProjection,
+} from "@spacebar/util";
+import { Request, Response, Router } from "express";
+
+const router: Router = Router();
+
+router.get(
+	"/",
+	route({
+		responses: {
+			200: {
+				body: "Application",
+			},
+		},
+	}),
+	async (req: Request, res: Response) => {
+		const app = await Application.findOneOrFail({
+			where: { id: req.params.id },
+			relations: ["bot", "owner"],
+			select: {
+				owner: Object.fromEntries(
+					PublicUserProjection.map((x) => [x, true]),
+				),
+			},
+		});
+
+		if (!app.bot) throw DiscordApiErrors.BOT_ONLY_ENDPOINT;
+
+		res.json({
+			...app,
+			owner: app.owner.toPublicUser(),
+			install_params:
+				app.install_params !== null ? app.install_params : undefined,
+		});
+	},
+);
+export default router;

--- a/src/util/dtos/ReadyGuildDTO.ts
+++ b/src/util/dtos/ReadyGuildDTO.ts
@@ -229,7 +229,7 @@ export class ReadyGuildDTO implements IReadyGuildDTO {
 			nsfw: guild.nsfw,
 			safety_alerts_channel_id: null,
 		};
-		this.roles = guild.roles;
+		this.roles = guild.roles.map((x) => x.toJSON());
 		this.stage_instances = [];
 		this.stickers = guild.stickers;
 		this.threads = [];

--- a/src/util/entities/Message.ts
+++ b/src/util/entities/Message.ts
@@ -238,6 +238,7 @@ export class Message extends BaseClass {
 			activity: this.activity ?? undefined,
 			application: this.application ?? undefined,
 			components: this.components ?? undefined,
+			content: this.content ?? "",
 		};
 	}
 }

--- a/src/util/entities/Role.ts
+++ b/src/util/entities/Role.ts
@@ -69,4 +69,11 @@ export class Role extends BaseClass {
 
 	@Column({ default: 0 })
 	flags: number;
+
+	toJSON(): Role {
+		return {
+			...this,
+			tags: this.tags ?? undefined,
+		};
+	}
 }


### PR DESCRIPTION
Various fixes for bot libraries to work correctly without needing to monkey patch them

- Role.tags should not be present if null
- Message.content should always be present, as an empty string if there is no content
- Added `/oauth2/applications/@me` which is used to fetch the applications owner/owners