### PR TITLE
Add missing `user` object for interaction messages

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -1058,14 +1058,49 @@
                     "id": {
                         "type": "string"
                     },
-                    "name": {
-                        "type": "string"
-                    },
                     "type": {
                         "$ref": "#/components/schemas/InteractionType"
                     },
+                    "name": {
+                        "type": "string"
+                    },
+                    "command_type": {
+                        "enum": [
+                            1,
+                            2,
+                            3,
+                            4
+                        ],
+                        "type": "number"
+                    },
+                    "ephemerality_reason": {
+                        "type": "integer"
+                    },
                     "user": {
                         "$ref": "#/components/schemas/PublicUser"
+                    },
+                    "authorizing_integration_owners": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": true
+                    },
+                    "original_response_message_id": {
+                        "description": "A container for useful snowflake-related methods.",
+                        "$ref": "#/components/schemas/Snowflake"
+                    },
+                    "interacted_message_id": {
+                        "description": "A container for useful snowflake-related methods.",
+                        "$ref": "#/components/schemas/Snowflake"
+                    },
+                    "triggering_interaction_metadata": {
+                        "$ref": "#/components/schemas/MessageInteractionSchema"
+                    },
+                    "target_user": {
+                        "$ref": "#/components/schemas/PublicUser"
+                    },
+                    "target_message_id": {
+                        "description": "A container for useful snowflake-related methods.",
+                        "$ref": "#/components/schemas/Snowflake"
                     }
                 },
                 "required": [
@@ -1146,6 +1181,10 @@
                     "public_flags",
                     "username"
                 ]
+            },
+            "Snowflake": {
+                "description": "A container for useful snowflake-related methods.",
+                "type": "object"
             },
             "InteractionCallbackSchema": {
                 "type": "object",
@@ -11618,10 +11657,6 @@
                         "type": "string"
                     }
                 }
-            },
-            "Snowflake": {
-                "description": "A container for useful snowflake-related methods.",
-                "type": "object"
             },
             "SendableApplicationCommandDataSchema": {
                 "type": "object",

--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -574,6 +574,12 @@
                     },
                     "avatar_url": {
                         "type": "string"
+                    },
+                    "interaction": {
+                        "$ref": "#/components/schemas/MessageInteractionSchema"
+                    },
+                    "interaction_metadata": {
+                        "$ref": "#/components/schemas/MessageInteractionSchema"
                     }
                 }
             },
@@ -1044,6 +1050,101 @@
                 },
                 "required": [
                     "poll_media"
+                ]
+            },
+            "MessageInteractionSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/InteractionType"
+                    },
+                    "user": {
+                        "$ref": "#/components/schemas/PublicUser"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "type"
+                ]
+            },
+            "InteractionType": {
+                "type": "number",
+                "enum": [
+                    0,
+                    1,
+                    2
+                ]
+            },
+            "PublicUser": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "description": "A Twitter-like snowflake, except the epoch is 2015-01-01T00:00:00.000Z\n```\nIf we have a snowflake '266241948824764416' we can represent it as binary:\n\n64                                          22     17     12          0\n 000000111011000111100001101001000101000000  00001  00000  000000000000\n      number of ms since Discord epoch       worker  pid    increment\n```",
+                        "type": "string"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_type": {
+                        "type": "integer"
+                    },
+                    "theme_colors": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "pronouns": {
+                        "type": "string"
+                    },
+                    "badge_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "premium_type",
+                    "public_flags",
+                    "username"
                 ]
             },
             "InteractionCallbackSchema": {
@@ -5308,7 +5409,7 @@
                             "sending_dns_records": {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/components/schemas/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Types/Domains/Domains\",{with:{\"resolution-mode\":\"import\"}}).DNSRecord"
+                                    "$ref": "#/components/schemas/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Types/Domains/Domains\",{with:{\"resolution-mode\":\"import\"}}).DNSRecord"
                                 }
                             }
                         },
@@ -8831,7 +8932,7 @@
                                 "type": "string"
                             },
                             "template": {
-                                "$ref": "#/components/schemas/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
+                                "$ref": "#/components/schemas/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
                             }
                         },
                         "additionalProperties": false,
@@ -8858,7 +8959,7 @@
                             "items": {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/components/schemas/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
+                                    "$ref": "#/components/schemas/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
                                 }
                             },
                             "paging": {
@@ -8908,7 +9009,7 @@
                         "type": "object",
                         "properties": {
                             "template": {
-                                "$ref": "#/components/schemas/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
+                                "$ref": "#/components/schemas/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
                             }
                         },
                         "additionalProperties": false,
@@ -8996,7 +9097,7 @@
                                 "type": "string"
                             },
                             "template": {
-                                "$ref": "#/components/schemas/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
+                                "$ref": "#/components/schemas/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
                             }
                         },
                         "additionalProperties": false,
@@ -10050,7 +10151,7 @@
                 "type": "object",
                 "properties": {
                     "body": {
-                        "$ref": "#/components/schemas/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Types/Suppressions/Suppressions\",{with:{\"resolution-mode\":\"import\"}}).SuppressionDataType"
+                        "$ref": "#/components/schemas/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Types/Suppressions/Suppressions\",{with:{\"resolution-mode\":\"import\"}}).SuppressionDataType"
                     },
                     "status": {
                         "type": "integer"
@@ -15965,14 +16066,6 @@
                     255
                 ]
             },
-            "InteractionType": {
-                "type": "number",
-                "enum": [
-                    0,
-                    1,
-                    2
-                ]
-            },
             "Poll": {
                 "type": "object",
                 "properties": {
@@ -17219,71 +17312,6 @@
                     "timestamp",
                     "tts",
                     "type"
-                ]
-            },
-            "PublicUser": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "description": "A Twitter-like snowflake, except the epoch is 2015-01-01T00:00:00.000Z\n```\nIf we have a snowflake '266241948824764416' we can represent it as binary:\n\n64                                          22     17     12          0\n 000000111011000111100001101001000101000000  00001  00000  000000000000\n      number of ms since Discord epoch       worker  pid    increment\n```",
-                        "type": "string"
-                    },
-                    "premium_since": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "avatar": {
-                        "type": "string"
-                    },
-                    "username": {
-                        "type": "string"
-                    },
-                    "discriminator": {
-                        "type": "string"
-                    },
-                    "public_flags": {
-                        "type": "integer"
-                    },
-                    "accent_color": {
-                        "type": "integer"
-                    },
-                    "banner": {
-                        "type": "string"
-                    },
-                    "bio": {
-                        "type": "string"
-                    },
-                    "bot": {
-                        "type": "boolean"
-                    },
-                    "premium_type": {
-                        "type": "integer"
-                    },
-                    "theme_colors": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
-                    },
-                    "pronouns": {
-                        "type": "string"
-                    },
-                    "badge_ids": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "required": [
-                    "bio",
-                    "bot",
-                    "discriminator",
-                    "id",
-                    "premium_since",
-                    "premium_type",
-                    "public_flags",
-                    "username"
                 ]
             },
             "GuildMessagesSearchResponse": {
@@ -21381,6 +21409,12 @@
                     },
                     "avatar_url": {
                         "type": "string"
+                    },
+                    "interaction": {
+                        "$ref": "#/components/schemas/MessageInteractionSchema"
+                    },
+                    "interaction_metadata": {
+                        "$ref": "#/components/schemas/MessageInteractionSchema"
                     }
                 }
             },

--- a/assets/schemas.json
+++ b/assets/schemas.json
@@ -1152,14 +1152,49 @@
                     "id": {
                         "type": "string"
                     },
-                    "name": {
-                        "type": "string"
-                    },
                     "type": {
                         "$ref": "#/definitions/InteractionType"
                     },
+                    "name": {
+                        "type": "string"
+                    },
+                    "command_type": {
+                        "enum": [
+                            1,
+                            2,
+                            3,
+                            4
+                        ],
+                        "type": "number"
+                    },
+                    "ephemerality_reason": {
+                        "type": "integer"
+                    },
                     "user": {
                         "$ref": "#/definitions/PublicUser"
+                    },
+                    "authorizing_integration_owners": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": true
+                    },
+                    "original_response_message_id": {
+                        "description": "A container for useful snowflake-related methods.",
+                        "$ref": "#/definitions/Snowflake"
+                    },
+                    "interacted_message_id": {
+                        "description": "A container for useful snowflake-related methods.",
+                        "$ref": "#/definitions/Snowflake"
+                    },
+                    "triggering_interaction_metadata": {
+                        "$ref": "#/definitions/MessageInteractionSchema"
+                    },
+                    "target_user": {
+                        "$ref": "#/definitions/PublicUser"
+                    },
+                    "target_message_id": {
+                        "description": "A container for useful snowflake-related methods.",
+                        "$ref": "#/definitions/Snowflake"
                     }
                 },
                 "additionalProperties": false,
@@ -1242,6 +1277,11 @@
                     "public_flags",
                     "username"
                 ]
+            },
+            "Snowflake": {
+                "description": "A container for useful snowflake-related methods.",
+                "type": "object",
+                "additionalProperties": false
             }
         },
         "$schema": "http://json-schema.org/draft-07/schema#"
@@ -109686,14 +109726,49 @@
                     "id": {
                         "type": "string"
                     },
-                    "name": {
-                        "type": "string"
-                    },
                     "type": {
                         "$ref": "#/definitions/InteractionType"
                     },
+                    "name": {
+                        "type": "string"
+                    },
+                    "command_type": {
+                        "enum": [
+                            1,
+                            2,
+                            3,
+                            4
+                        ],
+                        "type": "number"
+                    },
+                    "ephemerality_reason": {
+                        "type": "integer"
+                    },
                     "user": {
                         "$ref": "#/definitions/PublicUser"
+                    },
+                    "authorizing_integration_owners": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": true
+                    },
+                    "original_response_message_id": {
+                        "description": "A container for useful snowflake-related methods.",
+                        "$ref": "#/definitions/Snowflake"
+                    },
+                    "interacted_message_id": {
+                        "description": "A container for useful snowflake-related methods.",
+                        "$ref": "#/definitions/Snowflake"
+                    },
+                    "triggering_interaction_metadata": {
+                        "$ref": "#/definitions/MessageInteractionSchema"
+                    },
+                    "target_user": {
+                        "$ref": "#/definitions/PublicUser"
+                    },
+                    "target_message_id": {
+                        "description": "A container for useful snowflake-related methods.",
+                        "$ref": "#/definitions/Snowflake"
                     }
                 },
                 "additionalProperties": false,
@@ -109776,6 +109851,11 @@
                     "public_flags",
                     "username"
                 ]
+            },
+            "Snowflake": {
+                "description": "A container for useful snowflake-related methods.",
+                "type": "object",
+                "additionalProperties": false
             }
         },
         "$schema": "http://json-schema.org/draft-07/schema#"
@@ -109857,27 +109937,7 @@
         "$schema": "http://json-schema.org/draft-07/schema#"
     },
     "MessageInteractionSchema": {
-        "type": "object",
-        "properties": {
-            "id": {
-                "type": "string"
-            },
-            "name": {
-                "type": "string"
-            },
-            "type": {
-                "$ref": "#/definitions/InteractionType"
-            },
-            "user": {
-                "$ref": "#/definitions/PublicUser"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "id",
-            "name",
-            "type"
-        ],
+        "$ref": "#/definitions/MessageInteractionSchema",
         "definitions": {
             "InteractionType": {
                 "type": "number",
@@ -109951,6 +110011,69 @@
                     "premium_type",
                     "public_flags",
                     "username"
+                ]
+            },
+            "Snowflake": {
+                "description": "A container for useful snowflake-related methods.",
+                "type": "object",
+                "additionalProperties": false
+            },
+            "MessageInteractionSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/definitions/InteractionType"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "command_type": {
+                        "enum": [
+                            1,
+                            2,
+                            3,
+                            4
+                        ],
+                        "type": "number"
+                    },
+                    "ephemerality_reason": {
+                        "type": "integer"
+                    },
+                    "user": {
+                        "$ref": "#/definitions/PublicUser"
+                    },
+                    "authorizing_integration_owners": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": true
+                    },
+                    "original_response_message_id": {
+                        "description": "A container for useful snowflake-related methods.",
+                        "$ref": "#/definitions/Snowflake"
+                    },
+                    "interacted_message_id": {
+                        "description": "A container for useful snowflake-related methods.",
+                        "$ref": "#/definitions/Snowflake"
+                    },
+                    "triggering_interaction_metadata": {
+                        "$ref": "#/definitions/MessageInteractionSchema"
+                    },
+                    "target_user": {
+                        "$ref": "#/definitions/PublicUser"
+                    },
+                    "target_message_id": {
+                        "description": "A container for useful snowflake-related methods.",
+                        "$ref": "#/definitions/Snowflake"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "id",
+                    "name",
+                    "type"
                 ]
             }
         },
@@ -110636,14 +110759,49 @@
                     "id": {
                         "type": "string"
                     },
-                    "name": {
-                        "type": "string"
-                    },
                     "type": {
                         "$ref": "#/definitions/InteractionType"
                     },
+                    "name": {
+                        "type": "string"
+                    },
+                    "command_type": {
+                        "enum": [
+                            1,
+                            2,
+                            3,
+                            4
+                        ],
+                        "type": "number"
+                    },
+                    "ephemerality_reason": {
+                        "type": "integer"
+                    },
                     "user": {
                         "$ref": "#/definitions/PublicUser"
+                    },
+                    "authorizing_integration_owners": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": true
+                    },
+                    "original_response_message_id": {
+                        "description": "A container for useful snowflake-related methods.",
+                        "$ref": "#/definitions/Snowflake"
+                    },
+                    "interacted_message_id": {
+                        "description": "A container for useful snowflake-related methods.",
+                        "$ref": "#/definitions/Snowflake"
+                    },
+                    "triggering_interaction_metadata": {
+                        "$ref": "#/definitions/MessageInteractionSchema"
+                    },
+                    "target_user": {
+                        "$ref": "#/definitions/PublicUser"
+                    },
+                    "target_message_id": {
+                        "description": "A container for useful snowflake-related methods.",
+                        "$ref": "#/definitions/Snowflake"
                     }
                 },
                 "additionalProperties": false,
@@ -110726,6 +110884,11 @@
                     "public_flags",
                     "username"
                 ]
+            },
+            "Snowflake": {
+                "description": "A container for useful snowflake-related methods.",
+                "type": "object",
+                "additionalProperties": false
             }
         },
         "$schema": "http://json-schema.org/draft-07/schema#"

--- a/assets/schemas.json
+++ b/assets/schemas.json
@@ -654,6 +654,12 @@
                     },
                     "avatar_url": {
                         "type": "string"
+                    },
+                    "interaction": {
+                        "$ref": "#/definitions/MessageInteractionSchema"
+                    },
+                    "interaction_metadata": {
+                        "$ref": "#/definitions/MessageInteractionSchema"
                     }
                 },
                 "additionalProperties": false
@@ -1138,6 +1144,103 @@
                 "additionalProperties": false,
                 "required": [
                     "poll_media"
+                ]
+            },
+            "MessageInteractionSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/definitions/InteractionType"
+                    },
+                    "user": {
+                        "$ref": "#/definitions/PublicUser"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "id",
+                    "name",
+                    "type"
+                ]
+            },
+            "InteractionType": {
+                "type": "number",
+                "enum": [
+                    0,
+                    1,
+                    2
+                ]
+            },
+            "PublicUser": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "description": "A Twitter-like snowflake, except the epoch is 2015-01-01T00:00:00.000Z\n```\nIf we have a snowflake '266241948824764416' we can represent it as binary:\n\n64                                          22     17     12          0\n 000000111011000111100001101001000101000000  00001  00000  000000000000\n      number of ms since Discord epoch       worker  pid    increment\n```",
+                        "type": "string"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_type": {
+                        "type": "integer"
+                    },
+                    "theme_colors": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "pronouns": {
+                        "type": "string"
+                    },
+                    "badge_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "premium_type",
+                    "public_flags",
+                    "username"
                 ]
             }
         },
@@ -11629,7 +11732,7 @@
                     "sending_dns_records": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/definitions/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Types/Domains/Domains\",{with:{\"resolution-mode\":\"import\"}}).DNSRecord"
+                            "$ref": "#/definitions/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Types/Domains/Domains\",{with:{\"resolution-mode\":\"import\"}}).DNSRecord"
                         }
                     }
                 },
@@ -11650,7 +11753,7 @@
             "status"
         ],
         "definitions": {
-            "import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Types/Domains/Domains\",{with:{\"resolution-mode\":\"import\"}}).DNSRecord": {
+            "import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Types/Domains/Domains\",{with:{\"resolution-mode\":\"import\"}}).DNSRecord": {
                 "type": "object",
                 "properties": {
                     "cached": {
@@ -15252,7 +15355,7 @@
                         "type": "string"
                     },
                     "template": {
-                        "$ref": "#/definitions/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
+                        "$ref": "#/definitions/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
                     }
                 },
                 "additionalProperties": false,
@@ -15268,7 +15371,7 @@
             "status"
         ],
         "definitions": {
-            "import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate": {
+            "import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate": {
                 "type": "object",
                 "properties": {
                     "name": {
@@ -15295,7 +15398,7 @@
                         "type": "string"
                     },
                     "version": {
-                        "$ref": "#/definitions/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion"
+                        "$ref": "#/definitions/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion"
                     },
                     "versions": {
                         "type": "array",
@@ -15354,7 +15457,7 @@
                     "name"
                 ]
             },
-            "import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion": {
+            "import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion": {
                 "additionalProperties": false,
                 "type": "object",
                 "properties": {
@@ -15432,7 +15535,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/definitions/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
+                            "$ref": "#/definitions/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
                         }
                     },
                     "paging": {
@@ -15473,7 +15576,7 @@
             "status"
         ],
         "definitions": {
-            "import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate": {
+            "import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate": {
                 "type": "object",
                 "properties": {
                     "name": {
@@ -15500,7 +15603,7 @@
                         "type": "string"
                     },
                     "version": {
-                        "$ref": "#/definitions/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion"
+                        "$ref": "#/definitions/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion"
                     },
                     "versions": {
                         "type": "array",
@@ -15559,7 +15662,7 @@
                     "name"
                 ]
             },
-            "import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion": {
+            "import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion": {
                 "additionalProperties": false,
                 "type": "object",
                 "properties": {
@@ -15635,7 +15738,7 @@
                 "type": "object",
                 "properties": {
                     "template": {
-                        "$ref": "#/definitions/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
+                        "$ref": "#/definitions/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
                     }
                 },
                 "additionalProperties": false,
@@ -15650,7 +15753,7 @@
             "status"
         ],
         "definitions": {
-            "import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate": {
+            "import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate": {
                 "type": "object",
                 "properties": {
                     "name": {
@@ -15677,7 +15780,7 @@
                         "type": "string"
                     },
                     "version": {
-                        "$ref": "#/definitions/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion"
+                        "$ref": "#/definitions/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion"
                     },
                     "versions": {
                         "type": "array",
@@ -15736,7 +15839,7 @@
                     "name"
                 ]
             },
-            "import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion": {
+            "import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion": {
                 "additionalProperties": false,
                 "type": "object",
                 "properties": {
@@ -15880,7 +15983,7 @@
                         "type": "string"
                     },
                     "template": {
-                        "$ref": "#/definitions/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
+                        "$ref": "#/definitions/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate"
                     }
                 },
                 "additionalProperties": false,
@@ -15896,7 +15999,7 @@
             "status"
         ],
         "definitions": {
-            "import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate": {
+            "import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Interfaces/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).IDomainTemplate": {
                 "type": "object",
                 "properties": {
                     "name": {
@@ -15923,7 +16026,7 @@
                         "type": "string"
                     },
                     "version": {
-                        "$ref": "#/definitions/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion"
+                        "$ref": "#/definitions/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion"
                     },
                     "versions": {
                         "type": "array",
@@ -15982,7 +16085,7 @@
                     "name"
                 ]
             },
-            "import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion": {
+            "import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Types/Domains/DomainTemplates\",{with:{\"resolution-mode\":\"import\"}}).TemplateVersion": {
                 "additionalProperties": false,
                 "type": "object",
                 "properties": {
@@ -17115,7 +17218,7 @@
         "type": "object",
         "properties": {
             "body": {
-                "$ref": "#/definitions/import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Types/Suppressions/Suppressions\",{with:{\"resolution-mode\":\"import\"}}).SuppressionDataType"
+                "$ref": "#/definitions/import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Types/Suppressions/Suppressions\",{with:{\"resolution-mode\":\"import\"}}).SuppressionDataType"
             },
             "status": {
                 "type": "integer"
@@ -17127,7 +17230,7 @@
             "status"
         ],
         "definitions": {
-            "import(\"/home/Rory/git/spacebar/server-master/node_modules/mailgun.js/Types/Types/Suppressions/Suppressions\",{with:{\"resolution-mode\":\"import\"}}).SuppressionDataType": {
+            "import(\"/home/cyber/Dokumenty/git-projects/private/spacebar-test-station/server/node_modules/mailgun.js/Types/Types/Suppressions/Suppressions\",{with:{\"resolution-mode\":\"import\"}}).SuppressionDataType": {
                 "anyOf": [
                     {
                         "type": "object",
@@ -109085,6 +109188,12 @@
             },
             "avatar_url": {
                 "type": "string"
+            },
+            "interaction": {
+                "$ref": "#/definitions/MessageInteractionSchema"
+            },
+            "interaction_metadata": {
+                "$ref": "#/definitions/MessageInteractionSchema"
             }
         },
         "additionalProperties": false,
@@ -109570,6 +109679,103 @@
                 "required": [
                     "poll_media"
                 ]
+            },
+            "MessageInteractionSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/definitions/InteractionType"
+                    },
+                    "user": {
+                        "$ref": "#/definitions/PublicUser"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "id",
+                    "name",
+                    "type"
+                ]
+            },
+            "InteractionType": {
+                "type": "number",
+                "enum": [
+                    0,
+                    1,
+                    2
+                ]
+            },
+            "PublicUser": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "description": "A Twitter-like snowflake, except the epoch is 2015-01-01T00:00:00.000Z\n```\nIf we have a snowflake '266241948824764416' we can represent it as binary:\n\n64                                          22     17     12          0\n 000000111011000111100001101001000101000000  00001  00000  000000000000\n      number of ms since Discord epoch       worker  pid    increment\n```",
+                        "type": "string"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_type": {
+                        "type": "integer"
+                    },
+                    "theme_colors": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "pronouns": {
+                        "type": "string"
+                    },
+                    "badge_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "premium_type",
+                    "public_flags",
+                    "username"
+                ]
             }
         },
         "$schema": "http://json-schema.org/draft-07/schema#"
@@ -109645,6 +109851,106 @@
                 "additionalProperties": false,
                 "required": [
                     "poll_media"
+                ]
+            }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "MessageInteractionSchema": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string"
+            },
+            "name": {
+                "type": "string"
+            },
+            "type": {
+                "$ref": "#/definitions/InteractionType"
+            },
+            "user": {
+                "$ref": "#/definitions/PublicUser"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "id",
+            "name",
+            "type"
+        ],
+        "definitions": {
+            "InteractionType": {
+                "type": "number",
+                "enum": [
+                    0,
+                    1,
+                    2
+                ]
+            },
+            "PublicUser": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "description": "A Twitter-like snowflake, except the epoch is 2015-01-01T00:00:00.000Z\n```\nIf we have a snowflake '266241948824764416' we can represent it as binary:\n\n64                                          22     17     12          0\n 000000111011000111100001101001000101000000  00001  00000  000000000000\n      number of ms since Discord epoch       worker  pid    increment\n```",
+                        "type": "string"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_type": {
+                        "type": "integer"
+                    },
+                    "theme_colors": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "pronouns": {
+                        "type": "string"
+                    },
+                    "badge_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "premium_type",
+                    "public_flags",
+                    "username"
                 ]
             }
         },
@@ -109832,6 +110138,12 @@
             },
             "avatar_url": {
                 "type": "string"
+            },
+            "interaction": {
+                "$ref": "#/definitions/MessageInteractionSchema"
+            },
+            "interaction_metadata": {
+                "$ref": "#/definitions/MessageInteractionSchema"
             }
         },
         "additionalProperties": false,
@@ -110316,6 +110628,103 @@
                 "additionalProperties": false,
                 "required": [
                     "poll_media"
+                ]
+            },
+            "MessageInteractionSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/definitions/InteractionType"
+                    },
+                    "user": {
+                        "$ref": "#/definitions/PublicUser"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "id",
+                    "name",
+                    "type"
+                ]
+            },
+            "InteractionType": {
+                "type": "number",
+                "enum": [
+                    0,
+                    1,
+                    2
+                ]
+            },
+            "PublicUser": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "description": "A Twitter-like snowflake, except the epoch is 2015-01-01T00:00:00.000Z\n```\nIf we have a snowflake '266241948824764416' we can represent it as binary:\n\n64                                          22     17     12          0\n 000000111011000111100001101001000101000000  00001  00000  000000000000\n      number of ms since Discord epoch       worker  pid    increment\n```",
+                        "type": "string"
+                    },
+                    "premium_since": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "username": {
+                        "type": "string"
+                    },
+                    "discriminator": {
+                        "type": "string"
+                    },
+                    "public_flags": {
+                        "type": "integer"
+                    },
+                    "accent_color": {
+                        "type": "integer"
+                    },
+                    "banner": {
+                        "type": "string"
+                    },
+                    "bio": {
+                        "type": "string"
+                    },
+                    "bot": {
+                        "type": "boolean"
+                    },
+                    "premium_type": {
+                        "type": "integer"
+                    },
+                    "theme_colors": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "pronouns": {
+                        "type": "string"
+                    },
+                    "badge_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bio",
+                    "bot",
+                    "discriminator",
+                    "id",
+                    "premium_since",
+                    "premium_type",
+                    "public_flags",
+                    "username"
                 ]
             }
         },

--- a/src/api/routes/channels/#channel_id/messages/index.ts
+++ b/src/api/routes/channels/#channel_id/messages/index.ts
@@ -230,10 +230,9 @@ router.get(
 		});
 
 		await ret
-			.filter((x) => x.interaction_metadata && !x.interaction_metadata.user)
-			.forEachAsync(async (x) => {
-				x.interaction_metadata!.user = await User.findOne({ where: { id: x.interaction_metadata!.user_id } });
-				x.interaction!.user = await User.findOne({ where: { id: x.interaction_metadata!.user_id } });
+			.filter((x: MessageCreateSchema) => x.interaction_metadata && !x.interaction_metadata.user)
+			.forEachAsync(async (x: MessageCreateSchema) => {
+				x.interaction_metadata!.user = x.interaction!.user = await User.findOneOrFail({ where: { id: (x as Message).interaction_metadata!.user_id } });
 			});
 
 		// polyfill message references for old messages

--- a/src/schemas/uncategorised/MessageCreateSchema.ts
+++ b/src/schemas/uncategorised/MessageCreateSchema.ts
@@ -16,8 +16,8 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { InteractionType } from "@spacebar/util";
-import { ActionRowComponent, Embed, PollAnswer, PollMedia, PublicUser } from "@spacebar/schemas";
+import { InteractionType, Snowflake } from "@spacebar/util";
+import { ActionRowComponent, ApplicationCommandType, Embed, PollAnswer, PollMedia, PublicUser } from "@spacebar/schemas";
 
 export type MessageCreateAttachment = {
 	id: string;
@@ -84,7 +84,15 @@ export interface PollCreationSchema {
 
 interface MessageInteractionSchema {
 	id: string;
-	name: string;
 	type: InteractionType;
+	name: string;
+	command_type?: ApplicationCommandType;
+	ephemerality_reason?: number;
 	user?: PublicUser; // It has to be optional cause LSP gives an errors for some reason
+	authorizing_integration_owners?: object; // It has to be optional cause LSP gives an errors for some reason
+	original_response_message_id?: Snowflake;
+	interacted_message_id?: Snowflake;
+	triggering_interaction_metadata?: MessageInteractionSchema;
+	target_user?: PublicUser;
+	target_message_id?: Snowflake;
 }

--- a/src/schemas/uncategorised/MessageCreateSchema.ts
+++ b/src/schemas/uncategorised/MessageCreateSchema.ts
@@ -16,7 +16,8 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { ActionRowComponent, Embed, PollAnswer, PollMedia } from "@spacebar/schemas"
+import { InteractionType } from "@spacebar/util";
+import { ActionRowComponent, Embed, PollAnswer, PollMedia, PublicUser } from "@spacebar/schemas";
 
 export type MessageCreateAttachment = {
 	id: string;
@@ -28,7 +29,7 @@ export type MessageCreateCloudAttachment = {
 	filename: string;
 	uploaded_filename: string;
 	original_content_type?: string;
-}
+};
 
 export interface MessageCreateSchema {
 	type?: number;
@@ -68,6 +69,8 @@ export interface MessageCreateSchema {
 	applied_tags?: string[]; // Not implemented yet, for webhooks in forums
 	thread_name?: string; // Not implemented yet, for webhooks
 	avatar_url?: string; // Not implemented yet, for webhooks
+	interaction?: MessageInteractionSchema;
+	interaction_metadata?: MessageInteractionSchema;
 }
 
 // TypeScript complains once this is used above
@@ -77,4 +80,11 @@ export interface PollCreationSchema {
 	duration?: number;
 	allow_multiselect?: boolean;
 	layout_type?: number;
+}
+
+interface MessageInteractionSchema {
+	id: string;
+	name: string;
+	type: InteractionType;
+	user?: PublicUser; // It has to be optional cause LSP gives an errors for some reason
 }

--- a/src/util/entities/Message.ts
+++ b/src/util/entities/Message.ts
@@ -174,6 +174,7 @@ export class Message extends BaseClass {
 
 	@Column({ type: "simple-json", nullable: true })
 	interaction?: {
+		user: User | null;
 		id: string;
 		type: InteractionType;
 		name: string;
@@ -181,6 +182,7 @@ export class Message extends BaseClass {
 
 	@Column({ type: "simple-json", nullable: true })
 	interaction_metadata?: {
+		user: User | null;
 		id: string;
 		type: InteractionType;
 		user_id: string;

--- a/src/util/entities/Message.ts
+++ b/src/util/entities/Message.ts
@@ -174,7 +174,6 @@ export class Message extends BaseClass {
 
 	@Column({ type: "simple-json", nullable: true })
 	interaction?: {
-		user: User | null;
 		id: string;
 		type: InteractionType;
 		name: string;
@@ -182,7 +181,6 @@ export class Message extends BaseClass {
 
 	@Column({ type: "simple-json", nullable: true })
 	interaction_metadata?: {
-		user: User | null;
 		id: string;
 		type: InteractionType;
 		user_id: string;

--- a/src/util/entities/Message.ts
+++ b/src/util/entities/Message.ts
@@ -214,6 +214,7 @@ export class Message extends BaseClass {
 			guild: this.guild ?? undefined,
 			webhook: this.webhook ?? undefined,
 			interaction: this.interaction ?? undefined,
+			interaction_metadata: this.interaction_metadata ?? undefined,
 			reactions: this.reactions ?? undefined,
 			sticker_items: this.sticker_items ?? undefined,
 			message_reference: this.message_reference ?? undefined,


### PR DESCRIPTION
This PR adds the missing `user` object to both `interaction` and `interaction_metadata`.