### PR TITLE
feat: Add limit query parameter when fetching reactions

### DIFF
--- a/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
+++ b/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
@@ -150,6 +150,7 @@ router.get(
     }),
     async (req: Request, res: Response) => {
         const { message_id, channel_id } = req.params as { [key: string]: string };
+        const limit = req.query.limit ? Number(req.query.limit) : 25;
         const emoji = getEmoji(req.params.emoji as string);
 
         const message = await Message.findOneOrFail({
@@ -164,6 +165,7 @@ router.get(
                     id: In(reaction.user_ids),
                 },
                 select: PublicUserProjection,
+                take: limit,
             })
         ).map((user) => user.toPublicUser());
 


### PR DESCRIPTION
Aims to solve #1308 . Fermi has the parameter set to 3, and it has been tested with that locally, and I'm only getting 3 items back and not all of them. 