### PR TITLE
Add Json Decorators

### DIFF
--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -486,7 +486,7 @@ export async function postHandleMessage(message: Message) {
     const content = message.content?.replace(/ *`[^)]*` */g, ""); // remove markdown
 
     const linkMatches = content?.match(LINK_REGEX) || [];
-
+    message.clean_data();
     const data = { ...message };
 
     const currentNormalizedUrls = new Set<string>();

--- a/src/util/entities/Message.ts
+++ b/src/util/entities/Message.ts
@@ -31,6 +31,7 @@ import { Attachment } from "./Attachment";
 import { NewUrlUserSignatureData } from "../Signing";
 import { ActionRowComponent, ApplicationCommandType, Embed, MessageSnapshot, MessageType, PartialMessage, Poll, Reaction } from "@spacebar/schemas";
 import { MessageFlags } from "@spacebar/util";
+import { JsonRemoveEmpty } from "../util/Decorators";
 
 @Entity({
     name: "messages",
@@ -122,14 +123,17 @@ export class Message extends BaseClass {
     mention_everyone?: boolean;
 
     @JoinTable({ name: "message_user_mentions" })
+    @JsonRemoveEmpty
     @ManyToMany(() => User)
     mentions: User[];
 
     @JoinTable({ name: "message_role_mentions" })
+    @JsonRemoveEmpty
     @ManyToMany(() => Role)
     mention_roles: Role[];
 
     @JoinTable({ name: "message_channel_mentions" })
+    @JsonRemoveEmpty
     @ManyToMany(() => Channel)
     mention_channels: Channel[];
 
@@ -141,12 +145,15 @@ export class Message extends BaseClass {
         cascade: true,
         orphanedRowAction: "delete",
     })
+    @JsonRemoveEmpty
     attachments?: Attachment[];
 
     @Column({ type: "simple-json" })
+    @JsonRemoveEmpty
     embeds: Embed[];
 
     @Column({ type: "simple-json" })
+    @JsonRemoveEmpty
     reactions: Reaction[];
 
     @Column({ type: "text", nullable: true })
@@ -201,9 +208,11 @@ export class Message extends BaseClass {
     };
 
     @Column({ type: "simple-json", nullable: true })
+    @JsonRemoveEmpty
     components?: ActionRowComponent[];
 
     @Column({ type: "simple-json", nullable: true })
+    @JsonRemoveEmpty
     poll?: Poll;
 
     @Column({ nullable: true })

--- a/src/util/util/Decorators.ts
+++ b/src/util/util/Decorators.ts
@@ -1,0 +1,21 @@
+import { BaseClassWithoutId } from "@spacebar/util*";
+
+export const annotationsKey = Symbol("Annotations");
+
+// Generates an array using the annotationsKey as a property on a class when annotated with the below decorators
+export function initAnnotationMetadata(target: BaseClassWithoutId, propertyKey: string) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    target[annotationsKey] || (target[annotationsKey] = {});
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    target[annotationsKey][propertyKey] || (target[annotationsKey][propertyKey] = []);
+}
+
+// Adds to the generated array on the class with the annotation added.
+export function addAnnotationMetadata(target: BaseClassWithoutId, propertyKey: string, annotation: string) {
+    target[annotationsKey] = { ...target[annotationsKey], [propertyKey]: [...target[annotationsKey][propertyKey], annotation] };
+}
+
+export function JsonRemoveEmpty(target: BaseClassWithoutId, propertyKey: string) {
+    initAnnotationMetadata(target, propertyKey);
+    addAnnotationMetadata(target, propertyKey, "JsonRemoveEmpty");
+}


### PR DESCRIPTION
This adds the ability for custom property decorators on classes that inherit from BaseClassWithoutId that we can then reuse later for various purposes. The first decorator adds JsonRemoveEmpty which can be applied to fields that can be removed if null preventing errors with the API. 

To solve #1507 the Decorator has been added to certain message fields that are sometimes null rather than undefined during MESSAGE_UPDATE events.