### PR TITLE
fix op 8 handler for some discord libraries

### DIFF
--- a/src/gateway/opcodes/RequestGuildMembers.ts
+++ b/src/gateway/opcodes/RequestGuildMembers.ts
@@ -38,8 +38,15 @@ export async function onRequestGuildMembers(this: WebSocket, { d }: Payload) {
 
 	check.call(this, RequestGuildMembersSchema, d);
 
-	const { query, presences, nonce } = d as RequestGuildMembersSchema;
+	const {
+		presences,
+		nonce,
+		query: requestQuery,
+	} = d as RequestGuildMembersSchema;
 	let { limit, user_ids, guild_id } = d as RequestGuildMembersSchema;
+
+	// some discord libraries send empty string as query when they meant to send undefined, which was leading to errors being thrown in this handler
+	const query = requestQuery != "" ? requestQuery : undefined;
 
 	guild_id = guild_id as string;
 	user_ids = user_ids as string[] | undefined;


### PR DESCRIPTION
Discord libraries such as Discord.py send payload for op 8 with `query` as empty string `""` while attempting to indicate no query (ideally they would instead send undefined) and as a result, the server was closing the connection with errors

This PR fixes the expected behavior so that the query is ignored as if it was undefined