### PR TITLE
Properly filter existing embed links

### DIFF
--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -290,14 +290,8 @@ export async function postHandleMessage(message: Message) {
 		}
 	}
 
-	// Remove ALL embeds that have URLs when processing links (start fresh)
-	data.embeds = data.embeds.filter((embed) => {
-		if (!embed.url) {
-			return true;
-		}
-
-		return false;
-	});
+	// Filter out embeds that could be links, start from scratch
+	data.embeds = data.embeds.filter((embed) => embed.type === "rich");
 
 	const seenNormalizedUrls = new Set<string>();
 	const uniqueLinks: string[] = [];


### PR DESCRIPTION
## What changed?

- In a previous PR, I was checking if the `.url` property existed, the correct fix is to remove any embed that isn't a rich embed type (non-link).

See also: #1296

## How was this tested?

- Same as before, add link, edit link by adding trailing slash, re-order links, remove 1 link, remove all links.