### PR TITLE
feat(gateway): make heartbeat interval and timeout configurable via env vars

### DIFF
--- a/src/gateway/events/Connection.ts
+++ b/src/gateway/events/Connection.ts
@@ -132,10 +132,11 @@ export async function Connection(this: WS.Server, socket: WebSocket, request: In
 
         setHeartbeat(socket);
 
+        const heartbeatInterval = parseInt(process.env.GATEWAY_HEARTBEAT_INTERVAL ?? "30000");
         await Send(socket, {
             op: OPCODES.Hello,
             d: {
-                heartbeat_interval: 1000 * 30,
+                heartbeat_interval: heartbeatInterval,
             },
         });
 

--- a/src/gateway/util/Heartbeat.ts
+++ b/src/gateway/util/Heartbeat.ts
@@ -19,11 +19,12 @@
 import { CLOSECODES } from "./Constants";
 import { WebSocket } from "./WebSocket";
 
-// TODO: make heartbeat timeout configurable
+const HEARTBEAT_TIMEOUT_MS = parseInt(process.env.GATEWAY_HEARTBEAT_TIMEOUT ?? "45000");
+
 export function setHeartbeat(socket: WebSocket) {
     if (socket.heartbeatTimeout) clearTimeout(socket.heartbeatTimeout);
 
     socket.heartbeatTimeout = setTimeout(() => {
         return socket.close(CLOSECODES.Session_timed_out);
-    }, 1000 * 45);
+    }, HEARTBEAT_TIMEOUT_MS);
 }


### PR DESCRIPTION
## Summary

Add support for two environment variables to configure gateway heartbeat behavior:

- `GATEWAY_HEARTBEAT_INTERVAL` — interval (ms) sent to clients in the HELLO message (default: `30000`)
- `GATEWAY_HEARTBEAT_TIMEOUT` — server-side disconnect timeout (ms) (default: `45000`)

Both default to the original hardcoded values, so this is fully backwards-compatible.

## Motivation

The existing heartbeat timeout is hardcoded at 45 seconds. There was already a TODO comment in `Heartbeat.ts` noting this should be configurable:

```ts
// TODO: make heartbeat timeout configurable
```

This is particularly relevant for **mobile clients** (e.g. iOS PWA/home screen apps) where the browser may suspend JavaScript timers when the app is backgrounded. With a 45s timeout, clients frequently disconnect with code `4009 Session timed out` even during normal use. Operators can now set a larger timeout (e.g. `GATEWAY_HEARTBEAT_TIMEOUT=300000`) to accommodate mobile clients without affecting server behaviour for other users.

## Changes

- `src/gateway/util/Heartbeat.ts`: read timeout from `GATEWAY_HEARTBEAT_TIMEOUT` env var, default `45000`
- `src/gateway/events/Connection.ts`: read interval from `GATEWAY_HEARTBEAT_INTERVAL` env var, default `30000`

## Backwards Compatibility

No behaviour change when neither env var is set — defaults match the previous hardcoded values.