### PR TITLE
update schema for voiceIdentify

### DIFF
--- a/src/schemas/webrtc/VoiceIdentifySchema.ts
+++ b/src/schemas/webrtc/VoiceIdentifySchema.ts
@@ -20,6 +20,7 @@ export interface VoiceIdentifySchema {
 	server_id: string;
 	user_id: string;
 	session_id: string;
+	channel_id?: string;
 	token: string;
 	video?: boolean;
 	streams?: {
@@ -27,5 +28,7 @@ export interface VoiceIdentifySchema {
 		rid: string;
 		quality: number;
 	}[];
+	// Discord keeps changing the property name of this, probably will keep changing until Dave is finalized
 	max_secure_frames_version?: number;
+	max_dave_protocol_version?: number;
 }


### PR DESCRIPTION
Should resolve the error:

```
[WebRTC] Opcode IDENTIFY
[Validator] Validation error in  VoiceIdentifySchema
[WebRTC] error [
  {
    instancePath: '',
    schemaPath: '#/additionalProperties',
    keyword: 'additionalProperties',
    params: { additionalProperty: 'channel_id' },
    message: 'must NOT have additional properties'
  },
  {
    instancePath: '',
    schemaPath: '#/additionalProperties',
    keyword: 'additionalProperties',
    params: { additionalProperty: 'max_dave_protocol_version' },
    message: 'must NOT have additional properties'
  }
]
[WebRTC] closed 4003 
```