### PR TITLE
Implement opcode 8 (Request Guild Members)

### DIFF
--- a/src/gateway/events/Close.ts
+++ b/src/gateway/events/Close.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -50,7 +50,7 @@ export async function Close(this: WebSocket, code: number, reason: Buffer) {
 		} as SessionsReplace);
 		const session = sessions.first() || {
 			activities: [],
-			client_info: {},
+			client_status: {},
 			status: "offline",
 		};
 
@@ -68,7 +68,7 @@ export async function Close(this: WebSocket, code: number, reason: Buffer) {
 			data: {
 				user: userOrId,
 				activities: session.activities,
-				client_status: session?.client_info,
+				client_status: session?.client_status,
 				status: session.status,
 			},
 		} as PresenceUpdateEvent);

--- a/src/gateway/opcodes/Identify.ts
+++ b/src/gateway/opcodes/Identify.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -122,8 +122,8 @@ export async function onIdentify(this: WebSocket, data: Payload) {
 		session_id: this.session_id,
 		status: identify.presence?.status || "online",
 		client_info: {
-			client: identify.properties?.$device,
-			os: identify.properties?.os,
+			client: identify.properties?.device || identify.properties?.$device,
+			os: identify.properties?.os || identify.properties?.$os,
 			version: 0,
 		},
 		activities: identify.presence?.activities, // TODO: validation
@@ -372,7 +372,7 @@ export async function onIdentify(this: WebSocket, data: Payload) {
 			data: {
 				user: user.toPublicUser(),
 				activities: session.activities,
-				client_status: session.client_info,
+				client_status: session.client_status,
 				status: session.status,
 			},
 		} as PresenceUpdateEvent),

--- a/src/gateway/opcodes/LazyRequest.ts
+++ b/src/gateway/opcodes/LazyRequest.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -248,7 +248,7 @@ export async function onLazyRequest(this: WebSocket, { d }: Payload) {
 					d: {
 						user: user,
 						activities: session?.activities || [],
-						client_status: session?.client_info,
+						client_status: session?.client_status,
 						status: session?.status || "offline",
 					} as Presence,
 				});

--- a/src/gateway/opcodes/PresenceUpdate.ts
+++ b/src/gateway/opcodes/PresenceUpdate.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -35,14 +35,19 @@ export async function onPresenceUpdate(this: WebSocket, { d }: Payload) {
 		{ status: presence.status, activities: presence.activities },
 	);
 
+	const session = await Session.findOneOrFail({
+		select: ["client_status"],
+		where: { session_id: this.session_id },
+	});
+
 	await emitEvent({
 		event: "PRESENCE_UPDATE",
 		user_id: this.user_id,
 		data: {
 			user: await User.getPublicUser(this.user_id),
-			activities: presence.activities,
-			client_status: {}, // TODO:
 			status: presence.status,
+			activities: presence.activities,
+			client_status: session.client_status,
 		},
 	} as PresenceUpdateEvent);
 }

--- a/src/gateway/opcodes/RequestGuildMembers.ts
+++ b/src/gateway/opcodes/RequestGuildMembers.ts
@@ -1,23 +1,111 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { WebSocket } from "@spacebar/gateway";
+import {
+	getPermission,
+	GuildMembersChunkEvent,
+	Member,
+	Presence,
+	RequestGuildMembersSchema,
+} from "@spacebar/util";
+import {
+	WebSocket,
+	Payload,
+	OPCODES,
+	Send,
+} from "@spacebar/gateway";
+import { check } from "./instanceOf";
+import { FindManyOptions, In, Like } from "typeorm";
 
-export function onRequestGuildMembers(this: WebSocket) {
-	// return this.close(CLOSECODES.Unknown_error);
+export async function onRequestGuildMembers(this: WebSocket, { d }: Payload) {
+	// TODO: check data
+	check.call(this, RequestGuildMembersSchema, d);
+
+	const { guild_id, query, presences, nonce } =
+		d as RequestGuildMembersSchema;
+	let { limit, user_ids } =
+		d as RequestGuildMembersSchema;
+
+	if ("query" in d && (!limit || Number.isNaN(limit))) throw new Error("\"query\" requires \"limit\" to be set");
+	if ("query" in d && user_ids) throw new Error("\"query\" and \"user_ids\" are mutually exclusive");
+	if (user_ids && !Array.isArray(user_ids)) user_ids = [user_ids];
+	user_ids = user_ids as string[] | undefined;
+
+	// TODO: Configurable limit?
+	if ((query || (user_ids && user_ids.length > 0)) && (!limit || limit > 100)) limit = 100;
+
+	const permissions = await getPermission(this.user_id, guild_id);
+	permissions.hasThrow("VIEW_CHANNEL");
+
+	const whereQuery: any = {};
+	if (query) {
+		whereQuery.user = {
+			username: Like(query + "%")
+		};
+	} else if (user_ids && user_ids.length > 0) {
+		whereQuery.id = In(user_ids);
+	}
+
+	const memberFind: FindManyOptions = {
+		where: {
+			...whereQuery,
+			guild_id
+		},
+		relations: ["user", "roles", ...(presences ? ["presence"] : [])],
+	};
+	if (limit) memberFind.take = Math.abs(Number(limit || 100));
+	const members = await Member.find(memberFind);
+
+	const baseData = {
+		guild_id,
+		nonce,
+	}
+
+	const chunks: GuildMembersChunkEvent["data"][] = [];
+	while (members.length > 0) {
+		const chunk = members.splice(0, 1000);
+
+		const presenceList: Presence[] = [];
+		if (presences) {
+			for await (const member of chunk) {
+				presenceList.push(member.presence);
+				delete member.presence;
+			}
+		}
+
+		chunks.push({
+			...baseData,
+			members: chunk.map(member => member.toPublicMember()),
+			presences: presences ? presenceList : undefined,
+			chunk_index: chunks.length,
+			chunk_count: Math.ceil(members.length / 1000),
+		});
+	}
+
+	if (user_ids && user_ids.length > 0)
+		chunks[0].not_found = user_ids.filter(id => !members.some(member => member.user.id == id));
+
+	chunks.forEach((chunk) => {
+		Send(this, {
+			op: OPCODES.Dispatch,
+			s: this.sequence++,
+			t: "GUILD_MEMBERS_CHUNK",
+			d: chunk,
+		});
+	});
 }

--- a/src/util/entities/Session.ts
+++ b/src/util/entities/Session.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -19,7 +19,7 @@
 import { User } from "./User";
 import { BaseClass } from "./BaseClass";
 import { Column, Entity, JoinColumn, ManyToOne, RelationId } from "typeorm";
-import { Status } from "../interfaces/Status";
+import { ClientStatus, Status } from "../interfaces/Status";
 import { Activity } from "../interfaces/Activity";
 
 //TODO we need to remove all sessions on server start because if the server crashes without closing websockets it won't delete them
@@ -43,13 +43,15 @@ export class Session extends BaseClass {
 	@Column({ type: "simple-json", nullable: true })
 	activities: Activity[];
 
-	// TODO client_status
 	@Column({ type: "simple-json", select: false })
 	client_info: {
 		client: string;
 		os: string;
 		version: number;
 	};
+
+	@Column({ type: "simple-json" })
+	client_status: ClientStatus;
 
 	@Column({ nullable: false, type: "varchar" })
 	status: Status; //TODO enum

--- a/src/util/interfaces/Event.ts
+++ b/src/util/interfaces/Event.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -280,8 +280,8 @@ export interface GuildMembersChunkEvent extends Event {
 		members: PublicMember[];
 		chunk_index: number;
 		chunk_count: number;
-		not_found: string[];
-		presences: Presence[];
+		not_found?: string[];
+		presences?: Presence[];
 		nonce?: string;
 	};
 }

--- a/src/util/interfaces/Status.ts
+++ b/src/util/interfaces/Status.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -21,5 +21,6 @@ export type Status = "idle" | "dnd" | "online" | "offline" | "invisible";
 export interface ClientStatus {
 	desktop?: string; // e.g. Windows/Linux/Mac
 	mobile?: string; // e.g. iOS/Android
-	web?: string; // e.g. browser, bot account
+	web?: string; // e.g. browser, bot account, unknown
+	embedded?: string; // e.g. embedded
 }

--- a/src/util/migration/mariadb/1723347738541-client_status.ts
+++ b/src/util/migration/mariadb/1723347738541-client_status.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class client_status1723347738541 implements MigrationInterface {
+	name = "client_status1723347738541";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE `sessions` ADD `client_status` text NULL AFTER `client_info`",
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE `sessions` DROP COLUMN `client_status`",
+		);
+	}
+}

--- a/src/util/migration/mysql/1723347738541-client_status.ts
+++ b/src/util/migration/mysql/1723347738541-client_status.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class client_status1723347738541 implements MigrationInterface {
+	name = "client_status1723347738541";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE `sessions` ADD `client_status` text NULL AFTER `client_info`",
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE `sessions` DROP COLUMN `client_status`",
+		);
+	}
+}

--- a/src/util/migration/postgres/1723347738541-client_status.ts
+++ b/src/util/migration/postgres/1723347738541-client_status.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class client_status1723347738541 implements MigrationInterface {
+	name = "client_status1723347738541";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE sessions ADD client_status text NULL",
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE sessions DROP COLUMN client_status",
+		);
+	}
+}

--- a/src/util/schemas/RequestGuildMembersSchema.ts
+++ b/src/util/schemas/RequestGuildMembersSchema.ts
@@ -1,0 +1,35 @@
+/*
+	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
+	Copyright (C) 2023 Spacebar and Spacebar Contributors
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+export interface RequestGuildMembersSchema {
+	guild_id: string;
+	query?: string;
+	limit?: number;
+	presences?: boolean;
+	user_ids?: string | string[];
+	nonce?: string;
+}
+
+export const RequestGuildMembersSchema = {
+	guild_id: String,
+	$query: String,
+	$limit: Number,
+	$presences: Boolean,
+	$user_ids: [] as string | string[],
+	$nonce: String,
+};

--- a/src/util/schemas/index.ts
+++ b/src/util/schemas/index.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -58,6 +58,7 @@ export * from "./PurgeSchema";
 export * from "./RegisterSchema";
 export * from "./RelationshipPostSchema";
 export * from "./RelationshipPutSchema";
+export * from "./RequestGuildMembersSchema";
 export * from "./RoleModifySchema";
 export * from "./RolePositionUpdateSchema";
 export * from "./SelectProtocolSchema";


### PR DESCRIPTION
Implements opcode 8, mostly used by bots to request members within a server.

To support `presences`, `client_status` had to be added to sessions to be able to store and retrieve it. It's currently not possible to insert data into it, as I haven't been able to figure out where it comes from.

Closes #248