### PR TITLE
chore: do a migration to delete bot users with no application

### DIFF
--- a/src/util/migration/postgres/1761113394664-delete-bot-users-without-an-application.ts
+++ b/src/util/migration/postgres/1761113394664-delete-bot-users-without-an-application.ts
@@ -1,0 +1,9 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DeleteBotUsersWithoutAnApplication1761113394664 implements MigrationInterface {
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`DELETE FROM users WHERE bot = true AND id NOT IN (SELECT bot_user_id FROM applications);`);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
So you don't have to do it manually