### PR TITLE
Save channel on messageid update

### DIFF
--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -114,6 +114,7 @@ export async function handleMessage(opts: MessageOptions): Promise<Message> {
     }
     if (!ephermal) {
         channel.last_message_id = message.id;
+        channel.save();
     }
 
     if (cloudAttachments && cloudAttachments.length > 0) {


### PR DESCRIPTION
This should make readstates work more properly, for whatever reason it wasn't saving before.