### PR TITLE
feat: implement Gateway Resume (Op 6) with event replay

### DIFF
--- a/src/gateway/opcodes/Resume.ts
+++ b/src/gateway/opcodes/Resume.ts
@@ -16,15 +16,75 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { WebSocket } from "@spacebar/gateway";
+import { CLOSECODES, Payload, WebSocket } from "@spacebar/gateway";
 import { Send } from "../util/Send";
+import { OPCODES } from "../util/Constants";
+import { getReplayEvents, getReplaySession, deleteReplaySession } from "../util/ReplayBuffer";
+import { checkToken } from "@spacebar/util";
+import { setHeartbeat } from "../util/Heartbeat";
 
-export async function onResume(this: WebSocket) {
-    // console.log("Got Resume -> cancel not implemented");
+export async function onResume(this: WebSocket, data: Payload) {
+    const resume = data.d as { token: string; session_id: string; seq: number } | undefined;
+
+    if (!resume || !resume.token || !resume.session_id || resume.seq === undefined) {
+        console.log("[Gateway] Resume: missing fields, sending Invalid Session");
+        await Send(this, { op: OPCODES.Invalid_Session, d: false });
+        return;
+    }
+
+    // Validate the token
+    let tokenData;
+    try {
+        tokenData = await checkToken(resume.token, {
+            ipAddress: this.ipAddress,
+            fingerprint: this.fingerprint,
+        });
+    } catch {
+        console.log("[Gateway] Resume: invalid token");
+        await Send(this, { op: OPCODES.Invalid_Session, d: false });
+        return;
+    }
+
+    // Check the replay session exists and belongs to this user
+    const replaySession = getReplaySession(resume.session_id);
+    if (!replaySession || replaySession.userId !== tokenData.user.id) {
+        console.log("[Gateway] Resume: session not found or user mismatch");
+        await Send(this, { op: OPCODES.Invalid_Session, d: false });
+        return;
+    }
+
+    // Get events to replay
+    const events = getReplayEvents(resume.session_id, resume.seq);
+    if (events === null) {
+        console.log("[Gateway] Resume: no replay data available");
+        await Send(this, { op: OPCODES.Invalid_Session, d: false });
+        return;
+    }
+
+    // Restore session state on this socket
+    this.user_id = tokenData.user.id;
+    this.session_id = resume.session_id;
+    this.accessToken = resume.token;
+    this.sequence = resume.seq;
+
+    // Clear the ready timeout since we've authenticated via resume
+    if (this.readyTimeout) clearTimeout(this.readyTimeout);
+
+    // Reset heartbeat
+    setHeartbeat(this);
+
+    console.log(`[Gateway] Resume: replaying ${events.length} events for session ${resume.session_id}`);
+
+    // Replay missed events
+    for (const event of events) {
+        await Send(this, event);
+    }
+
+    // Send RESUMED event
     await Send(this, {
-        op: 9,
-        d: false,
+        op: OPCODES.Dispatch,
+        t: "RESUMED",
+        d: {},
+        s: this.sequence++,
     });
-
-    // return this.close(CLOSECODES.Invalid_session);
 }

--- a/src/gateway/util/ReplayBuffer.ts
+++ b/src/gateway/util/ReplayBuffer.ts
@@ -1,0 +1,108 @@
+/*
+	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
+	Copyright (C) 2023 Spacebar and Spacebar Contributors
+	
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+	
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Payload } from "./Constants";
+
+/**
+ * In-memory replay buffer for Gateway Resume.
+ * Stores dispatched events per session so they can be replayed on resume.
+ * Each session keeps the last MAX_REPLAY_EVENTS events.
+ * Sessions are cleaned up after SESSION_TIMEOUT_MS of inactivity.
+ */
+
+const MAX_REPLAY_EVENTS = 2048;
+const SESSION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+interface ReplaySession {
+    events: Payload[];
+    lastActivity: number;
+    userId: string;
+    accessToken: string;
+}
+
+const replaySessions = new Map<string, ReplaySession>();
+
+// Periodic cleanup of expired sessions
+setInterval(() => {
+    const now = Date.now();
+    for (const [sessionId, session] of replaySessions) {
+        if (now - session.lastActivity > SESSION_TIMEOUT_MS) {
+            replaySessions.delete(sessionId);
+        }
+    }
+}, 60000); // cleanup every minute
+
+/**
+ * Store a dispatched event for potential replay on resume.
+ */
+export function storeReplayEvent(sessionId: string, userId: string, accessToken: string, payload: Payload): void {
+    let session = replaySessions.get(sessionId);
+    if (!session) {
+        session = {
+            events: [],
+            lastActivity: Date.now(),
+            userId,
+            accessToken,
+        };
+        replaySessions.set(sessionId, session);
+    }
+
+    session.lastActivity = Date.now();
+    session.events.push(payload);
+
+    // Trim to max size
+    if (session.events.length > MAX_REPLAY_EVENTS) {
+        session.events = session.events.slice(-MAX_REPLAY_EVENTS);
+    }
+}
+
+/**
+ * Get events to replay for a resume request.
+ * Returns events after the given sequence number, or null if session not found / expired.
+ */
+export function getReplayEvents(sessionId: string, sequence: number): Payload[] | null {
+    const session = replaySessions.get(sessionId);
+    if (!session) return null;
+
+    // Return events with sequence > the client's last received sequence
+    return session.events.filter((e) => e.s !== undefined && e.s > sequence);
+}
+
+/**
+ * Get the session data for resume validation.
+ */
+export function getReplaySession(sessionId: string): ReplaySession | undefined {
+    return replaySessions.get(sessionId);
+}
+
+/**
+ * Remove a session's replay buffer (e.g., on explicit logout or permanent disconnect).
+ */
+export function deleteReplaySession(sessionId: string): void {
+    replaySessions.delete(sessionId);
+}
+
+/**
+ * Mark a session as disconnected (keeps the replay buffer alive for resume).
+ */
+export function markSessionDisconnected(sessionId: string): void {
+    const session = replaySessions.get(sessionId);
+    if (session) {
+        session.lastActivity = Date.now();
+    }
+}

--- a/src/gateway/util/index.ts
+++ b/src/gateway/util/index.ts
@@ -23,3 +23,4 @@ export * from "./Heartbeat";
 export * from "./WebSocket";
 export * from "./Capabilities";
 export * from "./Utils";
+export * from "./ReplayBuffer";


### PR DESCRIPTION
Previously Resume always returned Invalid Session (op 9), forcing clients to fully re-identify. Now:

- ReplayBuffer stores dispatched events per session (up to 2048 events)
- Sessions are kept in memory for 5 minutes after disconnect
- On Resume, the token is validated, then missed events (sequence > client's last seq) are replayed, followed by a RESUMED dispatch event
- Send() automatically stores Dispatch events in the replay buffer
- Close handler marks sessions as disconnected instead of immediately purging replay data

This matches Discord's Resume behavior and significantly improves reconnection performance for clients.