### PR TITLE
Fix new app property migration disallowing NULL

### DIFF
--- a/src/util/migration/mariadb/1725090962922-applicationProperties.ts
+++ b/src/util/migration/mariadb/1725090962922-applicationProperties.ts
@@ -5,10 +5,10 @@ export class ApplicationProperties1725090962922 implements MigrationInterface {
 
 	public async up(queryRunner: QueryRunner): Promise<void> {
 		await queryRunner.query(
-			"ALTER TABLE `applications` ADD COLUMN `guild_id` VARCHAR(255) NOT NULL",
+			"ALTER TABLE `applications` ADD COLUMN `guild_id` VARCHAR(255) DEFAULT NULL",
 		);
 		await queryRunner.query(
-			"ALTER TABLE `applications` ADD COLUMN `custom_install_url` TEXT NOT NULL",
+			"ALTER TABLE `applications` ADD COLUMN `custom_install_url` TEXT DEFAULT NULL",
 		);
 	}
 

--- a/src/util/migration/mysql/1725090962922-applicationProperties.ts
+++ b/src/util/migration/mysql/1725090962922-applicationProperties.ts
@@ -5,10 +5,10 @@ export class ApplicationProperties1725090962922 implements MigrationInterface {
 
 	public async up(queryRunner: QueryRunner): Promise<void> {
 		await queryRunner.query(
-			"ALTER TABLE `applications` ADD COLUMN `guild_id` VARCHAR(255) NOT NULL",
+			"ALTER TABLE `applications` ADD COLUMN `guild_id` VARCHAR(255) DEFAULT NULL",
 		);
 		await queryRunner.query(
-			"ALTER TABLE `applications` ADD COLUMN `custom_install_url` TEXT NOT NULL",
+			"ALTER TABLE `applications` ADD COLUMN `custom_install_url` TEXT DEFAULT NULL",
 		);
 	}
 

--- a/src/util/migration/postgres/1725090962922-applicationProperties.ts
+++ b/src/util/migration/postgres/1725090962922-applicationProperties.ts
@@ -5,10 +5,10 @@ export class ApplicationProperties1725090962922 implements MigrationInterface {
 
 	public async up(queryRunner: QueryRunner): Promise<void> {
 		await queryRunner.query(
-			"ALTER TABLE applications ADD COLUMN guild_id TEXT NOT NULL",
+			"ALTER TABLE applications ADD COLUMN guild_id TEXT NULL DEFAULT NULL",
 		);
 		await queryRunner.query(
-			"ALTER TABLE applications ADD COLUMN custom_install_url TEXT NOT NULL",
+			"ALTER TABLE applications ADD COLUMN custom_install_url TEXT NULL DEFAULT NULL",
 		);
 	}
 


### PR DESCRIPTION
I've missed this when copying the migration for #1206 