### PR TITLE
Add OP to message.mentions when replied to

### DIFF
--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -78,6 +78,7 @@ export async function handleMessage(opts: MessageOptions): Promise<Message> {
 		embeds: opts.embeds || [],
 		reactions: /*opts.reactions ||*/ [],
 		type: opts.type ?? 0,
+		mentions: [],
 	});
 
 	if (
@@ -255,12 +256,35 @@ export async function handleMessage(opts: MessageOptions): Promise<Message> {
 		}
 	}
 
+	if (message.message_reference?.message_id) {
+		const referencedMessage = await Message.findOne({
+			where: {
+				id: message.message_reference.message_id,
+				channel_id: message.channel_id,
+			},
+		});
+		if (
+			referencedMessage &&
+			referencedMessage.author_id !== message.author_id
+		) {
+			message.mentions.push(
+				User.create({
+					id: referencedMessage.author_id,
+				}),
+			);
+		}
+	}
+
 	// root@Rory - 20/02/2023 - This breaks channel mentions in test client. We're not sure this was used in older clients.
 	/*message.mention_channels = mention_channel_ids.map((x) =>
 		Channel.create({ id: x }),
 	);*/
 	message.mention_roles = mention_role_ids.map((x) => Role.create({ id: x }));
-	message.mentions = mention_user_ids.map((x) => User.create({ id: x }));
+	message.mentions = [
+		...message.mentions,
+		...mention_user_ids.map((x) => User.create({ id: x })),
+	];
+
 	message.mention_everyone = mention_everyone;
 
 	// TODO: check and put it all in the body


### PR DESCRIPTION
## What changed?

- Add OP's author to `.mentions` when a message is in reply to another
    - Uses `message_reference` to detect who we're replying to

Resolves: #1247
    
## How was this tested?

- Creating a message in reply to another user and checking that the reply counted as a ping
- Replied to myself to make sure it doesn't 'ping' me

| Before | After |
|:-:|:-:|
| ![image](https://github.com/user-attachments/assets/7cf9fcc8-051d-4cf0-8304-629d8073caf7) | ![image](https://github.com/user-attachments/assets/597c043a-94a5-43ed-b9bf-4351551a8c5c) |