### PR TITLE
Add decorator to change Bigint back to string using Number

### DIFF
--- a/src/util/entities/BaseClass.ts
+++ b/src/util/entities/BaseClass.ts
@@ -20,7 +20,7 @@ import { BaseEntity, BeforeInsert, BeforeUpdate, Column, ColumnOptions, FindOpti
 import { Snowflake } from "../util/Snowflake";
 import { getDatabase } from "../util/Database";
 import { OrmUtils } from "../imports/OrmUtils";
-import { annotationsKey } from "../util/Decorators";
+import { annotationsKey, JsonNumber } from "../util/Decorators";
 
 export class BaseClassWithoutId extends BaseEntity {
     private get construct() {
@@ -56,7 +56,7 @@ export class BaseClassWithoutId extends BaseEntity {
             if (
                 key in this && // This object has this property, should never fail but better to be safe
                 key in annotations && // If this property has an annotation
-                annotations[key].indexOf("BigintToLong") > -1 && // if one of the annotations is JsonRemoveEmpty
+                annotations[key].indexOf("JsonNumber") > -1 && // if one of the annotations is JsonRemoveEmpty
                 typeof this[key] == "string" // and its a String
             ) {
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/util/entities/BaseClass.ts
+++ b/src/util/entities/BaseClass.ts
@@ -38,6 +38,9 @@ export class BaseClassWithoutId extends BaseEntity {
     // Loops through all the keys and compares it to annotations. If the RemoveEmpty is there it sets the value to undefined if null
     clean_data() {
         const annotations = this.get_annotations();
+        if (annotations == undefined || annotations.length > 0)
+            //prevent errors if there are no annotations on an object
+            return;
         for (const key in this) {
             if (
                 key in this && // This object has this property, should never fail but better to be safe
@@ -49,6 +52,16 @@ export class BaseClassWithoutId extends BaseEntity {
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-expect-error
                 this[key] = undefined; // set to undefined to remove
+            }
+            if (
+                key in this && // This object has this property, should never fail but better to be safe
+                key in annotations && // If this property has an annotation
+                annotations[key].indexOf("BigintToLong") > -1 && // if one of the annotations is JsonRemoveEmpty
+                typeof this[key] == "string" // and its a String
+            ) {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-expect-error
+                this[key] = Number(this[key]); // convert string back to number
             }
         }
         return this;
@@ -66,6 +79,7 @@ export class BaseClassWithoutId extends BaseEntity {
     // TODO: fix eslint
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     toJSON(): any {
+        this.clean_data();
         return Object.fromEntries(
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             this.metadata!.columns // @ts-ignore

--- a/src/util/entities/Member.ts
+++ b/src/util/entities/Member.ts
@@ -29,6 +29,7 @@ import { Message } from "./Message";
 import { Role } from "./Role";
 import { User } from "./User";
 import { AvatarDecorationData, Collectibles, DisplayNameStyle, PrimaryGuild, PublicMember, PublicMemberProjection, UserGuildSettings } from "@spacebar/schemas";
+import { BigintToLong } from "../util/Decorators";
 
 export const MemberPrivateProjection: (keyof Member)[] = [
     "id",
@@ -98,6 +99,7 @@ export class Member extends BaseClassWithoutId {
     joined_at: Date;
 
     @Column({ type: "bigint", nullable: true })
+    @BigintToLong
     premium_since?: number;
 
     @Column()

--- a/src/util/entities/Member.ts
+++ b/src/util/entities/Member.ts
@@ -29,7 +29,7 @@ import { Message } from "./Message";
 import { Role } from "./Role";
 import { User } from "./User";
 import { AvatarDecorationData, Collectibles, DisplayNameStyle, PrimaryGuild, PublicMember, PublicMemberProjection, UserGuildSettings } from "@spacebar/schemas";
-import { BigintToLong } from "../util/Decorators";
+import { JsonNumber } from "../util/Decorators";
 
 export const MemberPrivateProjection: (keyof Member)[] = [
     "id",
@@ -99,7 +99,6 @@ export class Member extends BaseClassWithoutId {
     joined_at: Date;
 
     @Column({ type: "bigint", nullable: true })
-    @BigintToLong
     premium_since?: number;
 
     @Column()

--- a/src/util/entities/User.ts
+++ b/src/util/entities/User.ts
@@ -38,7 +38,7 @@ import {
     PublicUserProjection,
     UserPrivate,
 } from "@spacebar/schemas";
-import { BigintToLong } from "../util/Decorators";
+import { JsonNumber } from "../util/Decorators";
 
 @Entity({
     name: "users",
@@ -125,22 +125,22 @@ export class User extends BaseClass {
     email?: string; // email of the user
 
     @Column({ type: "bigint" })
-    @BigintToLong
+    @JsonNumber
     flags: number = 0; // UserFlags // TODO: generate
 
     @Column({ type: "bigint" })
-    @BigintToLong
+    @JsonNumber
     public_flags: number = 0;
 
     @Column({ type: "bigint" })
-    @BigintToLong
+    @JsonNumber
     purchased_flags: number = 0;
 
     @Column()
     premium_usage_flags: number = 0;
 
     @Column({ type: "bigint" })
-    @BigintToLong
+    @JsonNumber
     rights: string;
 
     @OneToMany(() => Session, (session: Session) => session.user)

--- a/src/util/entities/User.ts
+++ b/src/util/entities/User.ts
@@ -38,6 +38,7 @@ import {
     PublicUserProjection,
     UserPrivate,
 } from "@spacebar/schemas";
+import { BigintToLong } from "../util/Decorators";
 
 @Entity({
     name: "users",
@@ -124,18 +125,22 @@ export class User extends BaseClass {
     email?: string; // email of the user
 
     @Column({ type: "bigint" })
+    @BigintToLong
     flags: number = 0; // UserFlags // TODO: generate
 
     @Column({ type: "bigint" })
+    @BigintToLong
     public_flags: number = 0;
 
     @Column({ type: "bigint" })
+    @BigintToLong
     purchased_flags: number = 0;
 
     @Column()
     premium_usage_flags: number = 0;
 
     @Column({ type: "bigint" })
+    @BigintToLong
     rights: string;
 
     @OneToMany(() => Session, (session: Session) => session.user)

--- a/src/util/util/Decorators.ts
+++ b/src/util/util/Decorators.ts
@@ -20,7 +20,7 @@ export function JsonRemoveEmpty(target: BaseClassWithoutId, propertyKey: string)
     addAnnotationMetadata(target, propertyKey, "JsonRemoveEmpty");
 }
 
-export function BigintToLong(target: BaseClassWithoutId, propertyKey: string) {
+export function JsonNumber(target: BaseClassWithoutId, propertyKey: string) {
     initAnnotationMetadata(target, propertyKey);
-    addAnnotationMetadata(target, propertyKey, "BigintToLong");
+    addAnnotationMetadata(target, propertyKey, "JsonNumber");
 }

--- a/src/util/util/Decorators.ts
+++ b/src/util/util/Decorators.ts
@@ -19,3 +19,8 @@ export function JsonRemoveEmpty(target: BaseClassWithoutId, propertyKey: string)
     initAnnotationMetadata(target, propertyKey);
     addAnnotationMetadata(target, propertyKey, "JsonRemoveEmpty");
 }
+
+export function BigintToLong(target: BaseClassWithoutId, propertyKey: string) {
+    initAnnotationMetadata(target, propertyKey);
+    addAnnotationMetadata(target, propertyKey, "BigintToLong");
+}


### PR DESCRIPTION
Added a decorator BigintToLong which takes annotated fields and automatically makes them numbers again in toJson
Should fix #1506 