### PR TITLE
fix: display pinned message author

### DIFF
--- a/src/api/routes/channels/#channel_id/pins.ts
+++ b/src/api/routes/channels/#channel_id/pins.ts
@@ -179,6 +179,7 @@ router.get(
 
 		const pins = await Message.find({
 			where: { channel_id: channel_id, pinned: true },
+			relations: ["author"],
 		});
 
 		res.send(pins);


### PR DESCRIPTION
Currently when getting channel pins `author` is an empty object. This PR fixes that.

Before:
![obraz](https://github.com/user-attachments/assets/11a86cc9-f4fa-478a-97ad-e639b17c679d)
After:
![obraz](https://github.com/user-attachments/assets/d6bd2d22-97a0-4c0b-a15d-64fcffb68494)
