### PR TITLE
Replace ad-hoc `banInfo` using proper Ban type

### DIFF
--- a/src/api/routes/guilds/#guild_id/bans.ts
+++ b/src/api/routes/guilds/#guild_id/bans.ts
@@ -106,12 +106,9 @@ router.get(
 		if (ban.user_id === ban.executor_id) throw DiscordApiErrors.UNKNOWN_BAN;
 		// pretend self-bans don't exist to prevent victim chasing
 
-		const banInfo = {
-			user: await User.getPublicUser(ban.user_id),
-			reason: ban.reason,
-		};
+		delete ban.ip;
 
-		return res.json(banInfo);
+		return res.json(ban);
 	},
 );
 


### PR DESCRIPTION
## What changed?

- Use typed Ban for GET `guilds/{guild_id}/bans/{user_id}`
- Previously used ad-hoc `banInfo` object

Resolves: #1277

## How was this tested?

- Used cURL to confirm the new endpoint matches the `BanModeratorSchema`

```bash
$ curl 'http://localhost:3001/api/v9/guilds/1388681678108549570/bans/1388523905316094214' -H 'Authorization: eyJ...'

{"id":"1388996137796584550","user_id":"1388523905316094214","guild_id":"1388681678108549570","executor_id":"1388303637125623840","reason":null}
```