### PR TITLE
Fix updating vanity URL & widget.json

### DIFF
--- a/src/api/routes/guilds/#guild_id/vanity-url.ts
+++ b/src/api/routes/guilds/#guild_id/vanity-url.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -108,30 +108,23 @@ router.patch(
 		});
 
 		if (!guild.features.includes("ALIASABLE_NAMES")) {
-			await Invite.update(
-				{ guild_id },
-				{
-					code: code,
-				},
-			);
-
-			return res.json({ code });
+			await Invite.delete({ guild_id, vanity_url: true });
 		}
 
 		await Invite.create({
 			vanity_url: true,
-			code: code,
+			code,
 			temporary: false,
 			uses: 0,
 			max_uses: 0,
 			max_age: 0,
 			created_at: new Date(),
-			expires_at: new Date(),
 			guild_id: guild_id,
 			channel_id: id,
+			flags: 0,
 		}).save();
 
-		return res.json({ code: code });
+		return res.json({ code });
 	},
 );
 

--- a/src/api/routes/guilds/#guild_id/widget.json.ts
+++ b/src/api/routes/guilds/#guild_id/widget.json.ts
@@ -57,6 +57,10 @@ router.get(
 			where: { id: guild_id },
 			select: {
 				channel_ordering: true,
+				widget_channel_id: true,
+				widget_enabled: true,
+				presence_count: true,
+				name: true,
 			},
 		});
 		if (!guild.widget_enabled) throw DiscordApiErrors.EMBED_DISABLED;
@@ -82,6 +86,7 @@ router.get(
 				created_at: new Date(),
 				guild_id,
 				channel_id: guild.widget_channel_id,
+				flags: 0,
 			}).save();
 		}
 


### PR DESCRIPTION
- Currently, setting a vanity url on a server with no or more than one invite fails due either a logical error or PRIMARY key constraints when trying to update previous invite links. This PR deletes previous vanity URLs (normal invite links aren't affected) and inserts the new one.
- `flags` has no default value, so it has to be set to `0` (default from channel invite create endpoint¹)
- Removed `expires_at: new Date(),` to be consistent with channel invite create endpoint²
- typeorm is unintuitive (when specifying `select`, it only selects those properties and uses the default for all others) so I broke widget.json in #1184. This PR adds the required properties to the requested ones.

#### References

¹
https://github.com/spacebarchat/server/blob/f00a31540e8d887994358c32211c29e35fb9d674/src/api/routes/channels/%23channel_id/invites.ts#L83

²
https://github.com/spacebarchat/server/blob/f00a31540e8d887994358c32211c29e35fb9d674/src/api/routes/channels/%23channel_id/invites.ts#L67-L69