### PR TITLE
fix: return an error on username change with no password

### DIFF
--- a/src/api/routes/users/@me/index.ts
+++ b/src/api/routes/users/@me/index.ts
@@ -120,7 +120,7 @@ router.patch(
 			if (!body.password)
 				throw FieldErrors({
 					password: {
-						message: req.t("auth:register.INVALID_PASSWORD"),
+						message: req.t("auth:login.INVALID_PASSWORD"),
 						code: "INVALID_PASSWORD",
 					},
 				});
@@ -160,6 +160,15 @@ router.patch(
 					},
 				});
 			}
+		}
+
+		if (!body.password) {
+			throw FieldErrors({
+				password: {
+					message: req.t("auth:login.INVALID_PASSWORD"),
+					code: "INVALID_PASSWORD",
+				},
+			});
 		}
 
 		if (body.discriminator) {

--- a/src/api/routes/users/@me/index.ts
+++ b/src/api/routes/users/@me/index.ts
@@ -160,15 +160,15 @@ router.patch(
 					},
 				});
 			}
-		}
 
-		if (!body.password) {
-			throw FieldErrors({
-				password: {
-					message: req.t("auth:login.INVALID_PASSWORD"),
-					code: "INVALID_PASSWORD",
-				},
-			});
+			if (!body.password) {
+				throw FieldErrors({
+					password: {
+						message: req.t("auth:login.INVALID_PASSWORD"),
+						code: "INVALID_PASSWORD",
+					},
+				});
+			}
 		}
 
 		if (body.discriminator) {


### PR DESCRIPTION
Currently, it is possible to change your account's username with no password provided. This PR fixes that