### PR TITLE
Add validation to date_of_birth registration field

### DIFF
--- a/src/api/routes/auth/register.ts
+++ b/src/api/routes/auth/register.ts
@@ -206,10 +206,24 @@ router.post(
 			minimum.setFullYear(
 				minimum.getFullYear() - register.dateOfBirth.minimum,
 			);
-			body.date_of_birth = new Date(body.date_of_birth as Date);
+
+			let parsedDob;
+			try {
+				parsedDob = new Date(body.date_of_birth as Date);
+				if (isNaN(parsedDob.getTime())) {
+					throw new Error("Invalid date");
+				}
+			} catch (e) {
+				throw FieldErrors({
+					date_of_birth: {
+						code: "DATE_OF_BIRTH_INVALID",
+						message: req.t("auth:register.DATE_OF_BIRTH_INVALID"),
+					},
+				});
+			}
 
 			// higher is younger
-			if (body.date_of_birth > minimum) {
+			if (parsedDob > minimum) {
 				throw FieldErrors({
 					date_of_birth: {
 						code: "DATE_OF_BIRTH_UNDERAGE",


### PR DESCRIPTION
Resolves: #1020

## How was this tested?

**Before:**

This would pass and allow a user to register:

```sh
curl -X POST "http://localhost:3001/api/auth/register/" \
 -H 'accept: application/json'\
 -H 'content-type: application/json' \
 -d '{"username":"AAAA","password":"123456789","consent":true,"email":"user@example.com","fingerprint":"string","date_of_birth":"1999-32-25","gift_code_sku_id":"string","captcha_key":"string","promotional_email_opt_in":false,"unique_username_registration":false,"global_name":"string"}'
```

The critical field is `"date_of_birth":"1999-32-25"` (not a valid date)

**After:**

``` sh
{"code":50035,"message":"Invalid Form Body","errors":{"date_of_birth":{"_errors":[{"message":"register.DATE_OF_BIRTH_INVALID","code":"DATE_OF_BIRTH_INVALID"}]}}}
```

## Additional notes

If we want stronger/different validation on this, let's discuss.