### PR TITLE
Two fixes for discord mobile app to work

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -1440,10 +1440,7 @@
                         "properties": {
                             "guild_hashes": {},
                             "highest_last_message_id": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ]
+                                "type": "integer"
                             },
                             "read_state_version": {
                                 "type": "integer"
@@ -1475,10 +1472,7 @@
                         "properties": {
                             "guildHashes": {},
                             "highestLastMessageId": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ]
+                                "type": "integer"
                             },
                             "readStateVersion": {
                                 "type": "integer"

--- a/assets/schemas.json
+++ b/assets/schemas.json
@@ -1473,10 +1473,7 @@
                 "properties": {
                     "guild_hashes": {},
                     "highest_last_message_id": {
-                        "type": [
-                            "string",
-                            "integer"
-                        ]
+                        "type": "integer"
                     },
                     "read_state_version": {
                         "type": "integer"
@@ -1508,10 +1505,7 @@
                 "properties": {
                     "guildHashes": {},
                     "highestLastMessageId": {
-                        "type": [
-                            "string",
-                            "integer"
-                        ]
+                        "type": "integer"
                     },
                     "readStateVersion": {
                         "type": "integer"

--- a/src/gateway/opcodes/Identify.ts
+++ b/src/gateway/opcodes/Identify.ts
@@ -536,6 +536,7 @@ export async function onIdentify(this: WebSocket, data: Payload) {
 			version: 0, // TODO
 		},
 		private_channels: channels,
+		presences: [], // TODO: Send actual data
 		session_id: this.session_id,
 		country_code: user.settings.locale, // TODO: do ip analysis instead
 		users: Array.from(users),

--- a/src/schemas/gateway/IdentifySchema.ts
+++ b/src/schemas/gateway/IdentifySchema.ts
@@ -18,7 +18,7 @@
 
 // TODO: Need a way to allow camalCase and pascal_case without just duplicating the schema
 
-import { ActivitySchema } from "@spacebar/schemas"
+import { ActivitySchema } from "@spacebar/schemas";
 
 export const IdentifySchema = {
 	token: String,
@@ -58,7 +58,7 @@ export const IdentifySchema = {
 	$capabilities: Number,
 	$client_state: {
 		$guild_hashes: Object,
-		$highest_last_message_id: String || Number,
+		$highest_last_message_id: Number,
 		$read_state_version: Number,
 		$user_guild_settings_version: Number,
 		$user_settings_version: undefined,
@@ -70,7 +70,7 @@ export const IdentifySchema = {
 	},
 	$clientState: {
 		$guildHashes: Object,
-		$highestLastMessageId: String || Number,
+		$highestLastMessageId: Number,
 		$readStateVersion: Number,
 		$useruserGuildSettingsVersion: undefined,
 		$userGuildSettingsVersion: undefined,
@@ -120,7 +120,7 @@ export interface IdentifySchema {
 	capabilities?: number;
 	client_state?: {
 		guild_hashes?: unknown;
-		highest_last_message_id?: string | number;
+		highest_last_message_id?: number;
 		read_state_version?: number;
 		user_guild_settings_version?: number;
 		user_settings_version?: number;
@@ -132,7 +132,7 @@ export interface IdentifySchema {
 	};
 	clientState?: {
 		guildHashes?: unknown;
-		highestLastMessageId?: string | number;
+		highestLastMessageId?: number;
 		readStateVersion?: number;
 		userGuildSettingsVersion?: number;
 		useruserGuildSettingsVersion?: number;

--- a/src/util/interfaces/Event.ts
+++ b/src/util/interfaces/Event.ts
@@ -69,6 +69,7 @@ export interface ReadyEventData {
 	v: number;
 	user: UserPrivate;
 	private_channels: ReadyPrivateChannel[]; // this will be empty for bots
+	presences: Presence[];
 	session_id: string; // resuming
 	guilds: IReadyGuildDTO[] | GuildOrUnavailable[]; // depends on capability
 	analytics_token?: string;


### PR DESCRIPTION
The app expects `presences` array to be included in the `READY` event, so I did (empty for now cause yes). Also, I discovered that there's a bug in lambert-server's `check` function that ignores arrays of types, but `highest_last_message_id` is always a number apparently.