### PR TITLE
fix opcode 8 handler: onRequestGuildMembers

### DIFF
--- a/src/gateway/opcodes/RequestGuildMembers.ts
+++ b/src/gateway/opcodes/RequestGuildMembers.ts
@@ -27,7 +27,7 @@ import {
 } from "@spacebar/util";
 import { WebSocket, Payload, OPCODES, Send } from "@spacebar/gateway";
 import { check } from "./instanceOf";
-import { FindManyOptions, In, Like } from "typeorm";
+import { FindManyOptions, ILike, In } from "typeorm";
 
 export async function onRequestGuildMembers(this: WebSocket, { d }: Payload) {
 	// Schema validation can only accept either string or array, so transforming it here to support both
@@ -114,7 +114,7 @@ export async function onRequestGuildMembers(this: WebSocket, { d }: Payload) {
 		if (query) {
 			// @ts-expect-error memberFind.where is very much defined
 			memberFind.where.user = {
-				username: Like(query + "%"),
+				username: ILike(query + "%"),
 			};
 		} else if (user_ids && user_ids.length > 0) {
 			// @ts-expect-error memberFind.where is still very much defined
@@ -166,15 +166,17 @@ export async function onRequestGuildMembers(this: WebSocket, { d }: Payload) {
 		});
 	}
 
+	if (chunks.length == 0) {
+		chunks.push({
+			...baseData,
+			members: [],
+			presences: presences ? [] : undefined,
+			chunk_index: 0,
+			chunk_count: 1,
+		});
+	}
+
 	if (notFound.length > 0) {
-		if (chunks.length == 0)
-			chunks.push({
-				...baseData,
-				members: [],
-				presences: presences ? [] : undefined,
-				chunk_index: 0,
-				chunk_count: 1,
-			});
 		chunks[0].not_found = notFound;
 	}
 

--- a/src/util/entities/Member.ts
+++ b/src/util/entities/Member.ts
@@ -466,8 +466,8 @@ export class Member extends BaseClassWithoutId {
 			member[x] = this[x];
 		});
 
-		if (member.roles) member.roles = member.roles.map((x: Role) => x.id);
-		if (member.user) member.user = member.user.toPublicUser();
+		if (this.roles) member.roles = this.roles.map((x: Role) => x.id);
+		if (this.user) member.user = this.user.toPublicUser();
 
 		return member as PublicMember;
 	}


### PR DESCRIPTION
Addresses the following:
- [x] Query should not be case sensitive
- [x] When the query returns no member results, we should still return a guild member chunk with empty array of member results
- [x] There was a bug in the `toPublicMember` method that never set the user property of the `Member` entity object

Closes https://github.com/spacebarchat/server/issues/1230