### PR TITLE
Remove @everyone role from `onIdentify`

### DIFF
--- a/src/gateway/opcodes/Identify.ts
+++ b/src/gateway/opcodes/Identify.ts
@@ -238,7 +238,10 @@ export async function onIdentify(this: WebSocket, data: Payload) {
 		return [
 			{
 				...x,
-				roles: x.roles.map((x) => x.id),
+				// filter out @everyone role
+				roles: x.roles
+					.filter((r) => r.id !== x.guild.id)
+					.map((x) => x.id),
 
 				// add back user, which we don't fetch from db
 				// TODO: For guild profiles, this may need to be changed.


### PR DESCRIPTION
## What changed?

This prevents the @everyone role from leaking into places that might display it on the frontend. The @everyone role is still visible when needed, but `merged_members` (aka GuildMembers) won't include the role.

Resolves: #1213

## How was this tested?

- Checked the role list in Server Settings, @everyone still shows.
- Checked the Spacebar React client (which doesn't filter out the @everyone role like Firmi does) and confirmed there is no @everyone role.

From Fermi client:

![image](https://github.com/user-attachments/assets/58c9540a-f328-45e5-94fb-227f93fdcee4)

| Before | After |
| :-: | :-: |
| ![image](https://github.com/user-attachments/assets/00d0bc88-03ea-494d-b6de-a7566752b6ce) | ![image](https://github.com/user-attachments/assets/f71c6d72-e5f9-4f6f-9a38-007b11d8b58a) |

## Additional notes

This has the potential to be a high-impact change if done incorrectly. Having a second set of eyes on this PR couldn't hurt.