### PR TITLE
Make guild_folders array overwrite old one instead of merging them

### DIFF
--- a/src/api/routes/users/@me/settings.ts
+++ b/src/api/routes/users/@me/settings.ts
@@ -69,6 +69,8 @@ router.patch(
 		});
 
 		user.settings.assign(body);
+		if (body.guild_folders)
+			user.settings.guild_folders = body.guild_folders;
 
 		await user.settings.save();
 


### PR DESCRIPTION
This should fix a bug where the array is larger than the old array, the client is able to delete elements of the array by submitting a shorter one, instead of being forever cursed with the very long one.