### PR TITLE
Add `guild_template_code` to `GuildCreateSchema`

### DIFF
--- a/src/util/schemas/GuildCreateSchema.ts
+++ b/src/util/schemas/GuildCreateSchema.ts
@@ -28,4 +28,5 @@ export interface GuildCreateSchema {
 	channels?: ChannelModifySchema[];
 	system_channel_id?: string;
 	rules_channel_id?: string;
+	guild_template_code?: string;
 }


### PR DESCRIPTION
Fixes guild creation due to additional property error.