### PR TITLE
update guild bans api

### DIFF
--- a/src/util/schemas/responses/TypedResponses.ts
+++ b/src/util/schemas/responses/TypedResponses.ts
@@ -16,7 +16,7 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { GuildCreateResponse } from "@spacebar/util";
+import { GuildBansResponse, GuildCreateResponse } from "@spacebar/util";
 import { GeneralConfiguration, LimitsConfiguration } from "../../config";
 import { DmChannelDTO } from "../../dtos";
 import {
@@ -72,6 +72,8 @@ export type ApplicationEntitlementsResponse = unknown[];
 export type ApplicationSkusResponse = unknown[];
 
 export type APIApplicationArray = Application[];
+
+export type APIBansArray = GuildBansResponse[];
 
 export type APIInviteArray = Invite[];
 


### PR DESCRIPTION
This PR addresses the following:

- [x] `GET /guilds/{guild.id}/bans/{user.id}` should return a response body of type `GuildBansResponse`. Closes https://github.com/spacebarchat/server/issues/1277
- [x] `GET /guilds/{guild.id}/bans` should return response body of type `APIBansArray` which is just an array of `GuildBansResponse`. Closes https://github.com/spacebarchat/server/issues/1275
- [x] `PUT /guilds/{guild.id}/bans/{user.id}` should return 204 empty response on success
- [x] add route `GET /guilds/{guild.id}/bans/search` 

Supersedes https://github.com/spacebarchat/server/pull/1306 which can be closed now 