### PR TITLE
German translations + EN PW length requirement

### DIFF
--- a/assets/locales/de/auth.json
+++ b/assets/locales/de/auth.json
@@ -1,16 +1,24 @@
 {
 	"login": {
-		"INVALID_LOGIN": "E-Mail or Phone not found",
-		"INVALID_PASSWORD": "Invalid Password",
-		"ACCOUNT_DISABLED": "This account is disabled"
+		"INVALID_LOGIN": "Ungültiger Benutzername/E-Mail oder Passwort.",
+		"INVALID_PASSWORD": "Ungültiges Passwort",
+		"ACCOUNT_DISABLED": "Dieser Account wurde deaktiviert",
+		"INVALID_TOTP_CODE": "Ungültiger Zwei-Faktor-Authentifierungs-Code.",
+		"INVALID_TOTP_SECRET": "Ungültiges Zwei-Faktor-Authentifierungs-Secret"
 	},
 	"register": {
-		"REGISTRATION_DISABLED": "New user registration is disabled",
-		"INVITE_ONLY": "You must be invited to register",
-		"EMAIL_INVALID": "Invalid Email",
-		"EMAIL_ALREADY_REGISTERED": "Email is already registered",
-		"DATE_OF_BIRTH_UNDERAGE": "You need to be {{years}} years or older",
-		"CONSENT_REQUIRED": "You must agree to the Terms of Service and Privacy Policy.",
-		"USERNAME_TOO_MANY_USERS": "Too many users have this username, please try another"
+		"REGISTRATION_DISABLED": "Die Registrierung von neuen Benutzern ist deaktiviert",
+		"INVITE_ONLY": "Du musst eingeladen werden, um dich registrieren zu können",
+		"EMAIL_INVALID": "Ungültige E-Mail-Adresse",
+		"EMAIL_ALREADY_REGISTERED": "E-Mail-Adresse ist bereits registriert",
+		"DATE_OF_BIRTH_UNDERAGE": "Du musst mindestens {{years}} Jahre oder älter sein",
+		"PASSWORD_REQUIREMENTS_MIN_LENGTH": "Das Passwort muss mindestens {{min}} Zeichen lang sein.",
+		"CONSENT_REQUIRED": "Du musst den Nutzungsbedingungen und der Datenschutzerklärung zustimmen.",
+		"USERNAME_TOO_MANY_USERS": "Zu viele Nutzer haben diesen Benutzernamen, bitte probiere einen anderen",
+		"TOO_MANY_REGISTRATIONS": "Zu viele Registrierungen, bitte versuche es später erneut"
+	},
+	"password_reset": {
+		"EMAIL_DOES_NOT_EXIST": "E-Mail-Adresse existiert nicht.",
+		"INVALID_TOKEN": "Ungültiger Token."
 	}
 }

--- a/assets/locales/en/auth.json
+++ b/assets/locales/en/auth.json
@@ -12,9 +12,9 @@
 		"EMAIL_INVALID": "Invalid Email",
 		"EMAIL_ALREADY_REGISTERED": "Email is already registered",
 		"DATE_OF_BIRTH_UNDERAGE": "You need to be {{years}} years or older",
+		"PASSWORD_REQUIREMENTS_MIN_LENGTH": "The password must be at least {{min}} characters long.",
 		"CONSENT_REQUIRED": "You must agree to the Terms of Service and Privacy Policy.",
 		"USERNAME_TOO_MANY_USERS": "Too many users have this username, please try another",
-		"GUESTS_DISABLED": "Guest users are disabled",
 		"TOO_MANY_REGISTRATIONS": "Too many registrations, please try again later"
 	},
 	"password_reset": {

--- a/assets/locales/ur/auth.json
+++ b/assets/locales/ur/auth.json
@@ -10,8 +10,8 @@
 		"EMAIL_INVALID": "Invalid Email",
 		"EMAIL_ALREADY_REGISTERED": "Email is already registered",
 		"DATE_OF_BIRTH_UNDERAGE": "You need to be {{years}} years or older",
-                "PASSWORD_REQUIREMENTS_MIN_LENGTH": "Must be at least {{min}} characters long.",
-                "CONSENT_REQUIRED": "You must agree to the Terms of Service and Privacy Policy.",
+		"PASSWORD_REQUIREMENTS_MIN_LENGTH": "The password must be at least {{min}} characters long.",
+		"CONSENT_REQUIRED": "You must agree to the Terms of Service and Privacy Policy.",
 		"USERNAME_TOO_MANY_USERS": "Too many users have this username, please try another"
 	}
 }


### PR DESCRIPTION
- Update the German translations (priorities yk)
- Remove the `GUESTS_DISABLED` string from EN as it doesn't exist anymore
- Add the `PASSWORD_REQUIREMENTS_MIN_LENGTH` string to EN as currently `register.PASSWORD_REQUIREMENTS_MIN_LENGTH` is returned as `message` in the error (PR #1069)
