### PR TITLE
New user setting entries migration

### DIFF
--- a/src/util/entities/UserSettings.ts
+++ b/src/util/entities/UserSettings.ts
@@ -122,7 +122,6 @@ export class UserSettings extends BaseClassWithoutId {
 
 	@Column({ nullable: true })
 	view_nsfw_guilds: boolean = true;
-
 }
 
 interface CustomStatus {

--- a/src/util/migration/mariadb/1719776735000-newUserSettings.ts
+++ b/src/util/migration/mariadb/1719776735000-newUserSettings.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class NewUserSettings1719776735000 implements MigrationInterface {
+	name = "NewUserSettings1719776735000";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE `user_settings` ADD friend_discovery_flags integer NULL DEFAULT 0;",
+		);
+		await queryRunner.query(
+			"ALTER TABLE `user_settings` ADD view_nsfw_guilds tinyint NULL DEFAULT 1;",
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE `user_settings` DROP COLUMN friend_discovery_flags;",
+		);
+		await queryRunner.query(
+			"ALTER TABLE `user_settings` DROP COLUMN view_nsfw_guilds;",
+		);
+	}
+}

--- a/src/util/migration/mysql/1719776735000-newUserSettings.ts
+++ b/src/util/migration/mysql/1719776735000-newUserSettings.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class NewUserSettings1719776735000 implements MigrationInterface {
+	name = "NewUserSettings1719776735000";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE `user_settings` ADD friend_discovery_flags integer NULL DEFAULT 0;",
+		);
+		await queryRunner.query(
+			"ALTER TABLE `user_settings` ADD view_nsfw_guilds tinyint NULL DEFAULT 1;",
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE `user_settings` DROP COLUMN friend_discovery_flags;",
+		);
+		await queryRunner.query(
+			"ALTER TABLE `user_settings` DROP COLUMN view_nsfw_guilds;",
+		);
+	}
+}

--- a/src/util/migration/postgres/1719776735000-newUserSettings.ts
+++ b/src/util/migration/postgres/1719776735000-newUserSettings.ts
@@ -8,7 +8,7 @@ export class NewUserSettings1719776735000 implements MigrationInterface {
 			"ALTER TABLE user_settings ADD COLUMN friend_discovery_flags integer DEFAULT 0;",
 		);
 		await queryRunner.query(
-			"ALTER TABLE user_settings ADD COLUMN view_nsfw_guilds tinyint DEFAULT 1;",
+			"ALTER TABLE user_settings ADD COLUMN view_nsfw_guilds boolean DEFAULT true;",
 		);
 	}
 

--- a/src/util/migration/postgres/1719776735000-newUserSettings.ts
+++ b/src/util/migration/postgres/1719776735000-newUserSettings.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class NewUserSettings1719776735000 implements MigrationInterface {
+	name = "NewUserSettings1719776735000";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE user_settings ADD COLUMN friend_discovery_flags integer DEFAULT 0;",
+		);
+		await queryRunner.query(
+			"ALTER TABLE user_settings ADD COLUMN view_nsfw_guilds tinyint DEFAULT 1;",
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE user_settings DROP COLUMN friend_discovery_flags;",
+		);
+		await queryRunner.query(
+			"ALTER TABLE user_settings DROP COLUMN view_nsfw_guilds;",
+		);
+	}
+}


### PR DESCRIPTION
#1129 added two new properties to the user settings object from upstream changes, `friend_discovery_flags` and `view_nsfw_guilds`.

This PR adds migrations for completeness (and for me to learn at least a bit about how they work).

MariaDB is tested and works fine, MySQL should therefore too. I've got no clue about Postgres.