### PR TITLE
Fix sort order when using ?around

### DIFF
--- a/src/api/routes/channels/#channel_id/messages/index.ts
+++ b/src/api/routes/channels/#channel_id/messages/index.ts
@@ -130,19 +130,25 @@ router.get(
 			query.take = Math.floor(limit / 2);
 			if (query.take != 0) {
 				const [right, left] = await Promise.all([
-					Message.find({ ...query, where: { id: LessThan(around) } }),
 					Message.find({
 						...query,
-						where: { id: MoreThanOrEqual(around) },
+						where: { channel_id, id: LessThan(around) },
+					}),
+					Message.find({
+						...query,
+						where: { channel_id, id: MoreThanOrEqual(around) },
+						order: { timestamp: "ASC" },
 					}),
 				]);
 				left.push(...right);
-				messages = left;
+				messages = left.sort(
+					(a, b) => a.timestamp.getTime() - b.timestamp.getTime(),
+				);
 			} else {
 				query.take = 1;
 				const message = await Message.findOne({
 					...query,
-					where: { id: around },
+					where: { channel_id, id: around },
 				});
 				messages = message ? [message] : [];
 			}


### PR DESCRIPTION
Currently, when using `api/v9/channels/:id/messages?around=:id`, it's (correctly) returning the messages before the specified message ID.

However, the messages after it are sorted in the wrong order to be filtered correctly, so it's always returning the most recent messages.
