### PR TITLE
Send "pinned" as "true" in pins update event

### DIFF
--- a/src/api/routes/channels/#channel_id/pins.ts
+++ b/src/api/routes/channels/#channel_id/pins.ts
@@ -1,24 +1,23 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { route } from "@spacebar/api";
 import {
-	Channel,
 	ChannelPinsUpdateEvent,
 	Config,
 	DiscordApiErrors,
@@ -60,8 +59,10 @@ router.put(
 		if (pinned_count >= maxPins)
 			throw DiscordApiErrors.MAXIMUM_PINS.withParams(maxPins);
 
+		message.pinned = true;
+
 		await Promise.all([
-			Message.update({ id: message_id }, { pinned: true }),
+			message.save(),
 			emitEvent({
 				event: "MESSAGE_UPDATE",
 				channel_id,
@@ -98,31 +99,27 @@ router.delete(
 	async (req: Request, res: Response) => {
 		const { channel_id, message_id } = req.params;
 
-		const channel = await Channel.findOneOrFail({
-			where: { id: channel_id },
-		});
-		if (channel.guild_id) req.permission?.hasThrow("MANAGE_MESSAGES");
-
 		const message = await Message.findOneOrFail({
 			where: { id: message_id },
 		});
+
+		if (message.guild_id) req.permission?.hasThrow("MANAGE_MESSAGES");
+
 		message.pinned = false;
 
 		await Promise.all([
 			message.save(),
-
 			emitEvent({
 				event: "MESSAGE_UPDATE",
 				channel_id,
 				data: message,
 			} as MessageUpdateEvent),
-
 			emitEvent({
 				event: "CHANNEL_PINS_UPDATE",
 				channel_id,
 				data: {
 					channel_id,
-					guild_id: channel.guild_id,
+					guild_id: message.guild_id,
 					last_pin_timestamp: undefined,
 				},
 			} as ChannelPinsUpdateEvent),


### PR DESCRIPTION
Currently, when pinning a message, as expected a `MESSAGE_UPDATE` gateway is sent. However, the `pinned` property is set to `false` instead of the expected `true` - unlike when unpinning a message, which sets it to `false` before sending the event.

This PR fixes the `pinned` property for the `CHANNEL_PINS_UPDATE` event and simplifies the unpinning code to be more similar to the pinning one.