### PR TITLE
Ban API compat & Bulk Ban endpoint

### DIFF
--- a/assets/email_templates/new_login_location.html
+++ b/assets/email_templates/new_login_location.html
@@ -73,7 +73,6 @@
 					<a href="{actionUrl}" target="_blank" style="
 								font-size: 15px;
 								border: none;
-								border-radius: 3px;
 								text-decoration: none;
 								color: white;
 								cursor: pointer;

--- a/assets/email_templates/password_reset_request.html
+++ b/assets/email_templates/password_reset_request.html
@@ -65,7 +65,6 @@
 					<a href="{actionUrl}" target="_blank" style="
 								font-size: 15px;
 								border: none;
-								border-radius: 3px;
 								text-decoration: none;
 								color: white;
 								cursor: pointer;

--- a/assets/email_templates/verify_email.html
+++ b/assets/email_templates/verify_email.html
@@ -74,7 +74,6 @@
 							style="
 								font-size: 15px;
 								border: none;
-								border-radius: 3px;
 								text-decoration: none;
 								color: white;
 								cursor: pointer;

--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -61,109 +61,208 @@
                     "read_states"
                 ]
             },
-            "DiagnosticsChannel.Response": {
+            "ConnectedAccountCommonOAuthTokenResponse": {
                 "type": "object",
                 "properties": {
-                    "statusCode": {
-                        "type": "integer"
-                    },
-                    "statusText": {
+                    "access_token": {
                         "type": "string"
                     },
-                    "headers": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "patternProperties": {
-                                "^[0-9]+$": {
-                                    "type": "integer"
-                                }
-                            }
-                        }
+                    "token_type": {
+                        "type": "string"
+                    },
+                    "scope": {
+                        "type": "string"
+                    },
+                    "refresh_token": {
+                        "type": "string"
+                    },
+                    "expires_in": {
+                        "type": "integer"
                     }
                 },
                 "required": [
-                    "headers",
-                    "statusCode",
-                    "statusText"
+                    "access_token",
+                    "scope",
+                    "token_type"
                 ]
             },
-            "Headers": {
+            "ApplicationAuthorizeSchema": {
                 "type": "object",
                 "properties": {
-                    "append": {
-                        "type": "object",
-                        "additionalProperties": false
+                    "authorize": {
+                        "type": "boolean"
                     },
-                    "delete": {
-                        "type": "object",
-                        "additionalProperties": false
+                    "guild_id": {
+                        "type": "string"
                     },
-                    "get": {
-                        "type": "object",
-                        "additionalProperties": false
+                    "permissions": {
+                        "type": "string"
                     },
-                    "has": {
-                        "type": "object",
-                        "additionalProperties": false
+                    "captcha_key": {
+                        "type": "string"
                     },
-                    "set": {
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "getSetCookie": {
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "forEach": {
-                        "description": "Performs the specified action for each element in an array.",
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "keys": {
-                        "description": "Returns an array consisting of the keys of the object",
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "values": {
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "entries": {
-                        "description": "Returns an array consisting of the key value pairs of the object",
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "__@iterator": {
-                        "type": "object",
-                        "additionalProperties": false
+                    "code": {
+                        "type": "string"
                     }
                 },
                 "required": [
-                    "__@iterator",
-                    "append",
-                    "delete",
-                    "entries",
-                    "forEach",
-                    "get",
-                    "getSetCookie",
-                    "has",
-                    "keys",
-                    "set",
-                    "values"
+                    "authorize",
+                    "guild_id",
+                    "permissions"
                 ]
             },
-            "ResponseType": {
-                "enum": [
-                    "basic",
-                    "cors",
-                    "default",
-                    "error",
-                    "opaque",
-                    "opaqueredirect"
-                ],
-                "type": "string"
+            "ApplicationCreateSchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "team_id": {
+                        "type": [
+                            "string",
+                            "integer"
+                        ]
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "ApplicationModifySchema": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "icon": {
+                        "type": "string"
+                    },
+                    "interactions_endpoint_url": {
+                        "type": "string"
+                    },
+                    "max_participants": {
+                        "type": "integer",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "privacy_policy_url": {
+                        "type": "string"
+                    },
+                    "role_connections_verification_url": {
+                        "type": "string"
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "terms_of_service_url": {
+                        "type": "string"
+                    },
+                    "bot_public": {
+                        "type": "boolean"
+                    },
+                    "bot_require_code_grant": {
+                        "type": "boolean"
+                    },
+                    "flags": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "BackupCodesChallengeSchema": {
+                "type": "object",
+                "properties": {
+                    "password": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "password"
+                ]
+            },
+            "BanCreateSchema": {
+                "type": "object",
+                "properties": {
+                    "delete_message_seconds": {
+                        "type": "string"
+                    },
+                    "delete_message_days": {
+                        "type": "string"
+                    },
+                    "reason": {
+                        "type": "string"
+                    }
+                }
+            },
+            "BanModeratorSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "user_id": {
+                        "type": "string"
+                    },
+                    "guild_id": {
+                        "type": "string"
+                    },
+                    "executor_id": {
+                        "type": "string"
+                    },
+                    "reason": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "executor_id",
+                    "guild_id",
+                    "id",
+                    "user_id"
+                ]
+            },
+            "BanRegistrySchema": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "user_id": {
+                        "type": "string"
+                    },
+                    "guild_id": {
+                        "type": "string"
+                    },
+                    "executor_id": {
+                        "type": "string"
+                    },
+                    "ip": {
+                        "type": "string"
+                    },
+                    "reason": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "executor_id",
+                    "guild_id",
+                    "id",
+                    "user_id"
+                ]
+            },
+            "BotModifySchema": {
+                "type": "object",
+                "properties": {
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "username": {
+                        "type": "string"
+                    }
+                }
             },
             "ChannelPermissionOverwriteType": {
                 "enum": [
@@ -3543,13 +3642,13 @@
             "APIGuild": {
                 "type": "object",
                 "properties": {
+                    "name": {
+                        "type": "string"
+                    },
                     "reload": {
                         "description": "Reloads entity data from the database.",
                         "type": "object",
                         "additionalProperties": false
-                    },
-                    "name": {
-                        "type": "string"
                     },
                     "id": {
                         "type": "string"
@@ -4262,372 +4361,6 @@
                     "token",
                     "webauthn"
                 ]
-            },
-            "_Response": {
-                "type": "object",
-                "properties": {
-                    "headers": {
-                        "$ref": "#/components/schemas/Headers"
-                    },
-                    "ok": {
-                        "type": "boolean"
-                    },
-                    "status": {
-                        "type": "integer"
-                    },
-                    "statusText": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/ResponseType"
-                    },
-                    "url": {
-                        "type": "string"
-                    },
-                    "redirected": {
-                        "type": "boolean"
-                    },
-                    "body": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/ReadableStream<any>"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "bodyUsed": {
-                        "type": "boolean"
-                    },
-                    "arrayBuffer": {
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "blob": {
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "formData": {
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "json": {
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "text": {
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "clone": {
-                        "type": "object",
-                        "additionalProperties": false
-                    }
-                },
-                "required": [
-                    "arrayBuffer",
-                    "blob",
-                    "body",
-                    "bodyUsed",
-                    "clone",
-                    "formData",
-                    "headers",
-                    "json",
-                    "ok",
-                    "redirected",
-                    "status",
-                    "statusText",
-                    "text",
-                    "type",
-                    "url"
-                ]
-            },
-            "global.Response": {
-                "type": "object",
-                "properties": {
-                    "headers": {
-                        "$ref": "#/components/schemas/Headers"
-                    },
-                    "ok": {
-                        "type": "boolean"
-                    },
-                    "status": {
-                        "type": "integer"
-                    },
-                    "statusText": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/ResponseType"
-                    },
-                    "url": {
-                        "type": "string"
-                    },
-                    "redirected": {
-                        "type": "boolean"
-                    },
-                    "body": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/ReadableStream<any>"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "bodyUsed": {
-                        "type": "boolean"
-                    },
-                    "arrayBuffer": {
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "blob": {
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "formData": {
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "json": {
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "text": {
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "clone": {
-                        "type": "object",
-                        "additionalProperties": false
-                    }
-                },
-                "required": [
-                    "arrayBuffer",
-                    "blob",
-                    "body",
-                    "bodyUsed",
-                    "clone",
-                    "formData",
-                    "headers",
-                    "json",
-                    "ok",
-                    "redirected",
-                    "status",
-                    "statusText",
-                    "text",
-                    "type",
-                    "url"
-                ]
-            },
-            "ConnectedAccountCommonOAuthTokenResponse": {
-                "type": "object",
-                "properties": {
-                    "access_token": {
-                        "type": "string"
-                    },
-                    "token_type": {
-                        "type": "string"
-                    },
-                    "scope": {
-                        "type": "string"
-                    },
-                    "refresh_token": {
-                        "type": "string"
-                    },
-                    "expires_in": {
-                        "type": "integer"
-                    }
-                },
-                "required": [
-                    "access_token",
-                    "scope",
-                    "token_type"
-                ]
-            },
-            "ExpressResponse": {
-                "type": "object"
-            },
-            "ApplicationAuthorizeSchema": {
-                "type": "object",
-                "properties": {
-                    "authorize": {
-                        "type": "boolean"
-                    },
-                    "guild_id": {
-                        "type": "string"
-                    },
-                    "permissions": {
-                        "type": "string"
-                    },
-                    "captcha_key": {
-                        "type": "string"
-                    },
-                    "code": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "authorize",
-                    "guild_id",
-                    "permissions"
-                ]
-            },
-            "ApplicationCreateSchema": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "team_id": {
-                        "type": [
-                            "string",
-                            "integer"
-                        ]
-                    }
-                },
-                "required": [
-                    "name"
-                ]
-            },
-            "ApplicationModifySchema": {
-                "type": "object",
-                "properties": {
-                    "description": {
-                        "type": "string"
-                    },
-                    "icon": {
-                        "type": "string"
-                    },
-                    "interactions_endpoint_url": {
-                        "type": "string"
-                    },
-                    "max_participants": {
-                        "type": "integer",
-                        "nullable": true
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "privacy_policy_url": {
-                        "type": "string"
-                    },
-                    "role_connections_verification_url": {
-                        "type": "string"
-                    },
-                    "tags": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "terms_of_service_url": {
-                        "type": "string"
-                    },
-                    "bot_public": {
-                        "type": "boolean"
-                    },
-                    "bot_require_code_grant": {
-                        "type": "boolean"
-                    },
-                    "flags": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "BackupCodesChallengeSchema": {
-                "type": "object",
-                "properties": {
-                    "password": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "password"
-                ]
-            },
-            "BanCreateSchema": {
-                "type": "object",
-                "properties": {
-                    "delete_message_seconds": {
-                        "type": "string"
-                    },
-                    "delete_message_days": {
-                        "type": "string"
-                    },
-                    "reason": {
-                        "type": "string"
-                    }
-                }
-            },
-            "BanModeratorSchema": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "user_id": {
-                        "type": "string"
-                    },
-                    "guild_id": {
-                        "type": "string"
-                    },
-                    "executor_id": {
-                        "type": "string"
-                    },
-                    "reason": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "executor_id",
-                    "guild_id",
-                    "id",
-                    "user_id"
-                ]
-            },
-            "BanRegistrySchema": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "user_id": {
-                        "type": "string"
-                    },
-                    "guild_id": {
-                        "type": "string"
-                    },
-                    "executor_id": {
-                        "type": "string"
-                    },
-                    "ip": {
-                        "type": "string"
-                    },
-                    "reason": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "executor_id",
-                    "guild_id",
-                    "id",
-                    "user_id"
-                ]
-            },
-            "BotModifySchema": {
-                "type": "object",
-                "properties": {
-                    "avatar": {
-                        "type": "string"
-                    },
-                    "username": {
-                        "type": "string"
-                    }
-                }
             },
             "ChannelPermissionOverwriteSchema": {
                 "type": "object",
@@ -5486,9 +5219,6 @@
             "MessageEditSchema": {
                 "type": "object",
                 "properties": {
-                    "embed": {
-                        "$ref": "#/components/schemas/Embed"
-                    },
                     "file": {
                         "type": "object",
                         "properties": {
@@ -5501,28 +5231,11 @@
                             "filename"
                         ]
                     },
+                    "embed": {
+                        "$ref": "#/components/schemas/Embed"
+                    },
                     "flags": {
                         "type": "integer"
-                    },
-                    "attachments": {
-                        "description": "TODO: we should create an interface for attachments\nTODO: OpenWAAO<-->attachment-style metadata conversion",
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "filename": {
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false,
-                            "required": [
-                                "filename",
-                                "id"
-                            ]
-                        }
                     },
                     "content": {
                         "type": "string"
@@ -5596,6 +5309,26 @@
                     },
                     "payload_json": {
                         "type": "string"
+                    },
+                    "attachments": {
+                        "description": "TODO: we should create an interface for attachments\nTODO: OpenWAAO<-->attachment-style metadata conversion",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "filename": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "filename",
+                                "id"
+                            ]
+                        }
                     },
                     "sticker_ids": {
                         "type": "array",
@@ -13994,6 +13727,62 @@
                 ]
             }
         },
+        "/guilds/{guild_id}/bulk-ban/": {
+            "post": {
+                "x-permission-required": "BAN_MEMBERS",
+                "security": [
+                    {
+                        "bearer": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Ban"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/APIErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/APIErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "guild_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "guild_id"
+                    }
+                ],
+                "tags": [
+                    "guilds"
+                ]
+            }
+        },
         "/guilds/{guild_id}/bans/": {
             "get": {
                 "x-permission-required": "BAN_MEMBERS",
@@ -14040,7 +13829,7 @@
                 ]
             }
         },
-        "/guilds/{guild_id}/bans/{user}": {
+        "/guilds/{guild_id}/bans/{user_id}": {
             "get": {
                 "x-permission-required": "BAN_MEMBERS",
                 "security": [
@@ -14091,21 +13880,19 @@
                         "description": "guild_id"
                     },
                     {
-                        "name": "user",
+                        "name": "user_id",
                         "in": "path",
                         "required": true,
                         "schema": {
                             "type": "string"
                         },
-                        "description": "user"
+                        "description": "user_id"
                     }
                 ],
                 "tags": [
                     "guilds"
                 ]
-            }
-        },
-        "/guilds/{guild_id}/bans/{user_id}": {
+            },
             "put": {
                 "x-permission-required": "BAN_MEMBERS",
                 "security": [

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"start:cdn": "node dist/cdn/start.js",
 		"start:gateway": "node dist/gateway/start.js",
 		"build": "tsc -p .",
+		"watch": "tsc -w -p .",
 		"test": "node scripts/test.js",
 		"lint": "eslint .",
 		"setup": "npm run build && npm run generate:schema",

--- a/src/api/routes/guilds/#guild_id/bans.ts
+++ b/src/api/routes/guilds/#guild_id/bans.ts
@@ -99,7 +99,7 @@ router.get(
 	async (req: Request, res: Response) => {
 		const { guild_id, user_id } = req.params;
 
-		let ban = (await Ban.findOneOrFail({
+		const ban = (await Ban.findOneOrFail({
 			where: { guild_id: guild_id, user_id: user_id },
 		})) as BanRegistrySchema;
 

--- a/src/api/routes/guilds/#guild_id/bans.ts
+++ b/src/api/routes/guilds/#guild_id/bans.ts
@@ -109,7 +109,7 @@ router.get(
 		const banInfo = {
 			user: await User.getPublicUser(ban.user_id),
 			reason: ban.reason,
-		}
+		};
 
 		return res.json(banInfo);
 	},

--- a/src/api/routes/guilds/#guild_id/bans.ts
+++ b/src/api/routes/guilds/#guild_id/bans.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -19,7 +19,6 @@
 import { getIpAdress, route } from "@spacebar/api";
 import {
 	Ban,
-	BanModeratorSchema,
 	BanRegistrySchema,
 	DiscordApiErrors,
 	GuildBanAddEvent,
@@ -82,7 +81,7 @@ router.get(
 );
 
 router.get(
-	"/:user",
+	"/:user_id",
 	route({
 		permission: "BAN_MEMBERS",
 		responses: {
@@ -98,8 +97,7 @@ router.get(
 		},
 	}),
 	async (req: Request, res: Response) => {
-		const { guild_id } = req.params;
-		const user_id = req.params.ban;
+		const { guild_id, user_id } = req.params;
 
 		let ban = (await Ban.findOneOrFail({
 			where: { guild_id: guild_id, user_id: user_id },
@@ -108,13 +106,12 @@ router.get(
 		if (ban.user_id === ban.executor_id) throw DiscordApiErrors.UNKNOWN_BAN;
 		// pretend self-bans don't exist to prevent victim chasing
 
-		/* Filter secret from registry. */
+		const banInfo = {
+			user: await User.getPublicUser(ban.user_id),
+			reason: ban.reason,
+		}
 
-		ban = ban as BanModeratorSchema;
-
-		delete ban.ip;
-
-		return res.json(ban);
+		return res.json(banInfo);
 	},
 );
 
@@ -151,6 +148,12 @@ router.put(
 		if (req.permission?.cache.guild?.owner_id === banned_user_id)
 			throw new HTTPError("You can't ban the owner", 400);
 
+		const existingBan = await Ban.findOne({
+			where: { guild_id: guild_id, user_id: banned_user_id },
+		});
+		// Bans on already banned users are silently ignored
+		if (existingBan) return res.status(204).send();
+
 		const banned_user = await User.getPublicUser(banned_user_id);
 
 		const ban = Ban.create({
@@ -174,7 +177,7 @@ router.put(
 			} as GuildBanAddEvent),
 		]);
 
-		return res.json(ban);
+		return res.status(204).send();
 	},
 );
 

--- a/src/api/routes/guilds/#guild_id/bulk-ban.ts
+++ b/src/api/routes/guilds/#guild_id/bulk-ban.ts
@@ -51,10 +51,12 @@ router.post(
 		const { guild_id } = req.params;
 
 		const userIds: Array<string> = req.body.user_ids;
-		if (!userIds)
-			throw new HTTPError("The user_ids array is missing", 400);
+		if (!userIds) throw new HTTPError("The user_ids array is missing", 400);
 		if (userIds.length > 200)
-			throw new HTTPError("The user_ids array must be between 1 and 200 in length", 400);
+			throw new HTTPError(
+				"The user_ids array must be between 1 and 200 in length",
+				400,
+			);
 
 		const banned_users = [];
 		const failed_users = [];
@@ -116,8 +118,12 @@ router.post(
 			}
 		}
 
-		if (banned_users.length === 0 && failed_users.length > 0) throw DiscordApiErrors.BULK_BAN_FAILED;
-		return res.json({ banned_users: banned_users, failed_users: failed_users });
+		if (banned_users.length === 0 && failed_users.length > 0)
+			throw DiscordApiErrors.BULK_BAN_FAILED;
+		return res.json({
+			banned_users: banned_users,
+			failed_users: failed_users,
+		});
 	},
 );
 

--- a/src/api/routes/guilds/#guild_id/bulk-ban.ts
+++ b/src/api/routes/guilds/#guild_id/bulk-ban.ts
@@ -1,0 +1,124 @@
+/*
+	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
+	Copyright (C) 2023 Spacebar and Spacebar Contributors
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { getIpAdress, route } from "@spacebar/api";
+import {
+	Ban,
+	DiscordApiErrors,
+	GuildBanAddEvent,
+	Member,
+	User,
+	emitEvent,
+} from "@spacebar/util";
+import { Request, Response, Router } from "express";
+import { HTTPError } from "lambert-server";
+
+const router: Router = Router();
+
+router.post(
+	"/",
+	route({
+		requestBody: "BulkBanSchema",
+		permission: ["BAN_MEMBERS", "MANAGE_GUILD"],
+		responses: {
+			200: {
+				body: "Ban",
+			},
+			400: {
+				body: "APIErrorResponse",
+			},
+			403: {
+				body: "APIErrorResponse",
+			},
+		},
+	}),
+	async (req: Request, res: Response) => {
+		const { guild_id } = req.params;
+
+		const userIds: Array<string> = req.body.user_ids;
+		if (!userIds)
+			throw new HTTPError("The user_ids array is missing", 400);
+		if (userIds.length > 200)
+			throw new HTTPError("The user_ids array must be between 1 and 200 in length", 400);
+
+		const banned_users = [];
+		const failed_users = [];
+		for await (const banned_user_id of userIds) {
+			if (
+				req.user_id === banned_user_id &&
+				banned_user_id === req.permission?.cache.guild?.owner_id
+			) {
+				failed_users.push(banned_user_id);
+				continue;
+			}
+
+			if (req.permission?.cache.guild?.owner_id === banned_user_id) {
+				failed_users.push(banned_user_id);
+				continue;
+			}
+
+			const existingBan = await Ban.findOne({
+				where: { guild_id: guild_id, user_id: banned_user_id },
+			});
+			if (existingBan) {
+				failed_users.push(banned_user_id);
+				continue;
+			}
+
+			let banned_user;
+			try {
+				banned_user = await User.getPublicUser(banned_user_id);
+			} catch {
+				failed_users.push(banned_user_id);
+				continue;
+			}
+
+			const ban = Ban.create({
+				user_id: banned_user_id,
+				guild_id: guild_id,
+				ip: getIpAdress(req),
+				executor_id: req.user_id,
+				reason: req.body.reason, // || otherwise empty
+			});
+
+			try {
+				await Promise.all([
+					Member.removeFromGuild(banned_user_id, guild_id),
+					ban.save(),
+					emitEvent({
+						event: "GUILD_BAN_ADD",
+						data: {
+							guild_id: guild_id,
+							user: banned_user,
+						},
+						guild_id: guild_id,
+					} as GuildBanAddEvent),
+				]);
+				banned_users.push(banned_user_id);
+			} catch {
+				failed_users.push(banned_user_id);
+				continue;
+			}
+		}
+
+		if (banned_users.length === 0 && failed_users.length > 0) throw DiscordApiErrors.BULK_BAN_FAILED;
+		return res.json({ banned_users: banned_users, failed_users: failed_users });
+	},
+);
+
+export default router;

--- a/src/api/util/handlers/route.ts
+++ b/src/api/util/handlers/route.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -90,19 +90,21 @@ export function route(opts: RouteOptions) {
 
 	return async (req: Request, res: Response, next: NextFunction) => {
 		if (opts.permission) {
-			const required = new Permissions(opts.permission);
 			req.permission = await getPermission(
 				req.user_id,
 				req.params.guild_id,
 				req.params.channel_id,
 			);
 
-			// bitfield comparison: check if user lacks certain permission
-			if (!req.permission.has(required)) {
-				throw DiscordApiErrors.MISSING_PERMISSIONS.withParams(
-					opts.permission as string,
-				);
-			}
+			const requiredPerms = Array.isArray(opts.permission) ? opts.permission : [opts.permission];
+			requiredPerms.forEach((perm) => {
+				// bitfield comparison: check if user lacks certain permission
+				if (!req.permission!.has(new Permissions(perm))) {
+					throw DiscordApiErrors.MISSING_PERMISSIONS.withParams(
+						perm as string,
+					);
+				}
+			});
 		}
 
 		if (opts.right) {

--- a/src/api/util/handlers/route.ts
+++ b/src/api/util/handlers/route.ts
@@ -96,7 +96,9 @@ export function route(opts: RouteOptions) {
 				req.params.channel_id,
 			);
 
-			const requiredPerms = Array.isArray(opts.permission) ? opts.permission : [opts.permission];
+			const requiredPerms = Array.isArray(opts.permission)
+				? opts.permission
+				: [opts.permission];
 			requiredPerms.forEach((perm) => {
 				// bitfield comparison: check if user lacks certain permission
 				if (!req.permission!.has(new Permissions(perm))) {

--- a/src/util/schemas/BulkBanSchema.ts
+++ b/src/util/schemas/BulkBanSchema.ts
@@ -1,0 +1,22 @@
+/*
+	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
+	Copyright (C) 2023 Spacebar and Spacebar Contributors
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+export interface BulkBanSchema {
+	user_ids: string[];
+	delete_message_seconds?: number;
+}

--- a/src/util/util/Constants.ts
+++ b/src/util/util/Constants.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -553,6 +553,8 @@ export const VerificationLevels = [
  * * LOTTIE_ANIMATION_MAXIMUM_DIMENSIONS
  * * STICKER_FRAME_RATE_TOO_SMALL_OR_TOO_LARGE
  * * STICKER_ANIMATION_DURATION_MAXIMUM
+ * * AUTOMODERATOR_BLOCK
+ * * BULK_BAN_FAILED
  * * UNKNOWN_VOICE_STATE
  * @typedef {string} APIError
  */
@@ -1000,6 +1002,10 @@ export const DiscordApiErrors = {
 	AUTOMODERATOR_BLOCK: new ApiError(
 		"Message was blocked by automatic moderation",
 		200000,
+	),
+	BULK_BAN_FAILED: new ApiError(
+		"Failed to ban users",
+		500000
 	),
 
 	//Other errors

--- a/src/util/util/Constants.ts
+++ b/src/util/util/Constants.ts
@@ -1003,10 +1003,7 @@ export const DiscordApiErrors = {
 		"Message was blocked by automatic moderation",
 		200000,
 	),
-	BULK_BAN_FAILED: new ApiError(
-		"Failed to ban users",
-		500000
-	),
+	BULK_BAN_FAILED: new ApiError("Failed to ban users", 500000),
 
 	//Other errors
 	UNKNOWN_VOICE_STATE: new ApiError("Unknown Voice State", 10065, 404),


### PR DESCRIPTION
- Remove duplicated "border-radius" CSS property
- Add `npm run watch` to simplify local development so TypeScript automatically builds on file changes

---
- Fix GET Ban using "ban"/"user" instead of "user_id" in params, making it unusable
- Return a processed user object instead of the raw DB one
- Silently ignore already banned users to prevent duplicate bans in the DB
- Return HTTP 204 on successful bans instead of the raw DB ban object

---
- /:guild_id/bulk-ban endpoint
- Support multiple required permissions for endpoints (untested as I don't know where those are set)
- New API error BULK_BAN_FAILED