### PR TITLE
Implement Signed Attachment CDN URLs

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -212,6 +212,48 @@
                     }
                 }
             },
+            "GuildSubscriptionSchema": {
+                "type": "object",
+                "properties": {
+                    "channels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "activities": {
+                        "type": "boolean"
+                    },
+                    "threads": {
+                        "type": "boolean"
+                    },
+                    "typing": {
+                        "enum": [
+                            true
+                        ],
+                        "type": "boolean"
+                    },
+                    "members": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "member_updates": {
+                        "type": "boolean"
+                    },
+                    "thread_member_lists": {
+                        "type": "array",
+                        "items": {}
+                    }
+                }
+            },
             "ActivitySchema": {
                 "type": "object",
                 "properties": {
@@ -3972,6 +4014,21 @@
                     "widget_enabled"
                 ]
             },
+            "RefreshedUrl": {
+                "type": "object",
+                "properties": {
+                    "original": {
+                        "type": "string"
+                    },
+                    "refreshed": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "original",
+                    "refreshed"
+                ]
+            },
             "TenorGifResponse": {
                 "type": "object",
                 "properties": {
@@ -4137,6 +4194,12 @@
                             "$ref": "#/components/schemas/Channel"
                         }
                     },
+                    "members": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Member"
+                        }
+                    },
                     "region": {
                         "type": "string"
                     },
@@ -4214,12 +4277,6 @@
                     },
                     "presence_count": {
                         "type": "integer"
-                    },
-                    "members": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Member"
-                        }
                     },
                     "template_id": {
                         "type": "string"
@@ -4620,30 +4677,13 @@
                     "channel": {
                         "$ref": "#/components/schemas/RateLimitOptions"
                     },
-                    "auth": {
-                        "$ref": "#/components/schemas/AuthRateLimit"
-                    }
+                    "auth": {}
                 },
                 "required": [
                     "auth",
                     "channel",
                     "guild",
                     "webhook"
-                ]
-            },
-            "AuthRateLimit": {
-                "type": "object",
-                "properties": {
-                    "login": {
-                        "$ref": "#/components/schemas/RateLimitOptions"
-                    },
-                    "register": {
-                        "$ref": "#/components/schemas/RateLimitOptions"
-                    }
-                },
-                "required": [
-                    "login",
-                    "register"
                 ]
             },
             "GlobalRateLimits": {
@@ -5390,6 +5430,68 @@
                     }
                 }
             },
+            "LazyRequestSchema": {
+                "type": "object",
+                "properties": {
+                    "guild_id": {
+                        "type": "string"
+                    },
+                    "channels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "activities": {
+                        "type": "boolean"
+                    },
+                    "threads": {
+                        "type": "boolean"
+                    },
+                    "typing": {
+                        "enum": [
+                            true
+                        ],
+                        "type": "boolean"
+                    },
+                    "members": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "member_updates": {
+                        "type": "boolean"
+                    },
+                    "thread_member_lists": {
+                        "type": "array",
+                        "items": {}
+                    }
+                },
+                "required": [
+                    "guild_id"
+                ]
+            },
+            "GuildSubscriptionsBulkSchema": {
+                "type": "object",
+                "properties": {
+                    "subscriptions": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/GuildSubscriptionSchema"
+                        }
+                    }
+                },
+                "required": [
+                    "subscriptions"
+                ]
+            },
             "GuildTemplateCreateSchema": {
                 "type": "object",
                 "properties": {
@@ -5739,51 +5841,6 @@
                         "type": "integer"
                     }
                 }
-            },
-            "LazyRequestSchema": {
-                "type": "object",
-                "properties": {
-                    "guild_id": {
-                        "type": "string"
-                    },
-                    "channels": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "array",
-                            "items": {
-                                "type": "array",
-                                "items": {
-                                    "type": "integer"
-                                }
-                            }
-                        }
-                    },
-                    "activities": {
-                        "type": "boolean"
-                    },
-                    "threads": {
-                        "type": "boolean"
-                    },
-                    "typing": {
-                        "enum": [
-                            true
-                        ],
-                        "type": "boolean"
-                    },
-                    "members": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "thread_member_lists": {
-                        "type": "array",
-                        "items": {}
-                    }
-                },
-                "required": [
-                    "guild_id"
-                ]
             },
             "LoginSchema": {
                 "type": "object",
@@ -6247,6 +6304,20 @@
                 "required": [
                     "after",
                     "before"
+                ]
+            },
+            "RefreshUrlsRequestSchema": {
+                "type": "object",
+                "properties": {
+                    "attachment_urls": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "attachment_urls"
                 ]
             },
             "RegisterSchema": {
@@ -7088,6 +7159,20 @@
                 },
                 "required": [
                     "location"
+                ]
+            },
+            "RefreshUrlsResponse": {
+                "type": "object",
+                "properties": {
+                    "refreshed_urls": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RefreshedUrl"
+                        }
+                    }
+                },
+                "required": [
+                    "refreshed_urls"
                 ]
             },
             "TeamListResponse": {
@@ -9054,6 +9139,9 @@
         },
         {
             "name": "applications"
+        },
+        {
+            "name": "attachments"
         },
         {
             "name": "auth"
@@ -11649,6 +11737,25 @@
                         "label": "Spacebar-only",
                         "color": "red"
                     }
+                ]
+            }
+        },
+        "/policies/instance/config/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": [
+                    "policies"
                 ]
             }
         },
@@ -18299,6 +18406,50 @@
                 },
                 "tags": [
                     "auth"
+                ]
+            }
+        },
+        "/attachments/refresh-urls/": {
+            "post": {
+                "security": [
+                    {
+                        "bearer": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RefreshUrlsRequestSchema"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RefreshUrlsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/APIErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": [
+                    "attachments"
                 ]
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
 				"missing-native-js-functions": "^1.4.3",
 				"module-alias": "^2.2.3",
 				"morgan": "^1.10.0",
+				"ms": "^2.1.3",
 				"multer": "^1.4.5-lts.1",
 				"murmurhash-js": "^1.0.0",
 				"node-2fa": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
 		"missing-native-js-functions": "^1.4.3",
 		"module-alias": "^2.2.3",
 		"morgan": "^1.10.0",
+		"ms": "^2.1.3",
 		"multer": "^1.4.5-lts.1",
 		"murmurhash-js": "^1.0.0",
 		"node-2fa": "^2.0.3",

--- a/src/api/routes/attachments/refresh-urls.ts
+++ b/src/api/routes/attachments/refresh-urls.ts
@@ -1,0 +1,48 @@
+/*
+	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
+	Copyright (C) 2023 Spacebar and Spacebar Contributors
+	
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+	
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { route } from "@spacebar/api";
+import { RefreshUrlsRequestSchema, resignUrl } from "@spacebar/util";
+import { Request, Response, Router } from "express";
+const router = Router();
+
+router.post(
+	"/",
+	route({
+		requestBody: "RefreshUrlsRequestSchema",
+		responses: {
+			200: {
+				body: "RefreshUrlsResponse",
+			},
+			400: {
+				body: "APIErrorResponse",
+			},
+		},
+	}),
+	async (req: Request, res: Response) => {
+		const { attachment_urls } = req.body as RefreshUrlsRequestSchema;
+
+		const refreshed_urls = attachment_urls.map(resignUrl);
+
+		return res.status(200).json({
+			refreshed_urls,
+		});
+	},
+);
+
+export default router;

--- a/src/api/routes/channels/#channel_id/messages/index.ts
+++ b/src/api/routes/channels/#channel_id/messages/index.ts
@@ -35,6 +35,7 @@ import {
 	emitEvent,
 	getPermission,
 	isTextChannel,
+	resignUrl,
 	uploadFile,
 } from "@spacebar/util";
 import { Request, Response, Router } from "express";
@@ -199,16 +200,18 @@ router.get(
 					? y.proxy_url
 					: `https://example.org${y.proxy_url}`;
 
-				let pathname = new URL(uri).pathname;
-				while (
-					pathname.split("/")[0] != "attachments" &&
-					pathname.length > 30
-				) {
-					pathname = pathname.split("/").slice(1).join("/");
+				const url = new URL(uri);
+				if (endpoint) {
+					const newBase = new URL(endpoint);
+					url.protocol = newBase.protocol;
+					url.hostname = newBase.hostname;
+					url.port = newBase.port;
 				}
-				if (!endpoint?.endsWith("/")) pathname = "/" + pathname;
 
-				y.proxy_url = `${endpoint == null ? "" : endpoint}${pathname}`;
+				y.proxy_url = url.toString();
+
+				y.proxy_url = resignUrl(y.proxy_url);
+				y.url = resignUrl(y.url);
 			});
 
 			/**

--- a/src/cdn/routes/attachments.ts
+++ b/src/cdn/routes/attachments.ts
@@ -73,8 +73,7 @@ router.post(
 
 		if (Config.get().security.cdnSignUrls) {
 			const signatureData = getUrlSignature(path);
-			console.log(signatureData);
-			finalUrl = `${finalUrl}?ex=${signatureData.expiresAt}&is=${signatureData.issuedAt}&hm=${signatureData.hash}&`;
+			finalUrl = `${finalUrl}?ex=${signatureData.expiresAt}&is=${signatureData.issuedAt}&hm=${signatureData.hash}`;
 		}
 
 		const file = {

--- a/src/util/Signing.ts
+++ b/src/util/Signing.ts
@@ -1,0 +1,136 @@
+/*
+	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
+	Copyright (C) 2023 Spacebar and Spacebar Contributors
+	
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+	
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Config } from "@spacebar/util";
+import { createHmac, timingSafeEqual } from "crypto";
+import ms, { StringValue } from "ms";
+import { ParsedQs } from "qs";
+
+export const getUrlSignature = (path: string) => {
+	const { cdnSignatureKey, cdnSignatureDuration } = Config.get().security;
+
+	// calculate the expiration time
+	const now = Date.now();
+	const issuedAt = now.toString(16);
+	const expiresAt = (now + ms(cdnSignatureDuration as StringValue)).toString(
+		16,
+	);
+
+	// hash the url with the cdnSignatureKey
+	const hash = createHmac("sha256", cdnSignatureKey as string)
+		.update(path)
+		.update(issuedAt)
+		.update(expiresAt)
+		.digest("hex");
+
+	return {
+		hash,
+		issuedAt,
+		expiresAt,
+	};
+};
+
+export const calculateHash = (
+	url: string,
+	issuedAt: string,
+	expiresAt: string,
+) => {
+	const { cdnSignatureKey } = Config.get().security;
+	const hash = createHmac("sha256", cdnSignatureKey as string)
+		.update(url)
+		.update(issuedAt)
+		.update(expiresAt)
+		.digest("hex");
+	return hash;
+};
+
+export const isExpired = (ex: string, is: string) => {
+	// convert issued at
+	const issuedAt = parseInt(is, 16);
+	const expiresAt = parseInt(ex, 16);
+
+	if (Number.isNaN(issuedAt) || Number.isNaN(expiresAt)) {
+		// console.debug("Invalid timestamps in query");
+		return true;
+	}
+
+	const currentTime = Date.now();
+	const isExpired = expiresAt < currentTime;
+	const isValidIssuedAt = issuedAt < currentTime;
+	if (isExpired || !isValidIssuedAt) {
+		// console.debug("Signature expired");
+		return true;
+	}
+
+	return false;
+};
+
+export const hasValidSignature = (path: string, query: ParsedQs) => {
+	// get url path
+	const { ex, is, hm } = query;
+
+	// if the required query parameters are not present, return false
+	if (!ex || !is || !hm) return false;
+
+	// check if the signature is expired
+	if (isExpired(ex as string, is as string)) {
+		return false;
+	}
+
+	const calcd = calculateHash(path, is as string, ex as string);
+	const calculated = Buffer.from(calcd);
+	const received = Buffer.from(hm as string);
+
+	const isHashValid =
+		calculated.length === received.length &&
+		timingSafeEqual(calculated, received);
+	// if (!isHashValid) {
+	// 	console.debug("Invalid signature");
+	// 	console.debug(calcd, hm);
+	// }
+	return isHashValid;
+};
+
+export const resignUrl = (attachmentUrl: string) => {
+	const url = new URL(attachmentUrl);
+
+	// if theres an existing signature, check if its expired or not. no reason to resign if its not expired
+	if (url.searchParams.has("ex") && url.searchParams.has("is")) {
+		// extract the ex and is
+		const ex = url.searchParams.get("ex");
+		const is = url.searchParams.get("is");
+
+		if (!isExpired(ex as string, is as string)) {
+			// if the signature is not expired, return the url as is
+			return attachmentUrl;
+		}
+	}
+
+	let path = url.pathname;
+	// strip / from the start
+	if (path.startsWith("/")) {
+		path = path.slice(1);
+	}
+
+	const { hash, issuedAt, expiresAt } = getUrlSignature(path);
+	url.searchParams.set("ex", expiresAt);
+	url.searchParams.set("is", issuedAt);
+	url.searchParams.set("hm", hash);
+
+	return url.toString();
+};

--- a/src/util/config/types/SecurityConfiguration.ts
+++ b/src/util/config/types/SecurityConfiguration.ts
@@ -37,4 +37,8 @@ export class SecurityConfiguration {
 	mfaBackupCodeCount: number = 10;
 	statsWorldReadable: boolean = true;
 	defaultRegistrationTokenExpiration: number = 1000 * 60 * 60 * 24 * 7; //1 week
+	// cdn signed urls
+	cdnSignUrls: boolean = false;
+	cdnSignatureKey: string = crypto.randomBytes(32).toString("base64");
+	cdnSignatureDuration: string = "24h";
 }

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -16,6 +16,8 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+// NOTE: !! DO NOT REORDER THE IMPORTS !!
+
 import "reflect-metadata";
 
 export * from "./util/index";
@@ -26,3 +28,4 @@ export * from "./schemas";
 export * from "./imports";
 export * from "./config";
 export * from "./connections";
+export * from "./Signing"

--- a/src/util/schemas/RefreshUrlsRequestSchema.ts
+++ b/src/util/schemas/RefreshUrlsRequestSchema.ts
@@ -1,0 +1,21 @@
+/*
+	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
+	Copyright (C) 2023 Spacebar and Spacebar Contributors
+	
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+	
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+export interface RefreshUrlsRequestSchema {
+	attachment_urls: string[];
+}

--- a/src/util/schemas/index.ts
+++ b/src/util/schemas/index.ts
@@ -59,6 +59,7 @@ export * from "./MfaCodesSchema";
 export * from "./ModifyGuildStickerSchema";
 export * from "./PasswordResetSchema";
 export * from "./PurgeSchema";
+export * from "./RefreshUrlsRequestSchema";
 export * from "./RegisterSchema";
 export * from "./RelationshipPostSchema";
 export * from "./RelationshipPutSchema";

--- a/src/util/schemas/responses/RefreshUrlsResponse.ts
+++ b/src/util/schemas/responses/RefreshUrlsResponse.ts
@@ -1,0 +1,26 @@
+/*
+	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
+	Copyright (C) 2023 Spacebar and Spacebar Contributors
+	
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+	
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+export interface RefreshedUrl {
+	original: string;
+	refreshed: string;
+}
+
+export interface RefreshUrlsResponse {
+	refreshed_urls: RefreshedUrl[];
+}

--- a/src/util/schemas/responses/index.ts
+++ b/src/util/schemas/responses/index.ts
@@ -44,6 +44,7 @@ export * from "./InstanceStatsResponse";
 export * from "./LocationMetadataResponse";
 export * from "./MemberJoinGuildResponse";
 export * from "./OAuthAuthorizeResponse";
+export * from "./RefreshUrlsResponse";
 export * from "./TeamListResponse";
 export * from "./Tenor";
 export * from "./TokenResponse";


### PR DESCRIPTION
Implementation is as close to Discord as possible, As with Discord, it only applies to attachments. This closes #1280 

https://discord.com/developers/docs/reference#signed-attachment-cdn-urls

- The signature duration (`security_cdnSignatureDuration`) is configurable using different duration strings like `1s`, `1m`, `1h`, `1d`, etc with the use of `ms`. Defaults to 24 hours (same as Discord)
- Signed attachments are disabled by default but can be enabled with `security_cdnSignUrls`
- The signing key is auto generated