### PR TITLE
Add method to NO_AUTHORIZATION_ROUTES

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -10936,13 +10936,8 @@
                 ]
             }
         },
-        "/scheduled-maintenances/upcoming_json/scheduled-maintenances/upcoming.json": {
+        "/scheduled-maintenances/upcoming.json/": {
             "get": {
-                "security": [
-                    {
-                        "bearer": []
-                    }
-                ],
                 "responses": {
                     "default": {
                         "description": "No description available"
@@ -10950,12 +10945,6 @@
                 },
                 "tags": [
                     "scheduled-maintenances"
-                ],
-                "x-badges": [
-                    {
-                        "label": "Spacebar-only",
-                        "color": "red"
-                    }
                 ]
             }
         },
@@ -11341,11 +11330,6 @@
         },
         "/invites/{code}": {
             "get": {
-                "security": [
-                    {
-                        "bearer": []
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "",

--- a/scripts/openapi.js
+++ b/scripts/openapi.js
@@ -134,8 +134,8 @@ function apiRoutes(missingRoutes) {
 
 		if (
 			!NO_AUTHORIZATION_ROUTES.some((x) => {
-				if (typeof x === "string") return path.startsWith(x);
-				return x.test(path);
+				if (typeof x === "string") return (method.toUpperCase() + " " + path).startsWith(x);
+				return x.test(method.toUpperCase() + " " + path);
 			})
 		) {
 			obj.security = [{ bearer: [] }];

--- a/scripts/openapi.js
+++ b/scripts/openapi.js
@@ -134,7 +134,8 @@ function apiRoutes(missingRoutes) {
 
 		if (
 			!NO_AUTHORIZATION_ROUTES.some((x) => {
-				if (typeof x === "string") return (method.toUpperCase() + " " + path).startsWith(x);
+				if (typeof x === "string")
+					return (method.toUpperCase() + " " + path).startsWith(x);
 				return x.test(method.toUpperCase() + " " + path);
 			})
 		) {

--- a/src/api/middlewares/Authentication.ts
+++ b/src/api/middlewares/Authentication.ts
@@ -80,7 +80,8 @@ export async function Authentication(
 	const url = req.url.replace(API_PREFIX, "");
 	if (
 		NO_AUTHORIZATION_ROUTES.some((x) => {
-			if (typeof x === "string") return (req.method + " " + url).startsWith(x);
+			if (typeof x === "string")
+				return (req.method + " " + url).startsWith(x);
 			return x.test(req.method + " " + url);
 		})
 	)

--- a/src/api/middlewares/Authentication.ts
+++ b/src/api/middlewares/Authentication.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -23,37 +23,37 @@ import { HTTPError } from "lambert-server";
 
 export const NO_AUTHORIZATION_ROUTES = [
 	// Authentication routes
-	"/auth/login",
-	"/auth/register",
-	"/auth/location-metadata",
-	"/auth/mfa/totp",
-	"/auth/mfa/webauthn",
-	"/auth/verify",
-	"/auth/forgot",
-	"/auth/reset",
+	"POST /auth/login",
+	"POST /auth/register",
+	"GET /auth/location-metadata",
+	"POST /auth/mfa/",
+	"POST /auth/verify",
+	"POST /auth/forgot",
+	"POST /auth/reset",
+	"GET /invites/",
 	// Routes with a seperate auth system
-	/\/webhooks\/\d+\/\w+\/?/, // no token requires auth
+	/POST \/webhooks\/\d+\/\w+\/?/, // no token requires auth
 	// Public information endpoints
-	"/ping",
-	"/gateway",
-	"/experiments",
-	"/updates",
-	"/download",
-	"/scheduled-maintenances/upcoming.json",
+	"GET /ping",
+	"GET /gateway",
+	"GET /experiments",
+	"GET /updates",
+	"GET /download",
+	"GET /scheduled-maintenances/upcoming.json",
 	// Public kubernetes integration
-	"/-/readyz",
-	"/-/healthz",
+	"GET /-/readyz",
+	"GET /-/healthz",
 	// Client analytics
-	"/science",
-	"/track",
+	"POST /science",
+	"POST /track",
 	// Public policy pages
-	"/policies/instance",
+	"GET /policies/instance/",
 	// Oauth callback
 	"/oauth2/callback",
 	// Asset delivery
-	/\/guilds\/\d+\/widget\.(json|png)/,
+	/GET \/guilds\/\d+\/widget\.(json|png)/,
 	// Connections
-	/\/connections\/\w+\/callback/,
+	/POST \/connections\/\w+\/callback/,
 ];
 
 export const API_PREFIX = /^\/api(\/v\d+)?/;
@@ -78,11 +78,10 @@ export async function Authentication(
 ) {
 	if (req.method === "OPTIONS") return res.sendStatus(204);
 	const url = req.url.replace(API_PREFIX, "");
-	if (url.startsWith("/invites") && req.method === "GET") return next();
 	if (
 		NO_AUTHORIZATION_ROUTES.some((x) => {
-			if (typeof x === "string") return url.startsWith(x);
-			return x.test(url);
+			if (typeof x === "string") return (req.method + " " + url).startsWith(x);
+			return x.test(req.method + " " + url);
 		})
 	)
 		return next();

--- a/src/api/routes/scheduled-maintenances/upcoming.json.ts
+++ b/src/api/routes/scheduled-maintenances/upcoming.json.ts
@@ -20,15 +20,11 @@ import { Router, Request, Response } from "express";
 import { route } from "@spacebar/api";
 const router = Router();
 
-router.get(
-	"/",
-	route({}),
-	async (req: Request, res: Response) => {
-		res.json({
-			page: {},
-			scheduled_maintenances: {},
-		});
-	},
-);
+router.get("/", route({}), async (req: Request, res: Response) => {
+	res.json({
+		page: {},
+		scheduled_maintenances: {},
+	});
+});
 
 export default router;

--- a/src/api/routes/scheduled-maintenances/upcoming.json.ts
+++ b/src/api/routes/scheduled-maintenances/upcoming.json.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -21,7 +21,7 @@ import { route } from "@spacebar/api";
 const router = Router();
 
 router.get(
-	"/scheduled-maintenances/upcoming.json",
+	"/",
 	route({}),
 	async (req: Request, res: Response) => {
 		res.json({


### PR DESCRIPTION
`NO_AUTHORIZATION_ROUTES` previously only checked the request path. This PR makes it check the HTTP method too.

By doing that, the `GET /api/invite/<code>` endpoint is now displayed correctly as "no authorization required".

I've also renamed `scheduled-maintenances/upcoming_json.ts` to `scheduled-maintenances/upcoming.json.ts` to fix the path, the current one `/scheduled-maintenances/upcoming_json/scheduled-maintenances/upcoming.json` is broken.