### PR TITLE
Fix GUILD_CREATE event not emitting when joining for a second time

### DIFF
--- a/src/gateway/listener/listener.ts
+++ b/src/gateway/listener/listener.ts
@@ -190,8 +190,8 @@ async function consume(this: WebSocket, opts: EventOpts) {
 		case "RELATIONSHIP_REMOVE":
 		case "CHANNEL_DELETE":
 		case "GUILD_DELETE":
+			this.events[id]?.();
 			delete this.events[id];
-			opts.cancel();
 			break;
 		case "CHANNEL_CREATE":
 			if (


### PR DESCRIPTION
## What changed?

Adding `this.events[id]?.()` cleans up the listener. I removed `opts.cancel()` because with it, the event had issues firing after the first time. If this listener requires `opts.cancel()`, let me know.

Resolves: #1242

## How was this tested?

- By joining and leaving a guild multiple times and inspecting the events received by the client

| Before | After |
|:-:|:-:|
| <video src="https://github.com/user-attachments/assets/137500d1-af06-426f-8a34-746629cc177e" /> | <video src="https://github.com/user-attachments/assets/8f791a78-9e96-46fa-89fd-d527aef7e08a" /> |


