### PR TITLE
Preserve reactions when a message is edited

### DIFF
--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -46,6 +46,7 @@ import {
 	handleFile,
 	Permissions,
 	normalizeUrl,
+	Reaction,
 } from "@spacebar/util";
 import { HTTPError } from "lambert-server";
 import { In } from "typeorm";
@@ -76,7 +77,7 @@ export async function handleMessage(opts: MessageOptions): Promise<Message> {
 		channel_id: opts.channel_id,
 		attachments: opts.attachments || [],
 		embeds: opts.embeds || [],
-		reactions: /*opts.reactions ||*/ [],
+		reactions: opts.reactions || [],
 		type: opts.type ?? 0,
 	});
 
@@ -442,6 +443,7 @@ interface MessageOptions extends MessageCreateSchema {
 	webhook_id?: string;
 	application_id?: string;
 	embeds?: Embed[];
+	reactions?: Reaction[];
 	channel_id?: string;
 	attachments?: Attachment[];
 	edited_timestamp?: Date;


### PR DESCRIPTION
## What changed?

- Attach reactions in the `MessageOptions` 

Resolves #1241

## How was this tested?

- Add a reaction, edit message, check that reaction is still there

| Before  | After |
|:-:|:-:|
| <video src="https://github.com/user-attachments/assets/8c6438fc-7d7c-459a-abb2-d0d6a20b4e46" /> | <video src="https://github.com/user-attachments/assets/df69aaa6-a3ab-40c3-a142-062ab5a62554" /> |

## Additional notes

This change was suspiciously simple, I'm wondering if reactions was intentionally left out from the `handleMessage(...)` function.