### PR TITLE
Change EOL to auto in prettier config

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -7,5 +7,6 @@
 	"bracketSpacing": true,
 	"quoteProps": "as-needed",
 	"useTabs": true,
-	"singleQuote": false
+	"singleQuote": false,
+	"endOfLine": "auto"
 }


### PR DESCRIPTION
Finally figured out why prettier was going crazy when we ran it on Windows. Seems they changed the default eol config in v2.0

>  End of Line
> First available in v1.15.0, default value changed from auto to lf in v2.0.0

The repository .gitattributes is configured to use auto eol so it will use CRLF on windows and LF on linux.
This PR configures prettier to do the same