### PR TITLE
fix unbundled startup for webrtc, and enable eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,6 @@ export default [
 			"**/dist",
 			"**/README.md",
 			"**/COPYING",
-			"src/webrtc",
 			"**/scripts/",
 			"**/assets",
 		],

--- a/src/webrtc/opcodes/Identify.ts
+++ b/src/webrtc/opcodes/Identify.ts
@@ -46,7 +46,7 @@ export async function onIdentify(this: WebRtcWebSocket, data: VoicePayload) {
 	let authenticated = false;
 
 	// first check if its a guild voice connection or DM voice call
-	let voiceState = await VoiceState.findOne({
+	const voiceState = await VoiceState.findOne({
 		where: [
 			{ guild_id: server_id, user_id, token, session_id },
 			{ channel_id: server_id, user_id, token, session_id },

--- a/src/webrtc/opcodes/index.ts
+++ b/src/webrtc/opcodes/index.ts
@@ -24,7 +24,10 @@ import { onSelectProtocol } from "./SelectProtocol";
 import { onSpeaking } from "./Speaking";
 import { onVideo } from "./Video";
 
-export type OPCodeHandler = (this: WebRtcWebSocket, data: VoicePayload) => any;
+export type OPCodeHandler = (
+	this: WebRtcWebSocket,
+	data: VoicePayload,
+) => Promise<void>;
 
 export default {
 	[VoiceOPCodes.HEARTBEAT]: onHeartbeat,

--- a/src/webrtc/start.ts
+++ b/src/webrtc/start.ts
@@ -15,7 +15,8 @@
 	You should have received a copy of the GNU Affero General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-
+import moduleAlias from "module-alias";
+moduleAlias(__dirname + "../../../package.json");
 process.on("uncaughtException", console.error);
 process.on("unhandledRejection", console.error);
 

--- a/src/webrtc/util/MediaServer.ts
+++ b/src/webrtc/util/MediaServer.ts
@@ -50,6 +50,7 @@ export const loadWebRtcLibrary = async () => {
 		if (!selectedWrtcLibrary)
 			throw new NoConfiguredLibraryError("No library configured in .env");
 
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		mediaServer = new // @ts-ignore
 		(await import(selectedWrtcLibrary)).default();
 


### PR DESCRIPTION
Missed this in the original PR.

This PR imports moduleAlias in `start.ts` so the aliases work when starting webrtc without the bundle

It also enables eslint for webrtc module