### PR TITLE
fix: poll message is not an empty message

### DIFF
--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -140,7 +140,8 @@ export async function handleMessage(opts: MessageOptions): Promise<Message> {
 		!opts.embeds?.length &&
 		!opts.attachments?.length &&
 		!opts.sticker_ids?.length &&
-		!opts.poll
+		!opts.poll &&
+		!opts.components?.length
 	) {
 		throw new HTTPError("Empty messages are not allowed", 50006);
 	}

--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -139,7 +139,8 @@ export async function handleMessage(opts: MessageOptions): Promise<Message> {
 		!opts.content &&
 		!opts.embeds?.length &&
 		!opts.attachments?.length &&
-		!opts.sticker_ids?.length
+		!opts.sticker_ids?.length &&
+		!opts.poll
 	) {
 		throw new HTTPError("Empty messages are not allowed", 50006);
 	}


### PR DESCRIPTION
Fixes empty message error when trying to do a poll and a message with only components