### PR TITLE
Stop sending X-Powered-By & use API CORS + BodyParser middlewares in CDN

### DIFF
--- a/src/api/Server.ts
+++ b/src/api/Server.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -98,6 +98,7 @@ export class SpacebarServer extends Server {
 		}
 
 		this.app.set("json replacer", JSONReplacer);
+		this.app.disable("x-powered-by");
 
 		this.app.use(CORS);
 		this.app.use(BodyParser({ inflate: true, limit: "10mb" }));

--- a/src/cdn/Server.ts
+++ b/src/cdn/Server.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -22,7 +22,8 @@ import path from "path";
 import avatarsRoute from "./routes/avatars";
 import guildProfilesRoute from "./routes/guild-profiles";
 import iconsRoute from "./routes/role-icons";
-import bodyParser from "body-parser";
+import { CORS } from "../api/middlewares/CORS";
+import { BodyParser } from "../api/middlewares/BodyParser";
 
 export type CDNServerOptions = ServerOptions;
 
@@ -38,24 +39,10 @@ export class CDNServer extends Server {
 		await Config.init();
 		await Sentry.init(this.app);
 
-		this.app.use((req, res, next) => {
-			res.set("Access-Control-Allow-Origin", "*");
-			// TODO: use better CSP policy
-			res.set(
-				"Content-security-policy",
-				"default-src *  data: blob: filesystem: about: ws: wss: 'unsafe-inline' 'unsafe-eval'; script-src * data: blob: 'unsafe-inline' 'unsafe-eval'; connect-src * data: blob: 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src * data: blob: ; style-src * data: blob: 'unsafe-inline'; font-src * data: blob: 'unsafe-inline';",
-			);
-			res.set(
-				"Access-Control-Allow-Headers",
-				req.header("Access-Control-Request-Headers") || "*",
-			);
-			res.set(
-				"Access-Control-Allow-Methods",
-				req.header("Access-Control-Request-Methods") || "*",
-			);
-			next();
-		});
-		this.app.use(bodyParser.json({ inflate: true, limit: "10mb" }));
+		this.app.disable("x-powered-by");
+
+		this.app.use(CORS);
+		this.app.use(BodyParser({ inflate: true, limit: "10mb" }));
 
 		await registerRoutes(this, path.join(__dirname, "routes/"));
 


### PR DESCRIPTION
re: X-Powered-By: https://expressjs.com/en/advanced/best-practice-security.html#reduce-fingerprinting

CDN and API got the same headers, so why not re-use the existing function for CDN.