### PR TITLE
Fix uploading of emojis

### DIFF
--- a/src/api/routes/guilds/#guild_id/emojis.ts
+++ b/src/api/routes/guilds/#guild_id/emojis.ts
@@ -123,13 +123,13 @@ router.post(
 		if (body.require_colons == null) body.require_colons = true;
 
 		const user = await User.findOneOrFail({ where: { id: req.user_id } });
-		body.image = (await handleFile(`/emojis/${id}`, body.image)) as string;
+		await handleFile(`/emojis/${id}`, body.image);
 
 		const mimeType = body.image.split(":")[1].split(";")[0];
 		const emoji = await Emoji.create({
 			id: id,
 			guild_id: guild_id,
-			...body,
+			name: body.name,
 			require_colons: body.require_colons ?? undefined, // schema allows nulls, db does not
 			user: user,
 			managed: false,


### PR DESCRIPTION
I broke this in #1146

https://github.com/spacebarchat/server/blob/143cbf2e98557fe937ace2a2e785e48f7f701bd1/src/api/routes/guilds/%23guild_id/emojis.ts#L128 requires `body.image` to be the original one, not the hash. As the hash is never used (`Emoji` doesn't have any `image` property) it's pointless to update the value.