### PR TITLE
SMTP support for Relays/Servers that don't use user/pass authentication

### DIFF
--- a/src/util/util/email/clients/SMTPEmailClient.ts
+++ b/src/util/util/email/clients/SMTPEmailClient.ts
@@ -27,7 +27,7 @@ export class SMTPEmailClient extends BaseEmailClient {
     override async init(): Promise<void> {
         try {
             // try to import the transporter package
-            this.nodemailer = require("nodemailer").default;
+            this.nodemailer = require("nodemailer");
         } catch {
             // if the package is not installed, log an error and return void so we don't set the transporter
             console.error("[Email] nodemailer is not installed. Please run `npm install --no-save nodemailer` to install it.");


### PR DESCRIPTION
This PR Addresses the following:

- Improper import of `nodemailer` (moved from `nodemailer.default` to `nodemailer`)
  - `this.nodemailer` was `undefined` causing the SMTP transport to fail to load
- Makes `email.smtp.username` and `email.smtp.password` for the SMTP mailer transport optional
  - Not all SMTP relays require authentication
  - This enables usage of SMTP relays on localhost/smarthosts that relay to another system
  - No changes made to existing SMTP support for servers that do use username/password authentication