### PR TITLE
Built-in image proxy fixes

### DIFF
--- a/src/api/middlewares/Authentication.ts
+++ b/src/api/middlewares/Authentication.ts
@@ -55,7 +55,7 @@ export const NO_AUTHORIZATION_ROUTES = [
 	// Connections
 	/POST \/connections\/\w+\/callback/,
 	// Image proxy
-	/GET \/imageproxy\/[A-Za-z0-9+/]\/\d+x\d+\/.+/
+	/GET \/imageproxy\/[A-Za-z0-9+/]\/\d+x\d+\/.+/,
 ];
 
 export const API_PREFIX = /^\/api(\/v\d+)?/;

--- a/src/api/middlewares/Authentication.ts
+++ b/src/api/middlewares/Authentication.ts
@@ -54,6 +54,8 @@ export const NO_AUTHORIZATION_ROUTES = [
 	/GET \/guilds\/\d+\/widget\.(json|png)/,
 	// Connections
 	/POST \/connections\/\w+\/callback/,
+	// Image proxy
+	/GET \/imageproxy\/[A-Za-z0-9+/]\/\d+x\d+\/.+/
 ];
 
 export const API_PREFIX = /^\/api(\/v\d+)?/;

--- a/src/api/middlewares/ImageProxy.ts
+++ b/src/api/middlewares/ImageProxy.ts
@@ -67,7 +67,7 @@ export async function ImageProxy(req: Request, res: Response) {
 		if (!crypto.timingSafeEqual(Buffer.from(hash), Buffer.from(path[0])))
 			throw new Error("Invalid signature");
 	} catch {
-		console.log("Invalid signature, expected " + hash + " got " + path[0]);
+		console.log("[ImageProxy] Invalid signature, expected " + hash + " but got " + path[0]);
 		res.status(403).send("Invalid signature");
 		return;
 	}
@@ -75,7 +75,7 @@ export async function ImageProxy(req: Request, res: Response) {
 	const abort = new AbortController();
 	setTimeout(() => abort.abort(), 5000);
 
-	const request = await fetch(path.slice(2).join("/"), {
+	const request = await fetch("https://" + path.slice(2).join("/"), {
 		headers: {
 			"User-Agent": "SpacebarImageProxy/1.0.0 (https://spacebar.chat)",
 		},

--- a/src/api/middlewares/ImageProxy.ts
+++ b/src/api/middlewares/ImageProxy.ts
@@ -67,7 +67,12 @@ export async function ImageProxy(req: Request, res: Response) {
 		if (!crypto.timingSafeEqual(Buffer.from(hash), Buffer.from(path[0])))
 			throw new Error("Invalid signature");
 	} catch {
-		console.log("[ImageProxy] Invalid signature, expected " + hash + " but got " + path[0]);
+		console.log(
+			"[ImageProxy] Invalid signature, expected " +
+				hash +
+				" but got " +
+				path[0],
+		);
 		res.status(403).send("Invalid signature");
 		return;
 	}


### PR DESCRIPTION
I've missed a few things in #1126:
1. Proxy shouldn't require auth because it's not really possible to handle that in clients across domains
2. Imagor leaves out the protocol in the proxy URL, therefore the proxy has to re-add it. Given that SSL is quite common nowadays using `https://` should be fine.