### PR TITLE
Consistent username length requirement

### DIFF
--- a/src/api/routes/auth/register.ts
+++ b/src/api/routes/auth/register.ts
@@ -291,8 +291,8 @@ router.post(
 		if (body.username.length > maxUsername) {
 			throw FieldErrors({
 				username: {
-					code: "USERNAME_INVALID",
-					message: `Username must be less than ${maxUsername} in length`,
+					code: "BASE_TYPE_BAD_LENGTH",
+					message: `Must be between 2 and ${maxUsername} in length.`,
 				},
 			});
 		}

--- a/src/api/routes/auth/register.ts
+++ b/src/api/routes/auth/register.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -283,6 +283,16 @@ router.post(
 				email: {
 					code: "TOO_MANY_REGISTRATIONS",
 					message: req.t("auth:register.TOO_MANY_REGISTRATIONS"),
+				},
+			});
+		}
+
+		const { maxUsername } = Config.get().limits.user;
+		if (body.username.length > maxUsername) {
+			throw FieldErrors({
+				username: {
+					code: "USERNAME_INVALID",
+					message: `Username must be less than ${maxUsername} in length`,
 				},
 			});
 		}

--- a/src/api/routes/users/@me/index.ts
+++ b/src/api/routes/users/@me/index.ts
@@ -155,8 +155,8 @@ router.patch(
 			if (check_username.length > maxUsername) {
 				throw FieldErrors({
 					username: {
-						code: "USERNAME_INVALID",
-						message: `Username must be less than ${maxUsername} in length`,
+						code: "BASE_TYPE_BAD_LENGTH",
+						message: `Must be between 2 and ${maxUsername} in length.`,
 					},
 				});
 			}

--- a/src/util/schemas/RegisterSchema.ts
+++ b/src/util/schemas/RegisterSchema.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -19,7 +19,6 @@
 export interface RegisterSchema {
 	/**
 	 * @minLength 2
-	 * @maxLength 32
 	 */
 	username: string;
 	/**

--- a/src/util/schemas/UserModifySchema.ts
+++ b/src/util/schemas/UserModifySchema.ts
@@ -18,8 +18,7 @@
 
 export interface UserModifySchema {
 	/**
-	 * @minLength 1
-	 * @maxLength 100
+	 * @minLength 2
 	 */
 	username?: string;
 	avatar?: string | null;


### PR DESCRIPTION
Currently, depending on the endpoint used, there's a minimum char count of 2 vs. 1, and maximum char count 32 vs. 100 for usernames.

This PR sets the requirement for usernames of users (not bots/webhooks) to minimum 2 characters, and maximum the value of the config `limits_user_maxUsername` (32 by default).
