### PR TITLE
when guild region is misconfigured, fallback to default region

### DIFF
--- a/src/gateway/opcodes/StreamCreate.ts
+++ b/src/gateway/opcodes/StreamCreate.ts
@@ -46,7 +46,11 @@ export async function onStreamCreate(this: WebSocket, data: Payload) {
 
     // TODO: actually apply preferred_region from the event payload
     const regions = Config.get().regions;
-    const guildRegion = regions.available.filter((r) => r.id === regions.default)[0];
+    const guildRegion = regions.available.find((r) => r.id === regions.default);
+
+    if (!guildRegion) {
+        throw new Error("No default region configured");
+    }
 
     // first make sure theres no other streams for this user that somehow didnt get cleared
     await Stream.delete({

--- a/src/gateway/opcodes/VoiceStateUpdate.ts
+++ b/src/gateway/opcodes/VoiceStateUpdate.ts
@@ -127,11 +127,21 @@ export async function onVoiceStateUpdate(this: WebSocket, data: Payload) {
             where: { id: voiceState.guild_id },
         });
         const regions = Config.get().regions;
-        let guildRegion: Region;
+        let guildRegion: Region | undefined;
+
+        const defaultRegion = regions.available.find((r) => r.id === regions.default);
+
         if (guild && guild.region) {
-            guildRegion = regions.available.filter((r) => r.id === guild.region)[0];
+            // in case the configured guild region does not exist (which can
+            // happen when server regions config is updated after guild creation),
+            // fallback to default region
+            guildRegion = regions.available.find((r) => r.id === guild.region) ?? defaultRegion;
         } else {
-            guildRegion = regions.available.filter((r) => r.id === regions.default)[0];
+            guildRegion = defaultRegion;
+        }
+
+        if (!guildRegion) {
+            throw new Error("Unable to find suitable region due to misconfiguration of regions");
         }
 
         await emitEvent({


### PR DESCRIPTION
This makes the region selection fallback to the default region when a guild is configured to connect to a non-existing region.

This can happen when a spacebar instance's region config is updated, since all the pre-existing guilds would have set the previous default region on guild creation