### PR TITLE
Bug fixes & handling for >75k/large_threshold guilds in Request Guild Members

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -6262,7 +6262,21 @@
                 "type": "object",
                 "properties": {
                     "guild_id": {
-                        "type": "string"
+                        "anyOf": [
+                            {
+                                "type": "array",
+                                "items": [
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "minItems": 1,
+                                "maxItems": 1
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
                     },
                     "query": {
                         "type": "string"

--- a/src/gateway/opcodes/Identify.ts
+++ b/src/gateway/opcodes/Identify.ts
@@ -82,6 +82,7 @@ export async function onIdentify(this: WebSocket, data: Payload) {
 	const identify: IdentifySchema = data.d;
 
 	this.capabilities = new Capabilities(identify.capabilities || 0);
+	this.large_threshold = identify.large_threshold || 250;
 
 	const user = await tryGetUserFromToken(identify.token, {
 		relations: ["relationships", "relationships.to", "settings"],

--- a/src/gateway/util/WebSocket.ts
+++ b/src/gateway/util/WebSocket.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -43,4 +43,5 @@ export interface WebSocket extends WS {
 	listen_options: ListenEventOpts;
 	capabilities?: Capabilities;
 	// client?: Client;
+	large_threshold: number;
 }

--- a/src/util/schemas/RequestGuildMembersSchema.ts
+++ b/src/util/schemas/RequestGuildMembersSchema.ts
@@ -26,7 +26,7 @@ export interface RequestGuildMembersSchema {
 }
 
 export const RequestGuildMembersSchema = {
-	guild_id: [] as string | string[],
+	guild_id: "" as string | string[],
 	$query: String,
 	$limit: Number,
 	$presences: Boolean,


### PR DESCRIPTION
Fixes two issues with `guild_id` and `user_ids` only accepting an array instead of only a string while both should technically be able to support strings too.

Also, there was a bug that occurred when requesting only non-existent user IDs, therefore erroring as `chunks[0].not_found` wasn't defined because there wasn't any other member that filled the `chunks` array.

The >75k or >large_threshold member count code was written in https://github.com/spacebarchat/server/commit/8313367fdb053bcbb772b3f1c667663392cb5b02 by @Puyodead1.