### PR TITLE
Stop returning defaults when using User.getPublicUser()

### DIFF
--- a/src/api/routes/channels/#channel_id/invites.ts
+++ b/src/api/routes/channels/#channel_id/invites.ts
@@ -1,17 +1,17 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
 	Copyright (C) 2023 Spacebar and Spacebar Contributors
-	
+
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
 	by the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU Affero General Public License for more details.
-	
+
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -84,7 +84,7 @@ router.post(
 		}).save();
 
 		const data = invite.toJSON();
-		data.inviter = (await User.getPublicUser(req.user_id)).toPublicUser();
+		data.inviter = await User.getPublicUser(req.user_id);
 		data.guild = await Guild.findOne({ where: { id: guild_id } });
 		data.channel = channel;
 

--- a/src/api/routes/users/#id/profile.ts
+++ b/src/api/routes/users/#id/profile.ts
@@ -41,7 +41,10 @@ router.get(
 
 		const { guild_id, with_mutual_guilds } = req.query;
 
-		const user = await User.getPublicUser(req.params.id, {
+		const user = await User.findOneOrFail({
+			where: {
+				id: req.params.id,
+			},
 			relations: ["connected_accounts"],
 		});
 

--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -87,7 +87,9 @@ export async function handleMessage(opts: MessageOptions): Promise<Message> {
 	}
 
 	if (opts.author_id) {
-		message.author = await User.getPublicUser(opts.author_id);
+		message.author = await User.findOneOrFail({
+			where: { id: opts.author_id },
+		});
 		const rights = await getRights(opts.author_id);
 		rights.hasThrow("SEND_MESSAGES");
 	}

--- a/src/gateway/opcodes/LazyRequest.ts
+++ b/src/gateway/opcodes/LazyRequest.ts
@@ -238,7 +238,7 @@ export async function onLazyRequest(this: WebSocket, { d }: Payload) {
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
 				if (session?.status == "unknown") session.status = "online";
-				const user = (await User.getPublicUser(x)).toPublicUser(); // why is this needed?
+				const user = await User.getPublicUser(x);
 
 				return Send(this, {
 					op: OPCODES.Dispatch,

--- a/src/util/entities/User.ts
+++ b/src/util/entities/User.ts
@@ -17,14 +17,7 @@
 */
 
 import { Request } from "express";
-import {
-	Column,
-	Entity,
-	FindOneOptions,
-	JoinColumn,
-	OneToMany,
-	OneToOne,
-} from "typeorm";
+import { Column, Entity, JoinColumn, OneToMany, OneToOne } from "typeorm";
 import { Config, Email, FieldErrors, Snowflake, trimSpecial } from "..";
 import { BitField } from "../util/BitField";
 import { BaseClass } from "./BaseClass";

--- a/src/util/entities/User.ts
+++ b/src/util/entities/User.ts
@@ -279,14 +279,12 @@ export class User extends BaseClass {
 		return user as UserPrivate;
 	}
 
-	static async getPublicUser(user_id: string, opts?: FindOneOptions<User>) {
-		return await User.findOneOrFail({
+	static async getPublicUser(user_id: string): Promise<PublicUser> {
+		const user = await User.findOneOrFail({
 			where: { id: user_id },
-			...opts,
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			//@ts-ignore
-			select: [...PublicUserProjection, ...(opts?.select || [])], // TODO: fix
+			select: PublicUserProjection,
 		});
+		return user.toPublicUser();
 	}
 
 	public static async generateDiscriminator(


### PR DESCRIPTION
Slightly annoying, confusing and sending unnecessary bytes, so I've fixed the `User.getPublicUser()` method to only return the properties that are actually needed for, well, public users.

Currently, properties like `desktop` and `webauthn_enabled` are returned with their default values, which, while not exposing anything, are not matching the schemas.

This PR adjusts the method to call `<User>.toPublicUser()` and removes arguments which were rarely used and can be replaced with e.g. `User.findOneOrFail()`.