### PR TITLE
fix greet API

### DIFF
--- a/src/api/routes/channels/#channel_id/greet.ts
+++ b/src/api/routes/channels/#channel_id/greet.ts
@@ -20,7 +20,7 @@ import { route } from "@spacebar/api";
 import { Channel, emitEvent, Message, MessageCreateEvent, Permissions, Sticker } from "@spacebar/util";
 import { Request, Response, Router } from "express";
 import { In } from "typeorm";
-import { GreetRequestSchema, MessageType } from "@spacebar/schemas"
+import { GreetRequestSchema, MessageType } from "@spacebar/schemas";
 
 const router: Router = Router({ mergeParams: true });
 
@@ -28,7 +28,7 @@ router.post(
 	"/",
 	route({
 		requestBody: "GreetRequestSchema",
-		permission: "MANAGE_CHANNELS",
+		permission: "SEND_MESSAGES",
 		responses: {
 			200: {
 				body: "Message",
@@ -97,7 +97,7 @@ router.post(
 			} as MessageCreateEvent),
 		]);
 
-		res.send(channel);
+		res.send(message);
 	},
 );
 


### PR DESCRIPTION
This should conform with the API here https://docs.discord.food/resources/message#create-greet-message
Now the API returns the message instead of the channel and requires the `SEND_MESSAGES` permission instead of the `MANAGE_CHANNELS` permission