### PR TITLE
Prevent bots from joining guilds on their own

### DIFF
--- a/src/api/routes/guilds/#guild_id/members/#member_id/index.ts
+++ b/src/api/routes/guilds/#guild_id/members/#member_id/index.ts
@@ -168,6 +168,7 @@ router.put(
 		if (member_id === "@me") {
 			member_id = req.user_id;
 			rights.hasThrow("JOIN_GUILDS");
+			if (req.user_bot) throw DiscordApiErrors.BOT_PROHIBITED_ENDPOINT;
 		} else {
 			// TODO: check oauth2 scope
 


### PR DESCRIPTION
Bots should not be able to join guilds on their own, as with the invite API, we should throw an error to prevent this from happening