### PR TITLE
Add channel position property to channel endpoints

### DIFF
--- a/src/api/routes/channels/#channel_id/index.ts
+++ b/src/api/routes/channels/#channel_id/index.ts
@@ -50,7 +50,13 @@ router.get(
 		const channel = await Channel.findOneOrFail({
 			where: { id: channel_id },
 		});
+		if (!channel.guild_id) return res.send(channel);
 
+		channel.position = await Channel.calculatePosition(
+			channel_id,
+			channel.guild_id,
+			channel.guild,
+		);
 		return res.send(channel);
 	},
 );

--- a/src/api/routes/channels/#channel_id/permissions.ts
+++ b/src/api/routes/channels/#channel_id/permissions.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -53,6 +53,11 @@ router.put(
 			where: { id: channel_id },
 		});
 		if (!channel.guild_id) throw new HTTPError("Channel not found", 404);
+		channel.position = await Channel.calculatePosition(
+			channel_id,
+			channel.guild_id,
+			channel.guild,
+		);
 
 		if (body.type === 0) {
 			if (!(await Role.count({ where: { id: overwrite_id } })))

--- a/src/api/routes/guilds/#guild_id/channels.ts
+++ b/src/api/routes/guilds/#guild_id/channels.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -40,6 +40,14 @@ router.get(
 	async (req: Request, res: Response) => {
 		const { guild_id } = req.params;
 		const channels = await Channel.find({ where: { guild_id } });
+
+		for await (const channel of channels) {
+			channel.position = await Channel.calculatePosition(
+				channel.id,
+				guild_id,
+				channel.guild,
+			);
+		}
 
 		res.json(channels);
 	},
@@ -70,6 +78,11 @@ router.post(
 		const channel = await Channel.createChannel(
 			{ ...body, guild_id },
 			req.user_id,
+		);
+		channel.position = await Channel.calculatePosition(
+			channel.id,
+			guild_id,
+			channel.guild,
 		);
 
 		res.status(201).json(channel);

--- a/src/api/routes/guilds/#guild_id/channels.ts
+++ b/src/api/routes/guilds/#guild_id/channels.ts
@@ -48,6 +48,7 @@ router.get(
 				channel.guild,
 			);
 		}
+		channels.sort((a, b) => a.position - b.position);
 
 		res.json(channels);
 	},

--- a/src/util/entities/Member.ts
+++ b/src/util/entities/Member.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -31,7 +31,7 @@ import {
 	PrimaryGeneratedColumn,
 	RelationId,
 } from "typeorm";
-import { Ban, PublicGuildRelations } from ".";
+import { Ban, Channel, PublicGuildRelations } from ".";
 import { ReadyGuildDTO } from "../dtos";
 import {
 	GuildCreateEvent,
@@ -329,6 +329,13 @@ export class Member extends BaseClassWithoutId {
 			relations: PublicGuildRelations,
 			relationLoadStrategy: "query",
 		});
+
+		for await (const channel of guild.channels) {
+			channel.position = await Channel.calculatePosition(
+				channel.id,
+				guild_id,
+			);
+		}
 
 		const memberCount = await Member.count({ where: { guild_id } });
 

--- a/src/util/entities/UserSettings.ts
+++ b/src/util/entities/UserSettings.ts
@@ -122,7 +122,6 @@ export class UserSettings extends BaseClassWithoutId {
 
 	@Column({ nullable: true })
 	view_nsfw_guilds: boolean = true;
-
 }
 
 interface CustomStatus {


### PR DESCRIPTION
This PR makes the server calculate the channel position for requests returning channels. Previously, the property wasn't returned.

Closes #1130.