### PR TITLE
prevent bots from joining guild with config

### DIFF
--- a/src/util/config/types/subconfigurations/guild/AutoJoin.ts
+++ b/src/util/config/types/subconfigurations/guild/AutoJoin.ts
@@ -20,4 +20,5 @@ export class AutoJoinConfiguration {
 	enabled: boolean = true;
 	guilds: string[] = [];
 	canLeave: boolean = true;
+	bots: boolean = false;
 }

--- a/src/util/entities/User.ts
+++ b/src/util/entities/User.ts
@@ -157,7 +157,7 @@ export class User extends BaseClass {
 	@OneToOne(() => UserSettings, {
 		cascade: true,
 		orphanedRowAction: "delete",
-		nullable: true
+		nullable: true,
 	})
 	@JoinColumn()
 	settings?: UserSettings;
@@ -257,6 +257,7 @@ export class User extends BaseClass {
 		password,
 		id,
 		req,
+		bot,
 	}: {
 		username: string;
 		password?: string;
@@ -264,6 +265,7 @@ export class User extends BaseClass {
 		date_of_birth?: Date; // "2000-04-03"
 		id?: string;
 		req?: Request;
+		bot?: boolean;
 	}) {
 		// trim special uf8 control characters -> Backspace, Newline, ...
 		username = trimSpecial(username);
@@ -306,6 +308,7 @@ export class User extends BaseClass {
 			premium_type: Config.get().defaults.user.premiumType ?? 0,
 			verified: Config.get().defaults.user.verified ?? true,
 			created_at: new Date(),
+			bot: !!bot,
 		});
 
 		user.validate();
@@ -319,6 +322,12 @@ export class User extends BaseClass {
 		}
 
 		setImmediate(async () => {
+			if (bot) {
+				const { guild } = Config.get();
+				if (!guild.autoJoin.bots) {
+					return;
+				}
+			}
 			if (Config.get().guild.autoJoin.enabled) {
 				for (const guild of Config.get().guild.autoJoin.guilds || []) {
 					await Member.addToGuild(user.id, guild).catch((e) => console.error("[Autojoin]", e));

--- a/src/util/util/Application.ts
+++ b/src/util/util/Application.ts
@@ -7,6 +7,7 @@ export async function createAppBotUser(app: Application, req: Request) {
 		password: undefined,
 		id: app.id,
 		req,
+		bot: true,
 	});
 
 	user.id = app.id;


### PR DESCRIPTION
This should prevent bots from autojoining the auto-join guilds, which is something one would want if they don't want their main guilds to be flooded with bots without the moderators adding them