### PR TITLE
fix: relationshipsSelf are now actually self

### DIFF
--- a/src/api/routes/users/#user_id/profile.ts
+++ b/src/api/routes/users/#user_id/profile.ts
@@ -100,7 +100,7 @@ router.get("/", route({ responses: { 200: { body: "UserProfileResponse" } } }), 
     let mutual_friends_count = 0;
 
     if (with_mutual_friends == "true" || with_mutual_friends_count == "true") {
-        const relationshipsSelf = await Relationship.find({ where: { from_id: user_id, type: RelationshipType.friends } });
+        const relationshipsSelf = await Relationship.find({ where: { from_id: req.user_id, type: RelationshipType.friends } });
         const relationshipsUser = await Relationship.find({ where: { from_id: user_id, type: RelationshipType.friends } });
         const relationshipsIntersection = relationshipsSelf.filter((r1) => relationshipsUser.some((r2) => r2.to_id === r1.to_id));
         if (with_mutual_friends_count) mutual_friends_count = relationshipsIntersection.length;


### PR DESCRIPTION
the two consts were equal creating a bug where all friends would be shown in a user's profile. The bug is no longer there