### PR TITLE
Fix message flags being null

### DIFF
--- a/src/util/entities/Message.ts
+++ b/src/util/entities/Message.ts
@@ -192,8 +192,8 @@ export class Message extends BaseClass {
 		party_id: string;
 	};
 
-	@Column({ nullable: true })
-	flags?: number;
+	@Column({ default: 0 })
+	flags: number;
 
 	@Column({ type: "simple-json", nullable: true })
 	message_reference?: {

--- a/src/util/migration/mariadb/1713116476900-messageFlagsNotNull.ts
+++ b/src/util/migration/mariadb/1713116476900-messageFlagsNotNull.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MessageFlagsNotNull1713116476900 implements MigrationInterface {
+	name = "MessageFlagsNotNull1713116476900";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE `messages` CHANGE flags flags_old integer;",
+		);
+		await queryRunner.query(
+			"ALTER TABLE `messages` ADD flags integer NOT NULL DEFAULT 0;",
+		);
+		await queryRunner.query(
+			"UPDATE `messages` SET flags = IFNULL(flags_old, 0);",
+		);
+		await queryRunner.query(
+			"ALTER TABLE `messages` DROP COLUMN flags_old;",
+		);
+	}
+
+	public async down(): Promise<void> {
+		// dont care
+		throw new Error("Migration down is not implemented.");
+	}
+}

--- a/src/util/migration/mysql/1713116476900-messageFlagsNotNull.ts
+++ b/src/util/migration/mysql/1713116476900-messageFlagsNotNull.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MessageFlagsNotNull1713116476900 implements MigrationInterface {
+	name = "MessageFlagsNotNull1713116476900";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE `messages` CHANGE flags flags_old integer;",
+		);
+		await queryRunner.query(
+			"ALTER TABLE `messages` ADD flags integer NOT NULL DEFAULT 0;",
+		);
+		await queryRunner.query(
+			"UPDATE `messages` SET flags = IFNULL(flags_old, 0);",
+		);
+		await queryRunner.query(
+			"ALTER TABLE `messages` DROP COLUMN flags_old;",
+		);
+	}
+
+	public async down(): Promise<void> {
+		// dont care
+		throw new Error("Migration down is not implemented.");
+	}
+}

--- a/src/util/migration/postgres/1713116476900-messageFlagsNotNull.ts
+++ b/src/util/migration/postgres/1713116476900-messageFlagsNotNull.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MessageFlagsNotNull1713116476900 implements MigrationInterface {
+	name = "MessageFlagsNotNull1713116476900";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE messages RENAME COLUMN flags TO flags_old;",
+		);
+		await queryRunner.query(
+			"ALTER TABLE messages ADD COLUMN flags integer NOT NULL DEFAULT 0;",
+		);
+		await queryRunner.query(
+			"UPDATE messages SET flags = COALESCE(flags_old, 0);",
+		);
+		await queryRunner.query("ALTER TABLE messages DROP COLUMN flags_old;");
+	}
+
+	public async down(): Promise<void> {
+		// dont care
+		throw new Error("Migration down is not implemented.");
+	}
+}


### PR DESCRIPTION
This issue was encountered in existing bot libraries such as discord.js: `RangeError [BitFieldInvalid]: Invalid bitfield flag or number: null.`

I think the migrations are correct, but would like a review first.