### PR TITLE
Add support for start:webrtc script to allow voice gateway to be run separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "start:api": "node --enable-source-maps dist/api/start.js",
         "start:cdn": "node --enable-source-maps dist/cdn/start.js",
         "start:gateway": "node --enable-source-maps dist/gateway/start.js",
+        "start:webrtc": "node --enable-source-maps dist/webrtc/start.js",
         "build": "npm run build:src && npm run generate:schema && npm run generate:openapi",
         "build:src": "tsc -b -v",
         "build:tsgo": "npm run build:src:tsgo && npm run generate:schema && npm run generate:openapi",


### PR DESCRIPTION
This allows the webrtc server to run separately from the rest of the server, like gateway/api/cdn.

I'd also like to add the @spacebarchat/medooze-wrtc and mediasoup-spacebar-wrtc packages under optional dependencies in the package.json. Let me know if it's fine to add that to this PR, separate it out into its own PR, or to not bother with it.