### PR TITLE
TODO: remove getIpAddress from API

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -30,17 +30,6 @@
             }
         },
         "schemas": {
-            "CreateFingerprintResponse": {
-                "type": "object",
-                "properties": {
-                    "fingerprint": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "fingerprint"
-                ]
-            },
             "ApplicationCommandSchema": {
                 "type": "object",
                 "properties": {
@@ -3109,9 +3098,6 @@
             "APIPrivateUser": {
                 "type": "object",
                 "properties": {
-                    "email": {
-                        "type": "string"
-                    },
                     "id": {
                         "description": "A Twitter-like snowflake, except the epoch is 2015-01-01T00:00:00.000Z\n```\nIf we have a snowflake '266241948824764416' we can represent it as binary:\n\n64                                          22     17     12          0\n 000000111011000111100001101001000101000000  00001  00000  000000000000\n      number of ms since Discord epoch       worker  pid    increment\n```",
                         "type": "string"
@@ -3121,6 +3107,9 @@
                     },
                     "disabled": {
                         "type": "boolean"
+                    },
+                    "email": {
+                        "type": "string"
                     },
                     "verified": {
                         "type": "boolean"
@@ -3236,9 +3225,6 @@
                     "newToken": {
                         "type": "string"
                     },
-                    "email": {
-                        "type": "string"
-                    },
                     "id": {
                         "description": "A Twitter-like snowflake, except the epoch is 2015-01-01T00:00:00.000Z\n```\nIf we have a snowflake '266241948824764416' we can represent it as binary:\n\n64                                          22     17     12          0\n 000000111011000111100001101001000101000000  00001  00000  000000000000\n      number of ms since Discord epoch       worker  pid    increment\n```",
                         "type": "string"
@@ -3248,6 +3234,9 @@
                     },
                     "disabled": {
                         "type": "boolean"
+                    },
+                    "email": {
+                        "type": "string"
                     },
                     "verified": {
                         "type": "boolean"
@@ -6945,6 +6934,17 @@
                 "items": {
                     "$ref": "#/components/schemas/ApplicationCommandCreateSchema"
                 }
+            },
+            "CreateFingerprintResponse": {
+                "type": "object",
+                "properties": {
+                    "fingerprint": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "fingerprint"
+                ]
             },
             "ApplicationCommandOption": {
                 "type": "object",
@@ -12138,7 +12138,7 @@
                             "length": {
                                 "type": "integer"
                             },
-                            "__@unscopables@698": {
+                            "__@unscopables@703": {
                                 "type": "object",
                                 "additionalProperties": false,
                                 "patternProperties": {
@@ -12267,17 +12267,17 @@
                                     "remove": {
                                         "type": "boolean"
                                     },
-                                    "__@iterator@696": {
+                                    "__@iterator@670": {
                                         "type": "boolean"
                                     },
-                                    "__@unscopables@698": {
+                                    "__@unscopables@703": {
                                         "type": "boolean"
                                     }
                                 }
                             }
                         },
                         "required": [
-                            "__@unscopables@698",
+                            "__@unscopables@703",
                             "length"
                         ]
                     },

--- a/assets/schemas.json
+++ b/assets/schemas.json
@@ -1,17 +1,4 @@
 {
-    "CreateFingerprintResponse": {
-        "type": "object",
-        "properties": {
-            "fingerprint": {
-                "type": "string"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "fingerprint"
-        ],
-        "$schema": "http://json-schema.org/draft-07/schema#"
-    },
     "ApplicationCommandSchema": {
         "type": "object",
         "properties": {
@@ -3260,9 +3247,6 @@
     "APIPrivateUser": {
         "type": "object",
         "properties": {
-            "email": {
-                "type": "string"
-            },
             "id": {
                 "description": "A Twitter-like snowflake, except the epoch is 2015-01-01T00:00:00.000Z\n```\nIf we have a snowflake '266241948824764416' we can represent it as binary:\n\n64                                          22     17     12          0\n 000000111011000111100001101001000101000000  00001  00000  000000000000\n      number of ms since Discord epoch       worker  pid    increment\n```",
                 "type": "string"
@@ -3272,6 +3256,9 @@
             },
             "disabled": {
                 "type": "boolean"
+            },
+            "email": {
+                "type": "string"
             },
             "verified": {
                 "type": "boolean"
@@ -3392,9 +3379,6 @@
             "newToken": {
                 "type": "string"
             },
-            "email": {
-                "type": "string"
-            },
             "id": {
                 "description": "A Twitter-like snowflake, except the epoch is 2015-01-01T00:00:00.000Z\n```\nIf we have a snowflake '266241948824764416' we can represent it as binary:\n\n64                                          22     17     12          0\n 000000111011000111100001101001000101000000  00001  00000  000000000000\n      number of ms since Discord epoch       worker  pid    increment\n```",
                 "type": "string"
@@ -3404,6 +3388,9 @@
             },
             "disabled": {
                 "type": "boolean"
+            },
+            "email": {
+                "type": "string"
             },
             "verified": {
                 "type": "boolean"
@@ -7389,6 +7376,19 @@
         "items": {
             "$ref": "#/definitions/ApplicationCommandCreateSchema"
         },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "CreateFingerprintResponse": {
+        "type": "object",
+        "properties": {
+            "fingerprint": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "fingerprint"
+        ],
         "$schema": "http://json-schema.org/draft-07/schema#"
     },
     "ApplicationCommandOption": {
@@ -12890,7 +12890,7 @@
                     "length": {
                         "type": "integer"
                     },
-                    "__@unscopables@698": {
+                    "__@unscopables@703": {
                         "type": "object",
                         "additionalProperties": false,
                         "patternProperties": {
@@ -13019,17 +13019,17 @@
                             "remove": {
                                 "type": "boolean"
                             },
-                            "__@iterator@696": {
+                            "__@iterator@670": {
                                 "type": "boolean"
                             },
-                            "__@unscopables@698": {
+                            "__@unscopables@703": {
                                 "type": "boolean"
                             }
                         }
                     }
                 },
                 "required": [
-                    "__@unscopables@698",
+                    "__@unscopables@703",
                     "length"
                 ]
             },

--- a/src/api/middlewares/RateLimit.ts
+++ b/src/api/middlewares/RateLimit.ts
@@ -16,7 +16,6 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { getIpAdress } from "@spacebar/api";
 import { Config, getRights, listenEvent } from "@spacebar/util";
 import { NextFunction, Request, Response, Router } from "express";
 import { API_PREFIX_TRAILING_SLASH } from "./Authentication";
@@ -65,21 +64,14 @@ export default function rateLimit(opts: {
 			if (rights.has("BYPASS_RATE_LIMITS")) return next();
 		}
 
-		const bucket_id =
-			opts.bucket ||
-			req.originalUrl.replace(API_PREFIX_TRAILING_SLASH, "");
-		let executor_id = getIpAdress(req);
+		const bucket_id = opts.bucket || req.originalUrl.replace(API_PREFIX_TRAILING_SLASH, "");
+		let executor_id = req.ip || "127.0.0.1";
 		if (!opts.onlyIp && req.user_id) executor_id = req.user_id;
 
 		let max_hits = opts.count;
 		if (opts.bot && req.user_bot) max_hits = opts.bot;
-		if (opts.GET && ["GET", "OPTIONS", "HEAD"].includes(req.method))
-			max_hits = opts.GET;
-		else if (
-			opts.MODIFY &&
-			["POST", "DELETE", "PATCH", "PUT"].includes(req.method)
-		)
-			max_hits = opts.MODIFY;
+		if (opts.GET && ["GET", "OPTIONS", "HEAD"].includes(req.method)) max_hits = opts.GET;
+		else if (opts.MODIFY && ["POST", "DELETE", "PATCH", "PUT"].includes(req.method)) max_hits = opts.MODIFY;
 
 		const offender = Cache.get(executor_id + bucket_id);
 
@@ -104,18 +96,13 @@ export default function rateLimit(opts: {
 			}
 
 			res.set("X-RateLimit-Reset", `${reset}`);
-			res.set(
-				"X-RateLimit-Reset-After",
-				`${Math.max(0, Math.ceil(resetAfterSec))}`,
-			);
+			res.set("X-RateLimit-Reset-After", `${Math.max(0, Math.ceil(resetAfterSec))}`);
 
 			if (offender.blocked) {
 				const global = bucket_id === "global";
 				// each block violation pushes the expiry one full window further
 				reset += opts.window * 1000;
-				offender.expires_at = new Date(
-					offender.expires_at.getTime() + opts.window * 1000,
-				);
+				offender.expires_at = new Date(offender.expires_at.getTime() + opts.window * 1000);
 				resetAfterMs = reset - Date.now();
 				resetAfterSec = Math.ceil(resetAfterMs / 1000);
 
@@ -129,10 +116,7 @@ export default function rateLimit(opts: {
 					res
 						.status(429)
 						.set("X-RateLimit-Remaining", "0")
-						.set(
-							"Retry-After",
-							`${Math.max(0, Math.ceil(resetAfterSec))}`,
-						)
+						.set("Retry-After", `${Math.max(0, Math.ceil(resetAfterSec))}`)
 						// TODO: error rate limit message translation
 						.send({
 							message: "You are being rate limited.",
@@ -156,11 +140,7 @@ export default function rateLimit(opts: {
 				// check if error and increment error rate limit
 				if (res.statusCode >= 400 && opts.error) {
 					return hitRoute(hitRouteOpts);
-				} else if (
-					res.statusCode >= 200 &&
-					res.statusCode < 300 &&
-					opts.success
-				) {
+				} else if (res.statusCode >= 200 && res.statusCode < 300 && opts.success) {
 					return hitRoute(hitRouteOpts);
 				}
 			});
@@ -213,18 +193,10 @@ export async function initRateLimits(app: Router) {
 	app.use("/webhooks/:webhook_id", rateLimit(routes.webhook));
 	app.use("/channels/:channel_id", rateLimit(routes.channel));
 	app.use("/auth/login", rateLimit(routes.auth.login));
-	app.use(
-		"/auth/register",
-		rateLimit({ onlyIp: true, success: true, ...routes.auth.register }),
-	);
+	app.use("/auth/register", rateLimit({ onlyIp: true, success: true, ...routes.auth.register }));
 }
 
-async function hitRoute(opts: {
-	executor_id: string;
-	bucket_id: string;
-	max_hits: number;
-	window: number;
-}) {
+async function hitRoute(opts: { executor_id: string; bucket_id: string; max_hits: number; window: number }) {
 	const id = opts.executor_id + opts.bucket_id;
 	let limit = Cache.get(id);
 	if (!limit) {

--- a/src/api/routes/auth/forgot.ts
+++ b/src/api/routes/auth/forgot.ts
@@ -16,10 +16,10 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { getIpAdress, route, verifyCaptcha } from "@spacebar/api";
+import { route, verifyCaptcha } from "@spacebar/api";
 import { Config, Email, User } from "@spacebar/util";
 import { Request, Response, Router } from "express";
-import { ForgotPasswordSchema } from "@spacebar/schemas"
+import { ForgotPasswordSchema } from "@spacebar/schemas";
 const router = Router({ mergeParams: true });
 
 router.post(
@@ -38,10 +38,7 @@ router.post(
 
 		const config = Config.get();
 
-		if (
-			config.passwordReset.requireCaptcha &&
-			config.security.captcha.enabled
-		) {
+		if (config.passwordReset.requireCaptcha && config.security.captcha.enabled) {
 			const { sitekey, service } = config.security.captcha;
 			if (!captcha_key) {
 				return res.status(400).json({
@@ -51,7 +48,7 @@ router.post(
 				});
 			}
 
-			const ip = getIpAdress(req);
+			const ip = req.ip;
 			const verify = await verifyCaptcha(captcha_key, ip);
 			if (!verify.success) {
 				return res.status(400).json({
@@ -71,9 +68,7 @@ router.post(
 
 		if (user && user.email) {
 			Email.sendResetPassword(user, user.email).catch((e) => {
-				console.error(
-					`Failed to send password reset email to ${user.username}#${user.discriminator} (${user.id}): ${e}`,
-				);
+				console.error(`Failed to send password reset email to ${user.username}#${user.discriminator} (${user.id}): ${e}`);
 			});
 		}
 	},

--- a/src/api/routes/auth/location-metadata.ts
+++ b/src/api/routes/auth/location-metadata.ts
@@ -16,7 +16,7 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { getIpAdress, route } from "@spacebar/api";
+import { route } from "@spacebar/api";
 import { IpDataClient } from "@spacebar/util";
 import { Request, Response, Router } from "express";
 const router = Router({ mergeParams: true });
@@ -33,7 +33,7 @@ router.get(
 	async (req: Request, res: Response) => {
 		//TODO
 		//Note: It's most likely related to legal. At the moment Discord hasn't finished this too
-		const country_code = (await IpDataClient.getIpInfo(getIpAdress(req)))?.country_code;
+		const country_code = (await IpDataClient.getIpInfo(req.ip!))?.country_code;
 		res.json({
 			consent_required: false,
 			country_code: country_code,

--- a/src/api/routes/auth/register.ts
+++ b/src/api/routes/auth/register.ts
@@ -16,7 +16,7 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { getIpAdress, route, verifyCaptcha } from "@spacebar/api";
+import { route, verifyCaptcha } from "@spacebar/api";
 import { Config, FieldErrors, Invite, User, ValidRegistrationToken, generateToken, IpDataClient, AbuseIpDbClient } from "@spacebar/util";
 import bcrypt from "bcrypt";
 import { Request, Response, Router } from "express";
@@ -38,7 +38,7 @@ router.post(
 	async (req: Request, res: Response) => {
 		const body = req.body as RegisterSchema;
 		const { register, security, limits } = Config.get();
-		const ip = getIpAdress(req);
+		const ip = req.ip!;
 
 		// Reg tokens
 		// They're a one time use token that bypasses registration limits ( rates, disabled reg, etc )
@@ -143,7 +143,7 @@ router.post(
 
 			const ipData = await IpDataClient.getIpInfo(ip);
 			if (ipData) {
-				if(!ipData.threat) {
+				if (!ipData.threat) {
 					console.log("Invalid IPData.co response, missing threat field", ipData);
 				}
 				const categories = Object.entries(ipData.threat)
@@ -287,7 +287,7 @@ router.post(
 				},
 			})) >= limits.absoluteRate.register.limit
 		) {
-			console.log(`Global register ratelimit exceeded for ${getIpAdress(req)}, ${req.body.username}, ${req.body.invite || "No invite given"}`);
+			console.log(`Global register ratelimit exceeded for ${req.ip}, ${req.body.username}, ${req.body.invite || "No invite given"}`);
 			throw FieldErrors({
 				email: {
 					code: "TOO_MANY_REGISTRATIONS",

--- a/src/api/routes/auth/verify/index.ts
+++ b/src/api/routes/auth/verify/index.ts
@@ -16,14 +16,8 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { getIpAdress, route, verifyCaptcha } from "@spacebar/api";
-import {
-	checkToken,
-	Config,
-	FieldErrors,
-	generateToken,
-	User,
-} from "@spacebar/util";
+import { route, verifyCaptcha } from "@spacebar/api";
+import { checkToken, Config, FieldErrors, generateToken, User } from "@spacebar/util";
 import { Request, Response, Router } from "express";
 const router = Router({ mergeParams: true });
 
@@ -67,7 +61,7 @@ router.post(
 				});
 			}
 
-			const ip = getIpAdress(req);
+			const ip = req.ip;
 			const verify = await verifyCaptcha(captcha_key, ip);
 			if (!verify.success) {
 				return res.status(400).json({

--- a/src/api/routes/guilds/#guild_id/bans.ts
+++ b/src/api/routes/guilds/#guild_id/bans.ts
@@ -16,7 +16,7 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { getIpAdress, route } from "@spacebar/api";
+import { route } from "@spacebar/api";
 import { Ban, DiscordApiErrors, GuildBanAddEvent, GuildBanRemoveEvent, Member, User, emitEvent } from "@spacebar/util";
 import { Request, Response, Router } from "express";
 import { HTTPError } from "lambert-server";
@@ -215,7 +215,7 @@ router.put(
 		const ban = Ban.create({
 			user_id: banned_user_id,
 			guild_id: guild_id,
-			ip: getIpAdress(req),
+			ip: req.ip,
 			executor_id: req.user_id,
 			reason: req.body.reason, // || otherwise empty
 		});

--- a/src/api/routes/guilds/#guild_id/bulk-ban.ts
+++ b/src/api/routes/guilds/#guild_id/bulk-ban.ts
@@ -16,7 +16,7 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { getIpAdress, route } from "@spacebar/api";
+import { route } from "@spacebar/api";
 import { Ban, DiscordApiErrors, GuildBanAddEvent, Member, User, emitEvent } from "@spacebar/util";
 import { Request, Response, Router } from "express";
 import { HTTPError } from "lambert-server";
@@ -81,7 +81,7 @@ router.post(
 			const ban = Ban.create({
 				user_id: banned_user_id,
 				guild_id: guild_id,
-				ip: getIpAdress(req),
+				ip: req.ip,
 				executor_id: req.user_id,
 				reason: req.body.reason, // || otherwise empty
 			});

--- a/src/api/routes/guilds/#guild_id/regions.ts
+++ b/src/api/routes/guilds/#guild_id/regions.ts
@@ -16,7 +16,7 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { getIpAdress, getVoiceRegions, route } from "@spacebar/api";
+import { getVoiceRegions, route } from "@spacebar/api";
 import { Guild } from "@spacebar/util";
 import { Request, Response, Router } from "express";
 
@@ -38,12 +38,7 @@ router.get(
 		const { guild_id } = req.params;
 		const guild = await Guild.findOneOrFail({ where: { id: guild_id } });
 		//TODO we should use an enum for guild's features and not hardcoded strings
-		return res.json(
-			await getVoiceRegions(
-				getIpAdress(req),
-				guild.features.includes("VIP_REGIONS"),
-			),
-		);
+		return res.json(await getVoiceRegions(req.ip!, guild.features.includes("VIP_REGIONS")));
 	},
 );
 

--- a/src/api/routes/invites/index.ts
+++ b/src/api/routes/invites/index.ts
@@ -16,7 +16,7 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { getIpAdress, route } from "@spacebar/api";
+import { route } from "@spacebar/api";
 import { Ban, DiscordApiErrors, emitEvent, getPermission, Guild, Invite, InviteDeleteEvent, PublicInviteRelation, User } from "@spacebar/util";
 import { Request, Response, Router } from "express";
 import { HTTPError } from "lambert-server";
@@ -83,7 +83,7 @@ router.post(
 		const ban = await Ban.findOne({
 			where: [
 				{ guild_id: guild_id, user_id: req.user_id },
-				{ guild_id: guild_id, ip: getIpAdress(req) },
+				{ guild_id: guild_id, ip: req.ip },
 			],
 		});
 

--- a/src/api/routes/voice/regions.ts
+++ b/src/api/routes/voice/regions.ts
@@ -16,7 +16,7 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { getIpAdress, getVoiceRegions, route } from "@spacebar/api";
+import { getVoiceRegions, route } from "@spacebar/api";
 import { Request, Response, Router } from "express";
 
 const router: Router = Router({ mergeParams: true });
@@ -31,7 +31,7 @@ router.get(
 		},
 	}),
 	async (req: Request, res: Response) => {
-		res.json(await getVoiceRegions(getIpAdress(req), true)); //vip true?
+		res.json(await getVoiceRegions(req.ip!, true)); //vip true?
 	},
 );
 

--- a/src/api/util/utility/ipAddress.ts
+++ b/src/api/util/utility/ipAddress.ts
@@ -16,41 +16,16 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Config } from "@spacebar/util";
-import { Request } from "express";
-
-export function getIpAdress(req: Request): string {
-	// TODO: express can do this (trustProxies: true)?
-
-	return req.ip!;
-}
-
 type Location = { latitude: number; longitude: number };
-export function distanceBetweenLocations(
-	loc1: Location,
-	loc2: Location,
-): number {
-	return distanceBetweenCoords(
-		loc1.latitude,
-		loc1.longitude,
-		loc2.latitude,
-		loc2.longitude,
-	);
+export function distanceBetweenLocations(loc1: Location, loc2: Location): number {
+	return distanceBetweenCoords(loc1.latitude, loc1.longitude, loc2.latitude, loc2.longitude);
 }
 
 //Haversine function
-function distanceBetweenCoords(
-	lat1: number,
-	lon1: number,
-	lat2: number,
-	lon2: number,
-) {
+function distanceBetweenCoords(lat1: number, lon1: number, lat2: number, lon2: number) {
 	const p = 0.017453292519943295; // Math.PI / 180
 	const c = Math.cos;
-	const a =
-		0.5 -
-		c((lat2 - lat1) * p) / 2 +
-		(c(lat1 * p) * c(lat2 * p) * (1 - c((lon2 - lon1) * p))) / 2;
+	const a = 0.5 - c((lat2 - lat1) * p) / 2 + (c(lat1 * p) * c(lat2 * p) * (1 - c((lon2 - lon1) * p))) / 2;
 
 	return 12742 * Math.asin(Math.sqrt(a)); // 2 * R; R = 6371 km
 }


### PR DESCRIPTION
### Refactor: Replace getIpAddress with req.ip 

This PR removes the deprecated `getIpAddress` utility and replaces all its usages in the API with the standard Express `req.ip` property.

**Changes:**
- Replaced all `getIpAddress(req)` calls with `req.ip`
- Removed the `getIpAddress` function 
- Updated related imports and cleaned up unused code

**Verification:**
- All tests pass (`npm run node:tests`).
- Build and schema generation succeed (`npm run build`).

Closes #1421.