### PR TITLE
fix: only `guild_ids` is required in guild folder

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -8447,10 +8447,7 @@
                     }
                 },
                 "required": [
-                    "color",
-                    "guild_ids",
-                    "id",
-                    "name"
+                    "guild_ids"
                 ]
             },
             "SecurityKey": {

--- a/assets/schemas.json
+++ b/assets/schemas.json
@@ -8944,10 +8944,7 @@
         },
         "additionalProperties": false,
         "required": [
-            "color",
-            "guild_ids",
-            "id",
-            "name"
+            "guild_ids"
         ],
         "$schema": "http://json-schema.org/draft-07/schema#"
     },

--- a/src/schemas/api/users/UserSettings.ts
+++ b/src/schemas/api/users/UserSettings.ts
@@ -62,10 +62,10 @@ export interface CustomStatus {
 }
 
 export interface GuildFolder {
-	color: number;
+	color?: number;
 	guild_ids: string[];
-	id: number;
-	name: string;
+	id?: number;
+	name?: string;
 }
 
 export interface FriendSourceFlags {


### PR DESCRIPTION
> If `id` is null and `guild_ids` is a single element array, this folder is not displayed and instead represents a single guild's position in the sidebar.

(takem from https://docs.discord.food/resources/user-settings#guild-folder-structure)