### PR TITLE
fix: prevent race condition in rabbitmq

### DIFF
--- a/src/gateway/listener/listener.ts
+++ b/src/gateway/listener/listener.ts
@@ -36,7 +36,7 @@ import { WebSocket } from "@spacebar/gateway";
 import { Channel as AMQChannel } from "amqplib";
 import { Recipient } from "@spacebar/util";
 import * as console from "node:console";
-import { PublicMember, RelationshipType } from "@spacebar/schemas"
+import { PublicMember, RelationshipType } from "@spacebar/schemas";
 import { bgRedBright } from "picocolors";
 
 // TODO: close connection on Invalidated Token
@@ -46,10 +46,7 @@ import { bgRedBright } from "picocolors";
 // Sharding: calculate if the current shard id matches the formula: shard_id = (guild_id >> 22) % num_shards
 // https://discord.com/developers/docs/topics/gateway#sharding
 
-export function handlePresenceUpdate(
-	this: WebSocket,
-	{ event, acknowledge, data }: EventOpts,
-) {
+export function handlePresenceUpdate(this: WebSocket, { event, acknowledge, data }: EventOpts) {
 	acknowledge?.();
 	if (event === EVENTEnum.PresenceUpdate) {
 		return Send(this, {
@@ -92,32 +89,24 @@ export async function setupListener(this: WebSocket) {
 	this.listen_options = opts;
 	const consumer = consume.bind(this);
 
+	const handleChannelError = (err: unknown) => {
+		console.error(`[RabbitMQ] [user-${this.user_id}] Channel Error (Handled):`, err);
+	};
+
 	console.log("[RabbitMQ] setupListener: open for ", this.user_id);
 	if (RabbitMQ.connection) {
-		console.log(
-			"[RabbitMQ] setupListener: opts.channel = ",
-			typeof opts.channel,
-			"with channel id",
-			opts.channel?.ch,
-		);
+		console.log("[RabbitMQ] setupListener: opts.channel = ", typeof opts.channel, "with channel id", opts.channel?.ch);
 		opts.channel = await RabbitMQ.connection.createChannel();
+
+		opts.channel.on("error", handleChannelError);
 		opts.channel.queues = {};
-		console.log(
-			"[RabbitMQ] channel created: ",
-			typeof opts.channel,
-			"with channel id",
-			opts.channel?.ch,
-		);
+		console.log("[RabbitMQ] channel created: ", typeof opts.channel, "with channel id", opts.channel?.ch);
 	}
 
 	this.events[this.user_id] = await listenEvent(this.user_id, consumer, opts);
 
 	relationships.forEach(async (relationship) => {
-		this.events[relationship.to_id] = await listenEvent(
-			relationship.to_id,
-			handlePresenceUpdate.bind(this),
-			opts,
-		);
+		this.events[relationship.to_id] = await listenEvent(relationship.to_id, handlePresenceUpdate.bind(this), opts);
 	});
 
 	dm_channels.forEach(async (channel) => {
@@ -130,33 +119,27 @@ export async function setupListener(this: WebSocket) {
 		this.events[guild.id] = await listenEvent(guild.id, consumer, opts);
 
 		guild.channels.forEach(async (channel) => {
-			if (
-				permission
-					.overwriteChannel(channel.permission_overwrites ?? [])
-					.has("VIEW_CHANNEL")
-			) {
-				this.events[channel.id] = await listenEvent(
-					channel.id,
-					consumer,
-					opts,
-				);
+			if (permission.overwriteChannel(channel.permission_overwrites ?? []).has("VIEW_CHANNEL")) {
+				this.events[channel.id] = await listenEvent(channel.id, consumer, opts);
 			}
 		});
 	});
 
-	this.once("close", () => {
-		console.log(
-			"[RabbitMQ] setupListener: close for",
-			this.user_id,
-			"=",
-			typeof opts.channel,
-			"with channel id",
-			opts.channel?.ch,
+	this.once("close", async () => {
+		console.log("[RabbitMQ] setupListener: close for", this.user_id, "=", typeof opts.channel, "with channel id", opts.channel?.ch);
+
+		// wait for event consumer cancellation
+		await Promise.all(
+			Object.values(this.events).map((x) => {
+				if (x) return x();
+				else return Promise.resolve();
+			}),
 		);
-		if (opts.channel) opts.channel.close();
-		else {
-			Object.values(this.events).forEach((x) => x?.());
-			Object.values(this.member_events).forEach((x) => x());
+		await Promise.all(Object.values(this.member_events).map((x) => x()));
+
+		if (opts.channel) {
+			await opts.channel.close();
+			opts.channel.off("error", handleChannelError);
 		}
 	});
 }
@@ -180,11 +163,7 @@ async function consume(this: WebSocket, opts: EventOpts) {
 			break;
 		case "GUILD_MEMBER_ADD":
 			if (this.member_events[data.user.id]) break; // already subscribed
-			this.member_events[data.user.id] = await listenEvent(
-				data.user.id,
-				handlePresenceUpdate.bind(this),
-				this.listen_options,
-			);
+			this.member_events[data.user.id] = await listenEvent(data.user.id, handlePresenceUpdate.bind(this), this.listen_options);
 			break;
 		case "GUILD_MEMBER_UPDATE":
 			if (!this.member_events[data.user.id]) break;
@@ -197,32 +176,20 @@ async function consume(this: WebSocket, opts: EventOpts) {
 			delete this.events[id];
 			break;
 		case "CHANNEL_CREATE":
-			if (
-				!permission
-					.overwriteChannel(data.permission_overwrites)
-					.has("VIEW_CHANNEL")
-			) {
+			if (!permission.overwriteChannel(data.permission_overwrites).has("VIEW_CHANNEL")) {
 				return;
 			}
 			this.events[id] = await listenEvent(id, consumer, listenOpts);
 			break;
 		case "RELATIONSHIP_ADD":
-			this.events[data.user.id] = await listenEvent(
-				data.user.id,
-				handlePresenceUpdate.bind(this),
-				this.listen_options,
-			);
+			this.events[data.user.id] = await listenEvent(data.user.id, handlePresenceUpdate.bind(this), this.listen_options);
 			break;
 		case "GUILD_CREATE":
 			this.events[id] = await listenEvent(id, consumer, listenOpts);
 			break;
 		case "CHANNEL_UPDATE": {
 			const exists = this.events[id];
-			if (
-				permission
-					.overwriteChannel(data.permission_overwrites)
-					.has("VIEW_CHANNEL")
-			) {
+			if (permission.overwriteChannel(data.permission_overwrites).has("VIEW_CHANNEL")) {
 				if (exists) break;
 				this.events[id] = await listenEvent(id, consumer, listenOpts);
 			} else {
@@ -294,20 +261,19 @@ async function consume(this: WebSocket, opts: EventOpts) {
 		case "MESSAGE_UPDATE":
 			// console.log(this.request)
 			if (data["attachments"])
-				data["attachments"] =
-					Message.prototype.withSignedAttachments.call(
-						data,
-						new NewUrlUserSignatureData({
-							ip: this.ipAddress,
-							userAgent: this.userAgent,
-						}),
-					).attachments;
+				data["attachments"] = Message.prototype.withSignedAttachments.call(
+					data,
+					new NewUrlUserSignatureData({
+						ip: this.ipAddress,
+						userAgent: this.userAgent,
+					}),
+				).attachments;
 			break;
 		default:
 			break;
 	}
 
-	if(event === "GUILD_MEMBER_ADD") {
+	if (event === "GUILD_MEMBER_ADD") {
 		if ((data as PublicMember).roles === undefined || (data as PublicMember).roles === null) {
 			console.log(bgRedBright("[Gateway]"), "[GUILD_MEMBER_ADD] roles is undefined, setting to empty array!", opts.origin ?? "(Event origin not defined)", data);
 			(data as PublicMember).roles = [];

--- a/src/gateway/util/WebSocket.ts
+++ b/src/gateway/util/WebSocket.ts
@@ -44,8 +44,8 @@ export interface WebSocket extends WS {
 	intents: Intents;
 	sequence: number;
 	permissions: Record<string, Permissions>;
-	events: Record<string, undefined | (() => unknown)>;
-	member_events: Record<string, () => unknown>;
+	events: Record<string, undefined | (() => Promise<unknown>)>;
+	member_events: Record<string, () => Promise<unknown>>;
 	listen_options: ListenEventOpts;
 	capabilities?: Capabilities;
 	large_threshold: number;

--- a/src/util/util/RabbitMQ.ts
+++ b/src/util/util/RabbitMQ.ts
@@ -34,7 +34,24 @@ export const RabbitMQ: {
 			timeout: 1000 * 60,
 		});
 		console.log(`[RabbitMQ] connected`);
+
+		// log connection errors
+		this.connection.on("error", (err) => {
+			console.error("[RabbitMQ] Connection Error:", err);
+		});
+
+		this.connection.on("close", () => {
+			console.error("[RabbitMQ] connection closed");
+			// TODO: Add reconnection logic here if the connection crashes??
+			// will be a pain since we will have to reconstruct entire state
+		});
+
 		this.channel = await this.connection.createChannel();
 		console.log(`[RabbitMQ] channel created`);
+
+		// log channel errors
+		this.channel.on("error", (err) => {
+			console.error("[RabbitMQ] Channel Error:", err);
+		});
 	},
 };


### PR DESCRIPTION
There was a race condition that was causing the RabbitMQ connection to close in Gateway. It went as follows:

1. User connects to gateway, a new channel is created for the user
2. We subscribe the user to listen to events using a consumer queue
3. User disconnects, causing our code to close the channel. Since the queue is exclusive, this causes the queue to be destroyed. At the exact same millisecond, a message was being published to that queue, causing RabbitMQ to reply with exception: `Error: Connection closed: 506 (RESOURCE-ERROR) with message "RESOURCE_ERROR - failed to deliver message: {not_found,{resource,<<"/">>,queue,<<"amq.gen-n_u9WDt5pqpZw2QJLp-oqQ">>` and forcefully closing our Gateway's RabbitMQ connection since it is a fatal error.
4. Now our Gateway is broken since we have no RabbitMQ connection and our events are not being routed

This PR takes the following mitigation steps:
- Fixed our call to  `channel.cancel(consumerTag)` which was previously passing the queue name instead of the consumerTag
- Properly call and await the cancel() function before closing the channel when a user's WebSocket is closed. Since this calls `channel.unbindQueue()`, RabbitMQ now stops routing messages to that queue before the queue is destroyed, preventing the race condition
- Adds logging to RabbitMQ connection and channels to detect any future bugs

stacktrace of the original error:
```console
Dec 08 20:30:12 tab-fosscord node[37333]: [RabbitMQ] setupListener: close for 1440078027854000171 = object with channel id 22

Dec 08 20:30:12 tab-fosscord node[37333]: Error: Connection closed: 506 (RESOURCE-ERROR) with message "RESOURCE_ERROR - failed to deliver message: {not_found,

Dec 08 20:30:12 tab-fosscord node[37333]: {resource,<<"/">>,queue,

Dec 08 20:30:12 tab-fosscord node[37333]: <<"amq.gen-n_u9WDt5pqpZw2QJLp-oqQ">>}}"

Dec 08 20:30:12 tab-fosscord node[37333]: at Object.accept (/root/fosscord/refactor/fosscord-server/node_modules/amqplib/lib/connection.js:606:15)

Dec 08 20:30:12 tab-fosscord node[37333]: at Connection.mainAccept [as accept] (/root/fosscord/refactor/fosscord-server/node_modules/amqplib/lib/connection.js:579:33)

Dec 08 20:30:12 tab-fosscord node[37333]: at Socket.go (/root/fosscord/refactor/fosscord-server/node_modules/amqplib/lib/connection.js:431:16)

Dec 08 20:30:12 tab-fosscord node[37333]: at Socket.emit (node:events:519:28)

Dec 08 20:30:12 tab-fosscord node[37333]: at emitReadable_ (node:internal/streams/readable:834:12)

Dec 08 20:30:12 tab-fosscord node[37333]: at process.processTicksAndRejections (node:internal/process/task_queues:89:21) {

Dec 08 20:30:12 tab-fosscord node[37333]: code: 506

Dec 08 20:30:12 tab-fosscord node[37333]: } uncaughtException
```

Hopefully this is enough to make Gateway more resilient