### PR TITLE
fix: reaction removing

### DIFF
--- a/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
+++ b/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
@@ -262,7 +262,7 @@ router.put(
 );
 
 router.delete(
-	"/:emoji/:user_id",
+	"/:emoji/:burst/:user_id",
 	route({
 		responses: {
 			204: {},


### PR DESCRIPTION
Discord changed the route for reaction removing since burst reactions were added and reactions cannot be removed. This PR fixes that