### PR TITLE
Make profile bio max length configurable

### DIFF
--- a/src/api/routes/users/#id/profile.ts
+++ b/src/api/routes/users/#id/profile.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -19,6 +19,8 @@
 import { route } from "@spacebar/api";
 import {
 	Badge,
+	Config,
+	FieldErrors,
 	Member,
 	PrivateUserProjection,
 	User,
@@ -135,6 +137,18 @@ router.patch(
 			where: { id: req.user_id },
 			select: [...PrivateUserProjection, "data"],
 		});
+
+		if (body.bio) {
+			const { maxBio } = Config.get().limits.user;
+			if (body.bio.length > maxBio) {
+				throw FieldErrors({
+					bio: {
+						code: "BIO_INVALID",
+						message: `Bio must be less than ${maxBio} in length`,
+					},
+				});
+			}
+		}
 
 		user.assign(body);
 		await user.save();

--- a/src/api/routes/users/@me/index.ts
+++ b/src/api/routes/users/@me/index.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -184,6 +184,18 @@ router.patch(
 					discriminator: {
 						code: "INVALID_DISCRIMINATOR",
 						message: "This discriminator is already in use.",
+					},
+				});
+			}
+		}
+
+		if (body.bio) {
+			const { maxBio } = Config.get().limits.user;
+			if (body.bio.length > maxBio) {
+				throw FieldErrors({
+					bio: {
+						code: "BIO_INVALID",
+						message: `Bio must be less than ${maxBio} in length`,
 					},
 				});
 			}

--- a/src/util/config/types/subconfigurations/limits/UserLimits.ts
+++ b/src/util/config/types/subconfigurations/limits/UserLimits.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -20,4 +20,5 @@ export class UserLimits {
 	maxGuilds: number = 1048576;
 	maxUsername: number = 32;
 	maxFriends: number = 5000;
+	maxBio: number = 190;
 }

--- a/src/util/entities/User.ts
+++ b/src/util/entities/User.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -130,7 +130,7 @@ export class User extends BaseClass {
 	bot: boolean = false; // if user is bot
 
 	@Column()
-	bio: string = ""; // short description of the user (max 190 chars -> should be configurable)
+	bio: string = ""; // short description of the user
 
 	@Column()
 	system: boolean = false; // shouldn't be used, the api sends this field type true, if the generated message comes from a system generated author

--- a/src/util/schemas/UserModifySchema.ts
+++ b/src/util/schemas/UserModifySchema.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -23,9 +23,6 @@ export interface UserModifySchema {
 	 */
 	username?: string;
 	avatar?: string | null;
-	/**
-	 * @maxLength 1024
-	 */
 	bio?: string;
 	accent_color?: number;
 	banner?: string | null;


### PR DESCRIPTION
As suggested this sets the default limit of the user profile bio ("about me") to 190 characters, but makes it configurable.

Currently there's no limit for `PATCH /api/users/<ID>/profile` and 1024 for `PATCH /api/users/@me`.