### PR TITLE
Gif stickers should have `format_type` 4 instead of 0

### DIFF
--- a/src/schemas/api/guilds/Sticker.ts
+++ b/src/schemas/api/guilds/Sticker.ts
@@ -4,8 +4,8 @@ export enum StickerType {
 }
 
 export enum StickerFormatType {
-	GIF = 0, // gif is a custom format type and not in discord spec
 	PNG = 1,
 	APNG = 2,
 	LOTTIE = 3,
+	GIF = 4,
 }

--- a/src/util/migration/postgres/1762611552514-fix-gif-stickers-format_type.ts
+++ b/src/util/migration/postgres/1762611552514-fix-gif-stickers-format_type.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class FixGifStickersFormatType1762611552514 implements MigrationInterface {
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`UPDATE "stickers" SET "format_type" = 4 WHERE "format_type" = 0;`);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`UPDATE "stickers" SET "format_type" = 0 WHERE "format_type" = 4;`);
+	}
+}


### PR DESCRIPTION
According to discord.food, gif stickers have `format_type` of `4`, not `0`.