### PR TITLE
try to resolve race condition, third time

### DIFF
--- a/src/util/util/Event.ts
+++ b/src/util/util/Event.ts
@@ -81,8 +81,6 @@ export async function initEvent() {
 
     // Set up the spacebar event listener (used for config reload, etc.)
     const setupSpacebarListener = async () => {
-        if (!RabbitMQ.connection) return;
-
         console.log("[Event] Setting up spacebar event listener");
         await listenEvent("spacebar", async (event) => {
             console.log("[Event] Received spacebar event:", event);
@@ -176,7 +174,7 @@ async function rabbitListen(channel: Channel, id: string, callback: (event: Even
 
     const cancel = async () => {
         try {
-            // Order matters here to prevent RESOURCE_ERROR:
+            // Order matters here to prevent RESOURCE_ERROR, due to potential race condition:
             // 1. Unbind first - stops new messages from being routed to this queue
             await channel.unbindQueue(q.queue, id, "");
             // 2. Cancel consumer - with autoDelete: true, this triggers queue deletion

--- a/src/util/util/RabbitMQ.ts
+++ b/src/util/util/RabbitMQ.ts
@@ -81,7 +81,6 @@ export class RabbitMQ {
         } catch (error) {
             console.error("[RabbitMQ] Connection failed:", error);
             await this.scheduleReconnect(host);
-            throw error;
         }
     }
 

--- a/src/util/util/RabbitMQ.ts
+++ b/src/util/util/RabbitMQ.ts
@@ -30,8 +30,7 @@ export class RabbitMQ {
     // Reconnection state
     private static isReconnecting = false;
     private static reconnectAttempts = 0;
-    private static readonly MAX_RECONNECT_DELAY_MS = 5000; // Max 5 seconds between retries
-    private static readonly BASE_RECONNECT_DELAY_MS = 500; // Start with 500 milliseconds
+    private static readonly BASE_RECONNECT_DELAY_MS = 500; // reconnect after 500 milliseconds delay
 
     // Track if event listeners have been set up (to avoid duplicates)
     private static connectionListenersAttached = false;
@@ -117,14 +116,9 @@ export class RabbitMQ {
         this.isReconnecting = true;
         this.reconnectAttempts++;
 
-        // add random jitter to reconnection delay
-        const baseDelay = Math.min(this.BASE_RECONNECT_DELAY_MS + Math.random() * 2000, this.MAX_RECONNECT_DELAY_MS);
+        console.log(`[RabbitMQ] Scheduling reconnection attempt ${this.reconnectAttempts} in ${this.BASE_RECONNECT_DELAY_MS}ms`);
 
-        const delay = Math.round(baseDelay);
-
-        console.log(`[RabbitMQ] Scheduling reconnection attempt ${this.reconnectAttempts} in ${delay}ms`);
-
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await new Promise((resolve) => setTimeout(resolve, this.BASE_RECONNECT_DELAY_MS));
 
         try {
             await this.connect(host);

--- a/src/util/util/RabbitMQ.ts
+++ b/src/util/util/RabbitMQ.ts
@@ -30,8 +30,8 @@ export class RabbitMQ {
     // Reconnection state
     private static isReconnecting = false;
     private static reconnectAttempts = 0;
-    private static readonly MAX_RECONNECT_DELAY_MS = 30000; // Max 30 seconds between retries
-    private static readonly BASE_RECONNECT_DELAY_MS = 1000; // Start with 1 second
+    private static readonly MAX_RECONNECT_DELAY_MS = 5000; // Max 5 seconds between retries
+    private static readonly BASE_RECONNECT_DELAY_MS = 500; // Start with 500 milliseconds
 
     // Track if event listeners have been set up (to avoid duplicates)
     private static connectionListenersAttached = false;
@@ -117,11 +117,10 @@ export class RabbitMQ {
         this.isReconnecting = true;
         this.reconnectAttempts++;
 
-        // Exponential backoff with jitter
-        const baseDelay = Math.min(this.BASE_RECONNECT_DELAY_MS * Math.pow(2, this.reconnectAttempts - 1), this.MAX_RECONNECT_DELAY_MS);
-        // Add jitter (±25%) to prevent thundering herd
-        const jitter = baseDelay * 0.25 * (Math.random() * 2 - 1);
-        const delay = Math.round(baseDelay + jitter);
+        // add random jitter to reconnection delay
+        const baseDelay = Math.min(this.BASE_RECONNECT_DELAY_MS + Math.random() * 2000, this.MAX_RECONNECT_DELAY_MS);
+
+        const delay = Math.round(baseDelay);
 
         console.log(`[RabbitMQ] Scheduling reconnection attempt ${this.reconnectAttempts} in ${delay}ms`);
 


### PR DESCRIPTION
The problem was not properly addressed last time because the exception was crashing the whole connection instead of just the channel, so the exception got thrown again when we tried creating a new channel on the old disconnected connection.

To address the instability that is introduced by publishing to a queue that might or might not be there, due to the race condition, ~~we now isolate the connections. We have separate connections for publishing and consuming messages, this way, when the exception triggers our publishing connection to close, our event consumers are unaffected since they will be using a separate connection. This also means that we can easily restart the connection without worrying about having to reconstruct any state (ie  recreating all the user channels and restablishing all the event consumers) since the publishing connection does not have any event consumers and was used purely for publishing events~~

When RabbitMQ connection drops (including from 506 RESOURCE_ERROR):

1. `RabbitMQ.ts` detects the connection close and emits `disconnected`
2. After exponential backoff delay, it attempts to reconnect
3. On successful reconnect, it emits `reconnected`
4. All consumers (WebSocket listeners, spacebar events, rate limits) re-establish their subscriptions