### PR TITLE
update last message id in more places

### DIFF
--- a/src/api/routes/channels/#channel_id/greet.ts
+++ b/src/api/routes/channels/#channel_id/greet.ts
@@ -20,7 +20,7 @@ import { route } from "@spacebar/api";
 import { Channel, emitEvent, Message, MessageCreateEvent, Permissions, Sticker } from "@spacebar/util";
 import { Request, Response, Router } from "express";
 import { In } from "typeorm";
-import { GreetRequestSchema, MessageType } from "@spacebar/schemas"
+import { GreetRequestSchema, MessageType } from "@spacebar/schemas";
 
 const router: Router = Router({ mergeParams: true });
 
@@ -88,6 +88,8 @@ router.post(
 			sticker_items: randomSticker ? [{ id: randomSticker.id, name: randomSticker.name, format_type: randomSticker.format_type }] : [],
 		});
 
+		channel.last_message_id = message.id;
+
 		await Promise.all([
 			message.save(),
 			emitEvent({
@@ -95,6 +97,7 @@ router.post(
 				data: message,
 				channel_id,
 			} as MessageCreateEvent),
+			channel.save(),
 		]);
 
 		res.send(channel);

--- a/src/util/entities/Member.ts
+++ b/src/util/entities/Member.ts
@@ -397,6 +397,9 @@ export class Member extends BaseClassWithoutId {
 		]);
 
 		if (guild.system_channel_id) {
+			const channel = await Channel.findOneOrFail({
+				where: { id: guild.system_channel_id },
+			});
 			// Send a welcome message
 			const message = Message.create({
 				type: 7,
@@ -414,6 +417,9 @@ export class Member extends BaseClassWithoutId {
 				mention_roles: [],
 				mention_everyone: false,
 			});
+
+			channel.last_message_id = message.id;
+
 			await Promise.all([
 				message.save(),
 				emitEvent({
@@ -421,6 +427,7 @@ export class Member extends BaseClassWithoutId {
 					channel_id: message.channel_id,
 					data: message,
 				} as MessageCreateEvent),
+				channel.save(),
 			]);
 		}
 	}


### PR DESCRIPTION
This update should update the last message id in the greet message endpoint and the Member creation message.
fixes: https://github.com/spacebarchat/server/issues/1336