### PR TITLE
gateway should not crash for discord clients that send Op 37

### DIFF
--- a/src/gateway/opcodes/LazyRequest.ts
+++ b/src/gateway/opcodes/LazyRequest.ts
@@ -212,7 +212,7 @@ export async function onLazyRequest(this: WebSocket, { d }: Payload) {
         if (!channels) return;
     }
 
-    if (!channels) throw new Error("Must provide channel ranges");
+    if (!channels) return;
 
     const channel_id = Object.keys(channels || {})[0];
     if (!channel_id) return;


### PR DESCRIPTION
gateway should not crash for clients that send Op 37 with missing channel ranges, instead ignore the message.

closes: https://github.com/spacebarchat/server/issues/1568