### PR TITLE
Use front end URI instead of API for connection callbacks

### DIFF
--- a/src/util/connections/Connection.ts
+++ b/src/util/connections/Connection.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -43,7 +43,7 @@ export abstract class Connection {
 	 */
 	getRedirectUri() {
 		const endpointPublic =
-			Config.get().api.endpointPublic ?? "http://localhost:3001";
+			Config.get().general.frontPage ?? "http://localhost:3001";
 		return `${endpointPublic}/connections/${this.id}/callback`;
 	}
 


### PR DESCRIPTION
The callback after connecting an external account is handled by a client sending a POST request to the backend. Therefore, the redirect URI has to be based on the main front end instead of the API URI.