### PR TITLE
Let spacebar properly handle relative images

### DIFF
--- a/src/api/util/utility/EmbedHandlers.ts
+++ b/src/api/util/utility/EmbedHandlers.ts
@@ -147,6 +147,7 @@ const genericImageHandler = async (url: URL): Promise<Embed | null> => {
 	let image;
 
 	if (type.headers.get("content-type")?.indexOf("image") !== -1) {
+		metas.image = new URL(metas.image, url).toString();
 		const result = await probe(url.href);
 		image = makeEmbedImage(url.href, result.width, result.height);
 	} else if (type.headers.get("content-type")?.indexOf("video") !== -1) {


### PR DESCRIPTION
This fixes a bug that's apparently been in here for a while, this will make relitive URLs based on the URL of the url it got the url from instead of the server.