### PR TITLE
Icon for discovery categories & fix "primary_only"

### DIFF
--- a/src/api/routes/discovery.ts
+++ b/src/api/routes/discovery.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -39,8 +39,8 @@ router.get(
 		const { primary_only } = req.query;
 
 		const out = primary_only
-			? await Categories.find()
-			: await Categories.find({ where: { is_primary: true } });
+			? await Categories.find({ where: { is_primary: true } })
+			: await Categories.find();
 
 		res.send(out);
 	},

--- a/src/util/entities/Categories.ts
+++ b/src/util/entities/Categories.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -46,6 +46,10 @@ export class Categories extends BaseClassWithoutId {
 	@Column({ type: "simple-json" })
 	localizations: string;
 
+	// Whether to show the category prominently (e.g. in a sidebar) instead of only secondary (e.g. in search results)
 	@Column({ nullable: true })
 	is_primary: boolean;
+
+	@Column({ nullable: true })
+	icon?: string;
 }

--- a/src/util/migration/mariadb/1723577874393-discoveryCategoryIcon.ts
+++ b/src/util/migration/mariadb/1723577874393-discoveryCategoryIcon.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DiscoveryCategoryIcon1723577874393 implements MigrationInterface {
+	name = "DiscoveryCategoryIcon1723577874393";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE `categories` ADD `icon` text NULL",
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query("ALTER TABLE `categories` DROP COLUMN `icon`");
+	}
+}

--- a/src/util/migration/mysql/1723577874393-discoveryCategoryIcon.ts
+++ b/src/util/migration/mysql/1723577874393-discoveryCategoryIcon.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DiscoveryCategoryIcon1723577874393 implements MigrationInterface {
+	name = "DiscoveryCategoryIcon1723577874393";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			"ALTER TABLE `categories` ADD `icon` text NULL",
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query("ALTER TABLE `categories` DROP COLUMN `icon`");
+	}
+}

--- a/src/util/migration/postgres/1723577874393-discoveryCategoryIcon.ts
+++ b/src/util/migration/postgres/1723577874393-discoveryCategoryIcon.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DiscoveryCategoryIcon1723577874393 implements MigrationInterface {
+	name = "DiscoveryCategoryIcon1723577874393";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query("ALTER TABLE categories ADD icon text NULL");
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query("ALTER TABLE categories DROP COLUMN icon");
+	}
+}


### PR DESCRIPTION
Now categories in the guild discovery can have an optional icon, it looks better than just showing text.

Also for some reason the `primary_only` filter seems to have been inverted? Should be fixed now