### PR TITLE
New message flags

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -734,6 +734,114 @@
                     }
                 }
             },
+            "MessageComponent": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "integer"
+                    },
+                    "style": {
+                        "type": "integer"
+                    },
+                    "label": {
+                        "type": "string"
+                    },
+                    "emoji": {
+                        "$ref": "#/components/schemas/PartialEmoji"
+                    },
+                    "custom_id": {
+                        "type": "string"
+                    },
+                    "sku_id": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "disabled": {
+                        "type": "boolean"
+                    },
+                    "components": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MessageComponent"
+                        }
+                    }
+                },
+                "required": [
+                    "components",
+                    "type"
+                ]
+            },
+            "PartialEmoji": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "animated": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "PollCreationSchema": {
+                "type": "object",
+                "properties": {
+                    "question": {
+                        "$ref": "#/components/schemas/PollMedia"
+                    },
+                    "answers": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PollAnswer"
+                        }
+                    },
+                    "duration": {
+                        "type": "integer"
+                    },
+                    "allow_multiselect": {
+                        "type": "boolean"
+                    },
+                    "layout_type": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "answers",
+                    "question"
+                ]
+            },
+            "PollMedia": {
+                "type": "object",
+                "properties": {
+                    "text": {
+                        "type": "string"
+                    },
+                    "emoji": {
+                        "$ref": "#/components/schemas/PartialEmoji"
+                    }
+                }
+            },
+            "PollAnswer": {
+                "type": "object",
+                "properties": {
+                    "answer_id": {
+                        "type": "string"
+                    },
+                    "poll_media": {
+                        "$ref": "#/components/schemas/PollMedia"
+                    }
+                },
+                "required": [
+                    "poll_media"
+                ]
+            },
             "ChannelOverride": {
                 "type": "object",
                 "properties": {
@@ -1193,7 +1301,8 @@
                         "$ref": "#/components/schemas/Guild"
                     },
                     "parent_id": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "parent": {
                         "$ref": "#/components/schemas/Channel"
@@ -1802,6 +1911,10 @@
                         "type": "integer",
                         "default": 0
                     },
+                    "friend_discovery_flags": {
+                        "type": "integer",
+                        "default": 0
+                    },
                     "friend_source_flags": {
                         "$ref": "#/components/schemas/FriendSourceFlags"
                     },
@@ -1892,6 +2005,10 @@
                     "timezone_offset": {
                         "type": "integer",
                         "default": 0
+                    },
+                    "view_nsfw_guilds": {
+                        "type": "boolean",
+                        "default": true
                     }
                 },
                 "required": [
@@ -1908,6 +2025,7 @@
                     "disable_games_tab",
                     "enable_tts_command",
                     "explicit_content_filter",
+                    "friend_discovery_flags",
                     "friend_source_flags",
                     "gateway_connected",
                     "gif_auto_play",
@@ -1926,7 +2044,8 @@
                     "status",
                     "stream_notifications_enabled",
                     "theme",
-                    "timezone_offset"
+                    "timezone_offset",
+                    "view_nsfw_guilds"
                 ]
             },
             "SecurityKey": {
@@ -2238,6 +2357,12 @@
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/MessageComponent"
+                        }
+                    },
+                    "poll": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Poll"
                         }
                     },
                     "id": {
@@ -2963,23 +3088,6 @@
                     "user_ids"
                 ]
             },
-            "PartialEmoji": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "animated": {
-                        "type": "boolean"
-                    }
-                },
-                "required": [
-                    "name"
-                ]
-            },
             "MessageType": {
                 "enum": [
                     0,
@@ -3018,40 +3126,71 @@
                 ],
                 "type": "number"
             },
-            "MessageComponent": {
+            "Poll": {
                 "type": "object",
                 "properties": {
-                    "type": {
-                        "type": "integer"
+                    "question": {
+                        "$ref": "#/components/schemas/PollMedia"
                     },
-                    "style": {
-                        "type": "integer"
-                    },
-                    "label": {
-                        "type": "string"
-                    },
-                    "emoji": {
-                        "$ref": "#/components/schemas/PartialEmoji"
-                    },
-                    "custom_id": {
-                        "type": "string"
-                    },
-                    "url": {
-                        "type": "string"
-                    },
-                    "disabled": {
-                        "type": "boolean"
-                    },
-                    "components": {
+                    "answers": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/MessageComponent"
+                            "$ref": "#/components/schemas/PollAnswer"
+                        }
+                    },
+                    "expiry": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "allow_multiselect": {
+                        "type": "boolean"
+                    },
+                    "results": {
+                        "$ref": "#/components/schemas/PollResult"
+                    }
+                },
+                "required": [
+                    "allow_multiselect",
+                    "answers",
+                    "expiry",
+                    "question"
+                ]
+            },
+            "PollResult": {
+                "type": "object",
+                "properties": {
+                    "is_finalized": {
+                        "type": "boolean"
+                    },
+                    "answer_counts": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PollAnswerCount"
                         }
                     }
                 },
                 "required": [
-                    "components",
-                    "type"
+                    "answer_counts",
+                    "is_finalized"
+                ]
+            },
+            "PollAnswerCount": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "count": {
+                        "type": "integer"
+                    },
+                    "me_voted": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "count",
+                    "id",
+                    "me_voted"
                 ]
             },
             "VoiceState": {
@@ -3444,7 +3583,12 @@
                     },
                     "components": {
                         "type": "array",
-                        "items": {}
+                        "items": {
+                            "$ref": "#/components/schemas/MessageComponent"
+                        }
+                    },
+                    "poll": {
+                        "$ref": "#/components/schemas/Poll"
                     },
                     "hit": {
                         "type": "boolean",
@@ -3466,6 +3610,7 @@
                     "mention_roles",
                     "mentions",
                     "pinned",
+                    "poll",
                     "timestamp",
                     "tts",
                     "type"
@@ -5212,7 +5357,27 @@
                     },
                     "components": {
                         "type": "array",
-                        "items": {}
+                        "items": {
+                            "$ref": "#/components/schemas/MessageComponent"
+                        }
+                    },
+                    "poll": {
+                        "$ref": "#/components/schemas/PollCreationSchema"
+                    },
+                    "enforce_nonce": {
+                        "type": "boolean"
+                    },
+                    "applied_tags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "thread_name": {
+                        "type": "string"
+                    },
+                    "avatar_url": {
+                        "type": "string"
                     }
                 }
             },
@@ -5338,7 +5503,27 @@
                     },
                     "components": {
                         "type": "array",
-                        "items": {}
+                        "items": {
+                            "$ref": "#/components/schemas/MessageComponent"
+                        }
+                    },
+                    "poll": {
+                        "$ref": "#/components/schemas/PollCreationSchema"
+                    },
+                    "enforce_nonce": {
+                        "type": "boolean"
+                    },
+                    "applied_tags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "thread_name": {
+                        "type": "string"
+                    },
+                    "avatar_url": {
+                        "type": "string"
                     }
                 }
             },
@@ -5919,6 +6104,9 @@
                     "explicit_content_filter": {
                         "type": "integer"
                     },
+                    "friend_discovery_flags": {
+                        "type": "integer"
+                    },
                     "friend_source_flags": {
                         "$ref": "#/components/schemas/FriendSourceFlags"
                     },
@@ -5982,6 +6170,9 @@
                     },
                     "timezone_offset": {
                         "type": "integer"
+                    },
+                    "view_nsfw_guilds": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -7915,6 +8106,23 @@
                 "required": [
                     "hook",
                     "user"
+                ]
+            },
+            "BulkBanSchema": {
+                "type": "object",
+                "properties": {
+                    "user_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "delete_message_seconds": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "user_ids"
                 ]
             },
             "BulkDeleteSchema": {
@@ -13729,12 +13937,25 @@
         },
         "/guilds/{guild_id}/bulk-ban/": {
             "post": {
-                "x-permission-required": "BAN_MEMBERS",
+                "x-permission-required": [
+                    "BAN_MEMBERS",
+                    "MANAGE_GUILD"
+                ],
                 "security": [
                     {
                         "bearer": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BulkBanSchema"
+                            }
+                        }
+                    }
+                },
                 "responses": {
                     "200": {
                         "description": "",

--- a/src/api/routes/channels/#channel_id/messages/#message_id/crosspost.ts
+++ b/src/api/routes/channels/#channel_id/messages/#message_id/crosspost.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -56,6 +56,7 @@ router.post(
 			edited_timestamp: null,
 			flags: 1,
 			components: [],
+			poll: {},
 		}).status(200);
 	},
 );

--- a/src/api/routes/guilds/#guild_id/messages/search.ts
+++ b/src/api/routes/guilds/#guild_id/messages/search.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -162,6 +162,7 @@ router.get(
 				edited_timestamp: x.edited_timestamp,
 				flags: x.flags,
 				components: x.components,
+				poll: x.poll,
 				hit: true,
 			},
 		]);

--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -16,36 +16,36 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import * as Sentry from "@sentry/node";
+import { EmbedHandlers } from "@spacebar/api";
 import {
+	Application,
+	Attachment,
 	Channel,
+	Config,
 	Embed,
+	EmbedCache,
 	emitEvent,
-	Guild,
-	Message,
-	MessageCreateEvent,
-	MessageUpdateEvent,
+	EVERYONE_MENTION,
 	getPermission,
 	getRights,
+	Guild,
+	HERE_MENTION,
+	Message,
+	MessageCreateEvent,
+	MessageCreateSchema,
+	MessageType,
+	MessageUpdateEvent,
+	Role,
+	ROLE_MENTION,
+	Sticker,
+	User,
 	//CHANNEL_MENTION,
 	USER_MENTION,
-	ROLE_MENTION,
-	Role,
-	EVERYONE_MENTION,
-	HERE_MENTION,
-	MessageType,
-	User,
-	Application,
 	Webhook,
-	Attachment,
-	Config,
-	Sticker,
-	MessageCreateSchema,
-	EmbedCache,
 } from "@spacebar/util";
 import { HTTPError } from "lambert-server";
 import { In } from "typeorm";
-import { EmbedHandlers } from "@spacebar/api";
-import * as Sentry from "@sentry/node";
 const allow_empty = false;
 // TODO: check webhook, application, system author, stickers
 // TODO: embed gifs/videos/images
@@ -66,6 +66,7 @@ export async function handleMessage(opts: MessageOptions): Promise<Message> {
 		: undefined;
 	const message = Message.create({
 		...opts,
+		poll: opts.poll ? [opts.poll] : undefined,
 		sticker_items: stickers,
 		guild_id: channel.guild_id,
 		channel_id: opts.channel_id,

--- a/src/util/entities/Message.ts
+++ b/src/util/entities/Message.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -218,6 +218,9 @@ export class Message extends BaseClass {
 	@Column({ type: "simple-json", nullable: true })
 	components?: MessageComponent[];
 
+	@Column({ type: "simple-json", nullable: true })
+	poll?: Poll[];
+
 	toJSON(): Message {
 		return {
 			...this,
@@ -238,6 +241,7 @@ export class Message extends BaseClass {
 			activity: this.activity ?? undefined,
 			application: this.application ?? undefined,
 			components: this.components ?? undefined,
+			poll: this.poll ?? undefined,
 			content: this.content ?? "",
 		};
 	}
@@ -249,6 +253,7 @@ export interface MessageComponent {
 	label?: string;
 	emoji?: PartialEmoji;
 	custom_id?: string;
+	sku_id?: string;
 	url?: string;
 	disabled?: boolean;
 	components: MessageComponent[];
@@ -326,4 +331,33 @@ export interface AllowedMentions {
 	roles?: string[];
 	users?: string[];
 	replied_user?: boolean;
+}
+
+export interface Poll {
+	question: PollMedia;
+	answers: PollAnswer[];
+	expiry: Date;
+	allow_multiselect: boolean;
+	results?: PollResult;
+}
+
+export interface PollMedia {
+	text?: string;
+	emoji?: PartialEmoji;
+}
+
+export interface PollAnswer {
+	answer_id?: string;
+	poll_media: PollMedia;
+}
+
+export interface PollResult {
+	is_finalized: boolean;
+	answer_counts: PollAnswerCount[];
+}
+
+export interface PollAnswerCount {
+	id: string;
+	count: number;
+	me_voted: boolean;
 }

--- a/src/util/migration/mariadb/1720157926878-messagePollObject.ts
+++ b/src/util/migration/mariadb/1720157926878-messagePollObject.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MessagePollObject1720157926878 implements MigrationInterface {
+	name = "MessagePollObject1720157926878";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query("ALTER TABLE `messages` ADD `poll` text NULL");
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query("ALTER TABLE `messages` DROP COLUMN `poll`");
+	}
+}

--- a/src/util/migration/mysql/1720157926878-messagePollObject.ts
+++ b/src/util/migration/mysql/1720157926878-messagePollObject.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MessagePollObject1720157926878 implements MigrationInterface {
+	name = "MessagePollObject1720157926878";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query("ALTER TABLE `messages` ADD `poll` text NULL");
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query("ALTER TABLE `messages` DROP COLUMN `poll`");
+	}
+}

--- a/src/util/migration/postgres/1720157926878-messagePollObject.ts
+++ b/src/util/migration/postgres/1720157926878-messagePollObject.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MessagePollObject1720157926878 implements MigrationInterface {
+	name = "MessagePollObject1720157926878";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query("ALTER TABLE messages ADD poll text NULL");
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query("ALTER TABLE messages DROP COLUMN poll");
+	}
+}

--- a/src/util/schemas/MessageCreateSchema.ts
+++ b/src/util/schemas/MessageCreateSchema.ts
@@ -56,7 +56,7 @@ export interface MessageCreateSchema {
 	sticker_ids?: string[];
 	components?: MessageComponent[];
 	// TODO: Fix TypeScript errors in src\api\util\handlers\Message.ts once this is enabled
-	//poll?: PollCreationSchema;
+	poll?: PollCreationSchema;
 	enforce_nonce?: boolean; // For Discord compatibility, it's the default behavior here
 	applied_tags?: string[]; // Not implemented yet, for webhooks in forums
 	thread_name?: string; // Not implemented yet, for webhooks

--- a/src/util/schemas/MessageCreateSchema.ts
+++ b/src/util/schemas/MessageCreateSchema.ts
@@ -1,22 +1,22 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Embed } from "@spacebar/util";
+import { Embed, MessageComponent, PollAnswer, PollMedia } from "@spacebar/util";
 
 type Attachment = {
 	id: string;
@@ -54,6 +54,21 @@ export interface MessageCreateSchema {
 	**/
 	attachments?: Attachment[];
 	sticker_ids?: string[];
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	components?: any[];
+	components?: MessageComponent[];
+	// TODO: Fix TypeScript errors in src\api\util\handlers\Message.ts once this is enabled
+	//poll?: PollCreationSchema;
+	enforce_nonce?: boolean; // For Discord compatibility, it's the default behavior here
+	applied_tags?: string[]; // Not implemented yet, for webhooks in forums
+	thread_name?: string; // Not implemented yet, for webhooks
+	avatar_url?: string; // Not implemented yet, for webhooks
+}
+
+// TypeScript complains once this is used above
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+interface PollCreationSchema {
+	question: PollMedia;
+	answers: PollAnswer[];
+	duration?: number;
+	allow_multiselect?: boolean;
+	layout_type?: number;
 }

--- a/src/util/schemas/responses/GuildMessagesSearchResponse.ts
+++ b/src/util/schemas/responses/GuildMessagesSearchResponse.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -19,7 +19,9 @@
 import {
 	Attachment,
 	Embed,
+	MessageComponent,
 	MessageType,
+	Poll,
 	PublicUser,
 	Role,
 } from "../../entities";
@@ -40,7 +42,8 @@ export interface GuildMessagesSearchMessage {
 	timestamp: string;
 	edited_timestamp: string | null;
 	flags: number;
-	components: unknown[];
+	components: MessageComponent[];
+	poll: Poll;
 	hit: true;
 }
 


### PR DESCRIPTION
This PR adds the new message create properties `poll`, `enforce_nonce` (already enforced by Spacebar), `applied_tags`, `thread_name` and `avatar_url`.

`poll` sadly fails when being added to MessageCreateSchema, could someone look into this? Is anything else required to be accepted?