### PR TITLE
Add nixos module and (very basic, template) test

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,8 @@
               set +x
               runHook postInstall
             '';
+
+            passthru.tests = pkgs.testers.runNixOSTest (import ./nix/tests/test_1.nix self);
           };
 
           update-nix = pkgs.writeShellApplication {
@@ -88,5 +90,9 @@
           ];
         };
       }
-    );
+    )
+    //
+    {
+      nixosModules.default = import ./nix/modules/default self;
+    };
 }

--- a/nix/modules/default/default.nix
+++ b/nix/modules/default/default.nix
@@ -90,7 +90,7 @@ in
         ];
         StateDirectory = "spacebarchat-server";
         StateDirectoryMode = "0700";
-        ExecStart = "env  ${cfg.package}/bin/start-bundle";
+        ExecStart = "${cfg.package}/bin/start-bundle";
         Restart = "on-failure";
         RestartSec = 10;
         StartLimitBurst = 5;

--- a/nix/modules/default/default.nix
+++ b/nix/modules/default/default.nix
@@ -1,0 +1,99 @@
+self: { config, lib, pkgs, spacebar, ... }:
+
+let
+  cfg = config.services.spacebarchat-server;
+  jsonFormat = pkgs.formats.json {};
+  configFile = jsonFormat.generate "spacebarchat-server.json" cfg.settings;
+in
+{
+  options.services.spacebarchat-server = {
+    enable = lib.mkEnableOption "spacebarchat-server";
+    package = lib.mkPackageOption self.packages.${pkgs.stdenv.hostPlatform.system} "spacebar-server" { default = "default"; };
+    extraEnvironment = lib.mkOption {
+      default = {};
+      description = ''
+        Environment variables passed to spacebarchat-server.
+        See <link xlink:href="https://docs.spacebar.chat/setup/server/configuration/env"/>.
+      '';
+      type = lib.types.submodule {
+        freeformType = with lib.types; attrsOf (oneOf [ str bool ]);
+        options = {
+          THREADS = lib.mkOption {
+            type = lib.types.ints.positive;
+            default = 1;
+            description = "Number of threads to run Spacebar on when using bundle. Make sure you've enabled RabbitMQ if using more than one.";
+          };
+          PORT = lib.mkOption {
+            type = lib.types.port;
+            default = 3001;
+            description = "Port to listen on. Used by all components, including bundle. If using bundle, all components run under the same port";
+          };
+          DATABASE = lib.mkOption {
+            type = lib.types.str;
+            default = "database.db";
+            example = "postgres://username:passwort@host-IP:port/databaseName";
+            description = "Database connection string. Defaults to SQLite3 at project root";
+          };
+        };
+      };
+    };
+
+    settings = lib.mkOption {
+      type = jsonFormat.type;
+      default = {};
+      description = ''
+        Configuration for spacebarchat-server.
+        See <link xlink:href="https://docs.spacebar.chat/setup/server/configuration"/> for supported values.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [ {
+      assertion = !((cfg.extraEnvironment.THREADS > 1) && !config.services.rabbitmq.enable);
+      message = "Make sure you've setup RabbitMQ when using more than one thread with Spacebar";
+    } ];
+  
+    systemd.services.spacebarchat-server = {
+      description = "Spacebarchat Server";
+      documentation = [ "https://docs.spacebar.chat/" ];
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      environment = builtins.mapAttrs (_: val: builtins.toString val) (cfg.extraEnvironment // { CONFIG_PATH = configFile; CONFIG_READONLY = 1; });
+      serviceConfig = {
+        DynamicUser = true;
+        User = "spacebarchat-server";
+        LockPersonality = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateUsers = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+        ];
+        StateDirectory = "spacebarchat-server";
+        StateDirectoryMode = "0700";
+        ExecStart = "${cfg.package}/bin/start-bundle";
+        Restart = "on-failure";
+        RestartSec = 10;
+        StartLimitBurst = 5;
+        UMask = "077";
+        WorkingDirectory = "/var/lib/spacebarchat-server/";
+      };
+    };
+  };
+}

--- a/nix/tests/test_1.nix
+++ b/nix/tests/test_1.nix
@@ -1,0 +1,16 @@
+self:
+{ config, lib, pkgs, ... }:
+
+{
+  name = "example-test";
+
+  nodes.machine = {
+    imports = [ self.nixosModules.default ];
+
+    services.spacebarchat-server.enable = true;
+  };
+
+  testScript = ''
+    machine.wait_for_unit("spacebarchat-server")
+  '';
+}

--- a/src/util/util/Config.ts
+++ b/src/util/util/Config.ts
@@ -95,7 +95,9 @@ const generatePairs = (obj: object | null, key = ""): ConfigEntity[] => {
 
 async function applyConfig(val: ConfigValue) {
 	if (process.env.CONFIG_PATH)
-		await fs.writeFile(overridePath, JSON.stringify(val, null, 4));
+		if (!process.env.CONFIG_READONLY)
+			await fs.writeFile(overridePath, JSON.stringify(val, null, 4));
+		else console.log("[WARNING] JSON config file in use, and writing is disabled! Programmatic config changes will not be persisted, and your config will not get updated!");
 	else {
 		const pairs = generatePairs(val);
 		await Promise.all(pairs.map((pair) => pair.save()));


### PR DESCRIPTION
To allow for declarative configuration in the nixos module, writing to spacebar's config file is disabled when the environment variable `CONFIG_READONLY` is set accordingly, which the module does. (see https://github.com/spacebarchat/server/issues/1310)

To use the module, the following snippet can be added to the nixos configuration, where `spacebarchat-server-flake` refers to the flake input `github:spacebarchat/server`:

```
imports = [ spacebarchat-server-flake.nixosModules.default ];

services.spacebarchat-server = {
  enable = true;
  extraEnvironment = { ... };   ## see https://docs.spacebar.chat/setup/server/configuration/env/ for possible attributes
  settings = { ... };           ## see https://docs.spacebar.chat/setup/server/configuration/ for possible attributes
};
```

Note that no automatic nginx, external database and rabbitMQ setups are provided by the module yet.