### PR TITLE
try to handle race condition again

### DIFF
--- a/src/util/util/Event.ts
+++ b/src/util/util/Event.ts
@@ -39,6 +39,7 @@ export async function emitEvent(payload: Omit<Event, "created_at">) {
 			const successful = channel.publish(id, "", Buffer.from(`${data}`), { type: payload.event });
 			if (!successful) throw new Error("failed to send event");
 		} catch (e) {
+			// todo: should we retry publishng the event?
 			console.log("[RabbitMQ] ", e);
 		}
 	} else if (process.env.EVENT_TRANSMISSION === "process") {


### PR DESCRIPTION
Now we just restart the channel when it closes since I cannot think of a way of preventing the race condition from happening at all. At least our Gateway will recover and not stay in a broken state