### PR TITLE
Fix loading connection settings

### DIFF
--- a/src/connections/BattleNet/index.ts
+++ b/src/connections/BattleNet/index.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -47,13 +47,15 @@ export default class BattleNetConnection extends Connection {
 	settings: BattleNetSettings = new BattleNetSettings();
 
 	init(): void {
-		const settings =
-			ConnectionLoader.getConnectionConfig<BattleNetSettings>(
-				this.id,
-				this.settings,
-			);
+		this.settings = ConnectionLoader.getConnectionConfig<BattleNetSettings>(
+			this.id,
+			this.settings,
+		);
 
-		if (settings.enabled && (!settings.clientId || !settings.clientSecret))
+		if (
+			this.settings.enabled &&
+			(!this.settings.clientId || !this.settings.clientSecret)
+		)
 			throw new Error(`Invalid settings for connection ${this.id}`);
 	}
 

--- a/src/connections/Discord/index.ts
+++ b/src/connections/Discord/index.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -43,12 +43,15 @@ export default class DiscordConnection extends Connection {
 	settings: DiscordSettings = new DiscordSettings();
 
 	init(): void {
-		const settings = ConnectionLoader.getConnectionConfig<DiscordSettings>(
+		this.settings = ConnectionLoader.getConnectionConfig<DiscordSettings>(
 			this.id,
 			this.settings,
 		);
 
-		if (settings.enabled && (!settings.clientId || !settings.clientSecret))
+		if (
+			this.settings.enabled &&
+			(!this.settings.clientId || !this.settings.clientSecret)
+		)
 			throw new Error(`Invalid settings for connection ${this.id}`);
 	}
 

--- a/src/connections/EpicGames/index.ts
+++ b/src/connections/EpicGames/index.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -53,13 +53,15 @@ export default class EpicGamesConnection extends Connection {
 	settings: EpicGamesSettings = new EpicGamesSettings();
 
 	init(): void {
-		const settings =
-			ConnectionLoader.getConnectionConfig<EpicGamesSettings>(
-				this.id,
-				this.settings,
-			);
+		this.settings = ConnectionLoader.getConnectionConfig<EpicGamesSettings>(
+			this.id,
+			this.settings,
+		);
 
-		if (settings.enabled && (!settings.clientId || !settings.clientSecret))
+		if (
+			this.settings.enabled &&
+			(!this.settings.clientId || !this.settings.clientSecret)
+		)
 			throw new Error(`Invalid settings for connection ${this.id}`);
 	}
 

--- a/src/connections/Facebook/index.ts
+++ b/src/connections/Facebook/index.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -52,12 +52,15 @@ export default class FacebookConnection extends Connection {
 	settings: FacebookSettings = new FacebookSettings();
 
 	init(): void {
-		const settings = ConnectionLoader.getConnectionConfig<FacebookSettings>(
+		this.settings = ConnectionLoader.getConnectionConfig<FacebookSettings>(
 			this.id,
 			this.settings,
 		);
 
-		if (settings.enabled && (!settings.clientId || !settings.clientSecret))
+		if (
+			this.settings.enabled &&
+			(!this.settings.clientId || !this.settings.clientSecret)
+		)
 			throw new Error(`Invalid settings for connection ${this.id}`);
 	}
 

--- a/src/connections/GitHub/index.ts
+++ b/src/connections/GitHub/index.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -42,12 +42,15 @@ export default class GitHubConnection extends Connection {
 	settings: GitHubSettings = new GitHubSettings();
 
 	init(): void {
-		const settings = ConnectionLoader.getConnectionConfig<GitHubSettings>(
+		this.settings = ConnectionLoader.getConnectionConfig<GitHubSettings>(
 			this.id,
 			this.settings,
 		);
 
-		if (settings.enabled && (!settings.clientId || !settings.clientSecret))
+		if (
+			this.settings.enabled &&
+			(!this.settings.clientId || !this.settings.clientSecret)
+		)
 			throw new Error(`Invalid settings for connection ${this.id}`);
 	}
 

--- a/src/connections/Reddit/index.ts
+++ b/src/connections/Reddit/index.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -54,12 +54,15 @@ export default class RedditConnection extends Connection {
 	settings: RedditSettings = new RedditSettings();
 
 	init(): void {
-		const settings = ConnectionLoader.getConnectionConfig<RedditSettings>(
+		this.settings = ConnectionLoader.getConnectionConfig<RedditSettings>(
 			this.id,
 			this.settings,
 		);
 
-		if (settings.enabled && (!settings.clientId || !settings.clientSecret))
+		if (
+			this.settings.enabled &&
+			(!this.settings.clientId || !this.settings.clientSecret)
+		)
 			throw new Error(`Invalid settings for connection ${this.id}`);
 	}
 

--- a/src/connections/Spotify/index.ts
+++ b/src/connections/Spotify/index.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -63,12 +63,16 @@ export default class SpotifyConnection extends RefreshableConnection {
 		 * So to prevent spamming the spotify api we disable the ability to refresh.
 		 */
 		this.refreshEnabled = false;
-		const settings = ConnectionLoader.getConnectionConfig<SpotifySettings>(
+
+		this.settings = ConnectionLoader.getConnectionConfig<SpotifySettings>(
 			this.id,
 			this.settings,
 		);
 
-		if (settings.enabled && (!settings.clientId || !settings.clientSecret))
+		if (
+			this.settings.enabled &&
+			(!this.settings.clientId || !this.settings.clientSecret)
+		)
 			throw new Error(`Invalid settings for connection ${this.id}`);
 	}
 

--- a/src/connections/Twitch/index.ts
+++ b/src/connections/Twitch/index.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -55,12 +55,15 @@ export default class TwitchConnection extends RefreshableConnection {
 	settings: TwitchSettings = new TwitchSettings();
 
 	init(): void {
-		const settings = ConnectionLoader.getConnectionConfig<TwitchSettings>(
+		this.settings = ConnectionLoader.getConnectionConfig<TwitchSettings>(
 			this.id,
 			this.settings,
 		);
 
-		if (settings.enabled && (!settings.clientId || !settings.clientSecret))
+		if (
+			this.settings.enabled &&
+			(!this.settings.clientId || !this.settings.clientSecret)
+		)
 			throw new Error(`Invalid settings for connection ${this.id}`);
 	}
 

--- a/src/connections/Twitter/index.ts
+++ b/src/connections/Twitter/index.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -55,12 +55,15 @@ export default class TwitterConnection extends RefreshableConnection {
 	settings: TwitterSettings = new TwitterSettings();
 
 	init(): void {
-		const settings = ConnectionLoader.getConnectionConfig<TwitterSettings>(
+		this.settings = ConnectionLoader.getConnectionConfig<TwitterSettings>(
 			this.id,
 			this.settings,
 		);
 
-		if (settings.enabled && (!settings.clientId || !settings.clientSecret))
+		if (
+			this.settings.enabled &&
+			(!this.settings.clientId || !this.settings.clientSecret)
+		)
 			throw new Error(`Invalid settings for connection ${this.id}`);
 	}
 

--- a/src/connections/Xbox/index.ts
+++ b/src/connections/Xbox/index.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -62,12 +62,15 @@ export default class XboxConnection extends Connection {
 	settings: XboxSettings = new XboxSettings();
 
 	init(): void {
-		const settings = ConnectionLoader.getConnectionConfig<XboxSettings>(
+		this.settings = ConnectionLoader.getConnectionConfig<XboxSettings>(
 			this.id,
 			this.settings,
 		);
 
-		if (settings.enabled && (!settings.clientId || !settings.clientSecret))
+		if (
+			this.settings.enabled &&
+			(!this.settings.clientId || !this.settings.clientSecret)
+		)
 			throw new Error(`Invalid settings for connection ${this.id}`);
 	}
 

--- a/src/connections/Youtube/index.ts
+++ b/src/connections/Youtube/index.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -62,12 +62,15 @@ export default class YoutubeConnection extends Connection {
 	settings: YoutubeSettings = new YoutubeSettings();
 
 	init(): void {
-		const settings = ConnectionLoader.getConnectionConfig<YoutubeSettings>(
+		this.settings = ConnectionLoader.getConnectionConfig<YoutubeSettings>(
 			this.id,
 			this.settings,
 		);
 
-		if (settings.enabled && (!settings.clientId || !settings.clientSecret))
+		if (
+			this.settings.enabled &&
+			(!this.settings.clientId || !this.settings.clientSecret)
+		)
 			throw new Error(`Invalid settings for connection ${this.id}`);
 	}
 


### PR DESCRIPTION
```diff
  init(): void {
-    const settings = ConnectionLoader.getConnectionConfig<GitHubSettings>(
+    this.settings = ConnectionLoader.getConnectionConfig<GitHubSettings>(
          this.id,
```
> this is needed for me, otherwise the server uses the default settings and therefore doesn't enable the connection