### PR TITLE
fix missing properties in GUILD_CREATE for bots

### DIFF
--- a/src/gateway/opcodes/Identify.ts
+++ b/src/gateway/opcodes/Identify.ts
@@ -32,6 +32,7 @@ import {
 	DefaultUserGuildSettings,
 	EVENTEnum,
 	Guild,
+	GuildCreateEvent,
 	GuildOrUnavailable,
 	IdentifySchema,
 	Intents,
@@ -464,7 +465,7 @@ export async function onIdentify(this: WebSocket, data: Payload) {
 				s: this.sequence++,
 				d: {
 					...new ReadyGuildDTO(x).toJSON(),
-				},
+				} as GuildCreateEvent["data"],
 			})?.catch((e) =>
 				console.error(`[Gateway] error when sending bot guilds`, e),
 			),

--- a/src/gateway/opcodes/Identify.ts
+++ b/src/gateway/opcodes/Identify.ts
@@ -455,13 +455,16 @@ export async function onIdentify(this: WebSocket, data: Payload) {
 	});
 
 	// If we're a bot user, send GUILD_CREATE for each unavailable guild
+	// TODO: check if bot has permission to view some of these based on intents (i.e. GUILD_MEMBERS, GUILD_PRESENCES, GUILD_VOICE_STATES)
 	await Promise.all(
 		pending_guilds.map((x) =>
 			Send(this, {
 				op: OPCODES.Dispatch,
 				t: EVENTEnum.GuildCreate,
 				s: this.sequence++,
-				d: x,
+				d: {
+					...new ReadyGuildDTO(x).toJSON(),
+				},
 			})?.catch((e) =>
 				console.error(`[Gateway] error when sending bot guilds`, e),
 			),


### PR DESCRIPTION
Issue:
Bots received incomplete `GUILD_CREATE` event on successful `IDENTIFY`. This PR adds the missing properties.

One caveat is that it will send the whole object, regardless of intents since intents haven't been completed yet. The intents aren't applied anywhere else anyway. In the future, once intents have been flushed out, properties such as `members` and `voice_states` might have to be removed.