### PR TITLE
Send 204 status

### DIFF
--- a/src/api/routes/applications/#id/bot/index.ts
+++ b/src/api/routes/applications/#id/bot/index.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -57,7 +57,7 @@ router.post(
 
 		res.send({
 			token: await generateToken(user.id),
-		}).status(204);
+		});
 	},
 );
 

--- a/src/api/routes/channels/#channel_id/messages/index.ts
+++ b/src/api/routes/channels/#channel_id/messages/index.ts
@@ -155,12 +155,20 @@ router.get(
 		} else {
 			if (after) {
 				if (BigInt(after) > BigInt(Snowflake.generate()))
-					return res.status(422);
+					throw new HTTPError(
+						"after parameter must not be greater than current time",
+						422,
+					);
+
 				query.where.id = MoreThan(after);
 				query.order = { timestamp: "ASC" };
 			} else if (before) {
 				if (BigInt(before) > BigInt(Snowflake.generate()))
-					return res.status(422);
+					throw new HTTPError(
+						"before parameter must not be greater than current time",
+						422,
+					);
+
 				query.where.id = LessThan(before);
 			}
 

--- a/src/api/routes/read-states/ack-bulk.ts
+++ b/src/api/routes/read-states/ack-bulk.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -60,7 +60,7 @@ router.post(
 			}),
 		]);
 
-		return res.status(204);
+		return res.sendStatus(204);
 	},
 );
 

--- a/src/api/routes/users/@me/notes.ts
+++ b/src/api/routes/users/@me/notes.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -107,7 +107,7 @@ router.put(
 			user_id: owner.id,
 		});
 
-		return res.status(204);
+		return res.sendStatus(204);
 	},
 );
 


### PR DESCRIPTION
- Sends the 204 status instead of only setting it, causing the request to time out
- Proper error for the `after`/`before` parameters
- Remove `.status(204)` when sending a body

HTTP [204 No Content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204)