### PR TITLE
Make ban reason nullable

### DIFF
--- a/src/util/schemas/responses/GuildBansResponse.ts
+++ b/src/util/schemas/responses/GuildBansResponse.ts
@@ -17,7 +17,7 @@
 */
 
 export interface GuildBansResponse {
-	reason: string;
+	reason: string | null;
 	user: {
 		username: string;
 		discriminator: string;


### PR DESCRIPTION
## What changed?

- Simple type change (add `| null`) to ban reason

Resolves: #1276

## How was this tested?

- I didn't test this