### PR TITLE
Fix HEAD requests for no authorization routes

### DIFF
--- a/src/api/middlewares/Authentication.ts
+++ b/src/api/middlewares/Authentication.ts
@@ -32,7 +32,7 @@ export const NO_AUTHORIZATION_ROUTES = [
 	"POST /auth/reset",
 	"GET /invites/",
 	// Routes with a seperate auth system
-	/(POST|HEAD) \/webhooks\/\d+\/\w+\/?/, // no token requires auth
+	/^(POST|HEAD) \/webhooks\/\d+\/\w+\/?/, // no token requires auth
 	// Public information endpoints
 	"GET /ping",
 	"GET /gateway",
@@ -51,11 +51,11 @@ export const NO_AUTHORIZATION_ROUTES = [
 	// Oauth callback
 	"/oauth2/callback",
 	// Asset delivery
-	/(GET|HEAD) \/guilds\/\d+\/widget\.(json|png)/,
+	/^(GET|HEAD) \/guilds\/\d+\/widget\.(json|png)/,
 	// Connections
-	/(POST|HEAD) \/connections\/\w+\/callback/,
+	/^(POST|HEAD) \/connections\/\w+\/callback/,
 	// Image proxy
-	/(GET|HEAD) \/imageproxy\/[A-Za-z0-9+/]\/\d+x\d+\/.+/,
+	/^(GET|HEAD) \/imageproxy\/[A-Za-z0-9+/]\/\d+x\d+\/.+/,
 ];
 
 export const API_PREFIX = /^\/api(\/v\d+)?/;

--- a/src/api/middlewares/Authentication.ts
+++ b/src/api/middlewares/Authentication.ts
@@ -32,7 +32,7 @@ export const NO_AUTHORIZATION_ROUTES = [
 	"POST /auth/reset",
 	"GET /invites/",
 	// Routes with a seperate auth system
-	/POST \/webhooks\/\d+\/\w+\/?/, // no token requires auth
+	/(POST|HEAD) \/webhooks\/\d+\/\w+\/?/, // no token requires auth
 	// Public information endpoints
 	"GET /ping",
 	"GET /gateway",
@@ -51,11 +51,11 @@ export const NO_AUTHORIZATION_ROUTES = [
 	// Oauth callback
 	"/oauth2/callback",
 	// Asset delivery
-	/GET \/guilds\/\d+\/widget\.(json|png)/,
+	/(GET|HEAD) \/guilds\/\d+\/widget\.(json|png)/,
 	// Connections
-	/POST \/connections\/\w+\/callback/,
+	/(POST|HEAD) \/connections\/\w+\/callback/,
 	// Image proxy
-	/GET \/imageproxy\/[A-Za-z0-9+/]\/\d+x\d+\/.+/,
+	/(GET|HEAD) \/imageproxy\/[A-Za-z0-9+/]\/\d+x\d+\/.+/,
 ];
 
 export const API_PREFIX = /^\/api(\/v\d+)?/;
@@ -82,6 +82,12 @@ export async function Authentication(
 	const url = req.url.replace(API_PREFIX, "");
 	if (
 		NO_AUTHORIZATION_ROUTES.some((x) => {
+			if (req.method == "HEAD") {
+				if (typeof x === "string")
+					return url.startsWith(x.split(" ").slice(1).join(" "));
+				return x.test(req.method + " " + url);
+			}
+
 			if (typeof x === "string")
 				return (req.method + " " + url).startsWith(x);
 			return x.test(req.method + " " + url);


### PR DESCRIPTION
I broke this in #1197 .-.

HEAD requests should still be allowed, even if they're not specified in the list of allowed methods. Not sure how to automate it with regex, so it has to be added manually for now.