### PR TITLE
fix: handle URL-encoded @me in /users/:user_id route

### DIFF
--- a/src/api/routes/users/#user_id/index.ts
+++ b/src/api/routes/users/#user_id/index.ts
@@ -32,7 +32,8 @@ router.get(
         },
     }),
     async (req: Request, res: Response) => {
-        const { user_id } = req.params as { [key: string]: string };
+        let { user_id } = req.params as { [key: string]: string };
+        if (user_id === "@me") user_id = req.user_id;
 
         res.json(await User.getPublicUser(user_id));
     },


### PR DESCRIPTION
## Summary

- `/users/%40me` returns 404 because `%40me` (URL-encoded `@me`) is routed to `/users/:user_id` instead of the literal `/users/@me` route
- Express automatically decodes `%40` → `@`, so `req.params.user_id` becomes `"@me"`, but the handler passes it directly to `User.getPublicUser()` which fails
- Add the same `@me → req.user_id` substitution that other `:user_id` routes already have (e.g. `profile.ts`, `voice-states`)

Fixes #1525

## Test plan

- [ ] `GET /users/%40me` returns the authenticated user (same as `GET /users/@me`)
- [ ] `GET /users/<snowflake>` still works as before
- [ ] Existing `/users/@me/` literal route still works