### PR TITLE
Add option to set S3 endpoint for S3-compatible stores

### DIFF
--- a/src/cdn/util/S3Storage.ts
+++ b/src/cdn/util/S3Storage.ts
@@ -32,10 +32,11 @@ export class S3Storage implements Storage {
     public constructor(
         private region: string,
         private bucket: string,
+        private endpoint: string,
         private basePath?: string,
     ) {
         const { S3 } = require("@aws-sdk/client-s3");
-        this.client = new S3({ region });
+        this.client = new S3({ region: region, endpoint: endpoint });
     }
 
     /**

--- a/src/cdn/util/Storage.ts
+++ b/src/cdn/util/Storage.ts
@@ -60,6 +60,12 @@ if (process.env.STORAGE_PROVIDER === "file" || !process.env.STORAGE_PROVIDER) {
         process.exit(1);
     }
 
+    let endpoint = process.env.STORAGE_ENDPOINT;
+
+    if (!endpoint) {
+        endpoint = `https://s3.${region}.amazonaws.com`;
+    }
+
     if (!bucket) {
         console.error(`[CDN] You must provide a bucket when using the S3 storage provider.`);
         process.exit(1);
@@ -74,7 +80,7 @@ if (process.env.STORAGE_PROVIDER === "file" || !process.env.STORAGE_PROVIDER) {
     }
 
     const { S3Storage } = require("S3Storage");
-    storage = new S3Storage(region, bucket, location);
+    storage = new S3Storage(region, bucket, endpoint, location);
 }
 
 export { storage };


### PR DESCRIPTION
This adds the ability to set a custom S3 endpoint so that S3 compatible stores (Backblaze B2, Minio, Garage, etc) can be used instead of AWS-provided S3.

According to this StackOverflow answer:

https://stackoverflow.com/a/76111341

All that's really needed to support this is adding the 'endpoint' parameter when instantiating the S3 client. So I pull the endpoint from the STORAGE_ENDPOINT environment variable and default to using AWS S3 if the environment variable is blank.

Corresponding PR to docs here:

https://github.com/spacebarchat/docs/pull/111