### PR TITLE
Fix edit template route

### DIFF
--- a/src/api/routes/guilds/#guild_id/templates.ts
+++ b/src/api/routes/guilds/#guild_id/templates.ts
@@ -165,12 +165,14 @@ router.patch(
 		const { code, guild_id } = req.params;
 		const { name, description } = req.body;
 
-		const template = await Template.create({
-			code,
-			name: name,
-			description: description,
-			source_guild_id: guild_id,
-		}).save();
+		const template = await Template.findOneOrFail({
+			where: { code, source_guild_id: guild_id },
+		});
+
+		template.name = name;
+		template.description = description;
+
+		await template.save();
 
 		res.json(template);
 	},


### PR DESCRIPTION
## What changed?

- Change edit template implementation to update rather than create

Resolves: #1281

## How was this tested?

- I created a template using my existing guild, then edited the template's name and description.