### PR TITLE
Fix duplicate embeds on message updates

### DIFF
--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -290,18 +290,13 @@ export async function postHandleMessage(message: Message) {
 		}
 	}
 
-	// Remove existing embeds whose URLs ARE in the current message (we'll regenerate them)
+	// Remove ALL embeds that have URLs when processing links (start fresh)
 	data.embeds = data.embeds.filter((embed) => {
 		if (!embed.url) {
 			return true;
 		}
-		try {
-			const normalizedEmbedUrl = normalizeUrl(embed.url);
-			const shouldRemove = currentNormalizedUrls.has(normalizedEmbedUrl);
-			return !shouldRemove;
-		} catch {
-			return true;
-		}
+
+		return false;
 	});
 
 	const seenNormalizedUrls = new Set<string>();

--- a/src/util/util/Url.ts
+++ b/src/util/util/Url.ts
@@ -1,0 +1,32 @@
+/**
+ * Normalize a URL by:
+ * - Removing trailing slashes (except root path)
+ * - Sorting query params alphabetically
+ * - Removing empty query strings
+ * - Removing fragments
+ */
+export function normalizeUrl(input: string): string {
+	try {
+		const u = new URL(input);
+		// Remove fragment
+		u.hash = "";
+		// Normalize pathname - remove trailing slash except for root "/"
+		if (u.pathname !== "/" && u.pathname.endsWith("/")) {
+			u.pathname = u.pathname.slice(0, -1);
+		}
+		// Normalize query params: sort by key
+		if (u.search) {
+			const params = Array.from(u.searchParams.entries());
+			params.sort(([a], [b]) => a.localeCompare(b));
+			u.search = params.length
+				? "?" + params.map(([k, v]) => `${k}=${v}`).join("&")
+				: "";
+		} else {
+			// Ensure no empty search string
+			u.search = "";
+		}
+		return u.toString();
+	} catch (e) {
+		return input;
+	}
+}

--- a/src/util/util/index.ts
+++ b/src/util/util/index.ts
@@ -41,6 +41,7 @@ export * from "./String";
 export * from "./Token";
 export * from "./TraverseDirectory";
 export * from "./WebAuthn";
+export * from "./Url";
 export * from "./Gifs";
 export * from "./Application";
 export * from "./NameValidation";


### PR DESCRIPTION
## What changed?

The `postHandleMessage` function is parsing links and adding them to the EmbedCache table if necessary. In the previous implementation, message updates would push to the embeds unconditionally.

This commit parses links from the message and:

1. Normalizes the URLs
    - Useful for deduplicating similar URLs (checks trailing `/` and search params for uniqueness)
2. Remove any embeds with a `.url` property from the message data
3. Take the deduplicated + normalized URLs and add an embed to the message and insert into the EmbedCache table (if necessary)

This ensures

1. Embeds can be re-ordered by re-ordering links
2. Embeds can be removed by removing links

and fixes:

1. Duplicate embeds being attached to a message when edited

## How was this tested?

>[!important]
> I have not tested if/how this affects EmbedTypes other than links and articles

| Before | After |
|----------|---------|
| <video src="https://github.com/user-attachments/assets/bcf4373f-f329-4ab3-b308-e2710bd2c3d7" /> | <video src="https://github.com/user-attachments/assets/ef0942fd-55c4-4f9b-88ac-fa2790881853" /> |
