### PR TITLE
Added in date wrap on `/api/auth/generate-registration-tokens`

### DIFF
--- a/src/api/routes/auth/generate-registration-tokens.ts
+++ b/src/api/routes/auth/generate-registration-tokens.ts
@@ -52,9 +52,11 @@ router.get(
 		for (let i = 0; i < count; i++) {
 			const token = ValidRegistrationToken.create({
 				token: random(length),
-				expires_at:
+				expires_at: new Date(
 					Date.now() +
-					Config.get().security.defaultRegistrationTokenExpiration,
+						Config.get().security
+							.defaultRegistrationTokenExpiration,
+				),
 			});
 			tokens.push(token);
 		}


### PR DESCRIPTION
This was an issue not allowing the postgresql setup to correctly insert new registration tokens. This hot-fix wraps it in a new Date to satisfy how postgres wants that data inserted!