### PR TITLE
Reset listener for user on RELATIONSHIP_REMOVE

### DIFF
--- a/src/gateway/listener/listener.ts
+++ b/src/gateway/listener/listener.ts
@@ -188,6 +188,9 @@ async function consume(this: WebSocket, opts: EventOpts) {
 			this.member_events[data.user.id]();
 			break;
 		case "RELATIONSHIP_REMOVE":
+			this.events[data.user_id]?.();
+			delete this.events[data.user_id];
+			break;
 		case "CHANNEL_DELETE":
 		case "GUILD_DELETE":
 			delete this.events[id];


### PR DESCRIPTION
## What changed?

- Clean up listener created in the `RELATIONSHIP_ADD` case when `RELATIONSHIP_REMOVE` is emitted

Resolves: #1240

## How was this tested?

- Creating 2 accounts
- Having account A add account B
- Account B rejects the request
- Account A sends another request, and `RELATIONSHIP_ADD` gets fired again as expected

| Before | After |
|:-:|:-:|
| <video src="https://github.com/user-attachments/assets/d21db850-221b-4390-b0e5-d0a6bbaed1e6" /> | <video src="https://github.com/user-attachments/assets/b371b6c9-da83-4c11-b7b3-d7bc4b985f57" /> |