### PR TITLE
ignore bun lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tmp/
 dump/
 result
 jwt.key*
+bun.lock


### PR DESCRIPTION
This just makes it so git ignore includes the bun lock file so that way when devs use bun git will ignore the lock file