### PR TITLE
add op handler for `GUILD_SUBSCRIPTIONS_BULK` message

### DIFF
--- a/src/gateway/opcodes/GuildSubscriptionsBulk.ts
+++ b/src/gateway/opcodes/GuildSubscriptionsBulk.ts
@@ -1,0 +1,24 @@
+import { WebSocket, Payload } from "@spacebar/gateway";
+import { onLazyRequest } from "./LazyRequest";
+import { GuildSubscriptionsBulkSchema } from "@spacebar/util";
+import { check } from "./instanceOf";
+
+export async function onGuildSubscriptionsBulk(
+	this: WebSocket,
+	payload: Payload,
+) {
+	check.call(this, GuildSubscriptionsBulkSchema, payload.d);
+	const body = payload.d as GuildSubscriptionsBulkSchema;
+
+	let guildId: keyof GuildSubscriptionsBulkSchema["subscriptions"];
+
+	for (guildId in body.subscriptions) {
+		await onLazyRequest.call(this, {
+			...payload,
+			d: {
+				guild_id: guildId,
+				...body.subscriptions[guildId],
+			},
+		});
+	}
+}

--- a/src/gateway/opcodes/index.ts
+++ b/src/gateway/opcodes/index.ts
@@ -24,6 +24,7 @@ import { onPresenceUpdate } from "./PresenceUpdate";
 import { onRequestGuildMembers } from "./RequestGuildMembers";
 import { onResume } from "./Resume";
 import { onVoiceStateUpdate } from "./VoiceStateUpdate";
+import { onGuildSubscriptionsBulk } from "./GuildSubscriptionsBulk";
 
 export type OPCodeHandler = (this: WebSocket, data: Payload) => unknown;
 
@@ -40,4 +41,5 @@ export default {
 	// 10: Hello
 	// 13: Dm_update
 	14: onLazyRequest,
+	37: onGuildSubscriptionsBulk,
 } as { [key: number]: OPCodeHandler };

--- a/src/util/schemas/GuildSubscriptionsBulkSchema.ts
+++ b/src/util/schemas/GuildSubscriptionsBulkSchema.ts
@@ -1,0 +1,11 @@
+import { LazyRequestSchema } from "./LazyRequestSchema";
+
+export interface GuildSubscriptionsBulkSchema {
+	subscriptions: { [key: string]: GuildSubscriptionSchema };
+}
+
+export type GuildSubscriptionSchema = Omit<LazyRequestSchema, "guild_id">;
+
+export const GuildSubscriptionsBulkSchema = {
+	$subscriptions: Object,
+};

--- a/src/util/schemas/LazyRequestSchema.ts
+++ b/src/util/schemas/LazyRequestSchema.ts
@@ -30,6 +30,7 @@ export interface LazyRequestSchema {
 	threads?: boolean;
 	typing?: true;
 	members?: string[];
+	member_updates?: boolean;
 	thread_member_lists?: unknown[];
 }
 
@@ -40,5 +41,6 @@ export const LazyRequestSchema = {
 	$typing: Boolean,
 	$threads: Boolean,
 	$members: [] as string[],
+	$member_updates: Boolean,
 	$thread_member_lists: [] as unknown[],
 };

--- a/src/util/schemas/index.ts
+++ b/src/util/schemas/index.ts
@@ -41,6 +41,7 @@ export * from "./EmojiModifySchema";
 export * from "./ForgotPasswordSchema";
 export * from "./GatewayPayloadSchema";
 export * from "./GuildCreateSchema";
+export * from "./GuildSubscriptionsBulkSchema";
 export * from "./GuildTemplateCreateSchema";
 export * from "./GuildUpdateSchema";
 export * from "./GuildUpdateWelcomeScreenSchema";


### PR DESCRIPTION
Problem: guild member list never loads for the client currently

This PR adds the missing OP handler for message `GUILD_SUBSCRIPTIONS_BULK`, which solves the problem. The message is just a bulk version of `onLazyRequest`, so to avoid code duplication I just call that op handler with the appropriate payload