### PR TITLE
Add missing fields to `MessageAcknowledgeSchema`

### DIFF
--- a/src/util/schemas/MessageAcknowledgeSchema.ts
+++ b/src/util/schemas/MessageAcknowledgeSchema.ts
@@ -19,4 +19,7 @@
 export interface MessageAcknowledgeSchema {
 	manual?: boolean;
 	mention_count?: number;
+	flags?: number;
+	last_viewed?: number;
+	token?: string;
 }


### PR DESCRIPTION
I'm not entirely sure what these fields do, but I've added them to make the client happy.