### PR TITLE
Fix ?after messages fetch param

### DIFF
--- a/src/api/routes/channels/#channel_id/messages/index.ts
+++ b/src/api/routes/channels/#channel_id/messages/index.ts
@@ -157,6 +157,7 @@ router.get(
 				if (BigInt(after) > BigInt(Snowflake.generate()))
 					return res.status(422);
 				query.where.id = MoreThan(after);
+				query.order = { timestamp: "ASC" };
 			} else if (before) {
 				if (BigInt(before) > BigInt(Snowflake.generate()))
 					return res.status(422);


### PR DESCRIPTION
Same fix as #1155, the query didn't sort the results for `/api/channels/:id/messages?after=:id` so it always returned the most recent messages in the channel.