### PR TITLE
Don't expose user existence on Forgot Password endpoint

### DIFF
--- a/src/api/routes/auth/forgot.ts
+++ b/src/api/routes/auth/forgot.ts
@@ -1,31 +1,24 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { getIpAdress, route, verifyCaptcha } from "@spacebar/api";
-import {
-	Config,
-	Email,
-	FieldErrors,
-	ForgotPasswordSchema,
-	User,
-} from "@spacebar/util";
+import { Config, Email, ForgotPasswordSchema, User } from "@spacebar/util";
 import { Request, Response, Router } from "express";
-import { HTTPError } from "lambert-server";
 const router = Router();
 
 router.post(
@@ -36,9 +29,6 @@ router.post(
 			204: {},
 			400: {
 				body: "APIErrorOrCaptchaResponse",
-			},
-			500: {
-				body: "APIErrorResponse",
 			},
 		},
 	}),
@@ -71,50 +61,20 @@ router.post(
 			}
 		}
 
-		const user = await User.findOneOrFail({
+		res.sendStatus(204);
+
+		const user = await User.findOne({
 			where: [{ phone: login }, { email: login }],
-			select: ["username", "id", "disabled", "deleted", "email"],
-			relations: ["security_keys"],
-		}).catch(() => {
-			throw FieldErrors({
-				login: {
-					message: req.t("auth:password_reset.EMAIL_DOES_NOT_EXIST"),
-					code: "EMAIL_DOES_NOT_EXIST",
-				},
-			});
-		});
+			select: ["username", "id", "email"],
+		}).catch(() => {});
 
-		if (!user.email)
-			throw FieldErrors({
-				login: {
-					message:
-						"This account does not have an email address associated with it.",
-					code: "NO_EMAIL",
-				},
-			});
-
-		if (user.deleted)
-			return res.status(400).json({
-				message: "This account is scheduled for deletion.",
-				code: 20011,
-			});
-
-		if (user.disabled)
-			return res.status(400).json({
-				message: req.t("auth:login.ACCOUNT_DISABLED"),
-				code: 20013,
-			});
-
-		return await Email.sendResetPassword(user, user.email)
-			.then(() => {
-				return res.sendStatus(204);
-			})
-			.catch((e) => {
+		if (user && user.email) {
+			Email.sendResetPassword(user, user.email).catch((e) => {
 				console.error(
-					`Failed to send password reset email to ${user.username}#${user.discriminator}: ${e}`,
+					`Failed to send password reset email to ${user.username}#${user.discriminator} (${user.id}): ${e}`,
 				);
-				throw new HTTPError("Failed to send password reset email", 500);
 			});
+		}
 	},
 );
 


### PR DESCRIPTION
This PR makes the server return a HTTP `204 No Content` success response when requesting a password reset, regardless of the user existing or not, as long as the captcha (if enabled) was passed.

While this definitively hurts the user experience, it's [recommended by OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html#forgot-password-request:~:text=a%20secure%20process%3A-,Return%20a%20consistent%20message%20for%20both%20existent%20and%20non%2Dexistent%20accounts.,-Ensure%20that%20responses), and even if Big Corp does it like that, they might have other tracking measures or ratelimits to prevent brute-force attacks, or might just be vulnerable as well.

Also removes the "Account disabled/scheduled for deletion" error to prevent timing attacks and instead always sends an email. Those checks (as well as MFA verification!) should be handled after the user (and therefore the access of the user to the email account) was verified.

To my knowledge, there's no Spacebar client with a "Forgot password" button nor a server template to handle password resets.

