### PR TITLE
Allow more control over TLS settings for nodemailer (STARTTLS and self-signed certificates)

### DIFF
--- a/src/util/config/types/subconfigurations/email/SMTP.ts
+++ b/src/util/config/types/subconfigurations/email/SMTP.ts
@@ -20,6 +20,8 @@ export class SMTPConfiguration {
     host: string | null = null;
     port: number | null = null;
     secure: boolean | null = null;
+    starttls: boolean = false;
+    allowInsecure: boolean = false;
     username: string | null = null;
     password: string | null = null;
 }

--- a/src/util/util/email/clients/SMTPEmailClient.ts
+++ b/src/util/util/email/clients/SMTPEmailClient.ts
@@ -34,7 +34,7 @@ export class SMTPEmailClient extends BaseEmailClient {
             return;
         }
         // get configuration
-        const { host, port, secure, username, password } = Config.get().email.smtp;
+        const { host, port, secure, starttls, allowInsecure, username, password } = Config.get().email.smtp;
 
         // ensure all required configuration values are set
         if (!host || !port || secure === null) return console.error("[Email] SMTP has not been configured correctly.");
@@ -45,24 +45,27 @@ export class SMTPEmailClient extends BaseEmailClient {
             );
 
         /* Allow for SMTP relays with and without username/passwords (IE: Smarthosts/Local Relays, etc) */
-        let nodemailer_opts: unknown;
-        if(!username || !password) {
-            nodemailer_opts = {
-                host,
-                port,
-                secure,
-            };
-        } else {
-            nodemailer_opts = {
-                host,
-                port,
-                secure,
-                auth: {
-                    user: username,
-                    pass: password,
-                },
-            };
-        }
+        const nodemailer_opts = {
+            host: host,
+            port: port,
+            secure: secure,
+            ...(starttls ? { requireTLS: true } : { ignoreTLS: true }),
+            ...(allowInsecure
+                ? {
+                      tls: {
+                          rejectUnauthorized: false,
+                      },
+                  }
+                : {}),
+            ...(username && password
+                ? {
+                      auth: {
+                          user: username,
+                          pass: password,
+                      },
+                  }
+                : {}),
+        };
 
         // construct the transporter
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
**Problem**

Nodemailer still upgrades connections to TLS via STARTTLS even if `smtp.secure` is set to false in the configuration file. Furthermore there is no way to accept self signed certificates for both connections that start with TLS (secure == true) or connections that upgrade to TLS via STARTTLS.

**Solution**

Add two new configuration options to better manage nodemailer's usage of TLS.

- `smtp.starttls` - When set to true will set `requireTLS` to true in the nodemailer initialization, even if STARTTLS is not advertised. If set to false will set `ignoreTLS` to true which will prevent nodemailer from upgrading to TLS  via STARTTLS. Default to false.
- `smtp.allowInsecure` - When set to true will allow insecure certificates (self signed, expired, etc) to be accepted by nodemailer. Defaults to false.

By adding these options it will allow more flexibility when configuring SMTP settings for both instance owners and developers and solves the problem outlined above.

Source: https://nodemailer.com/usage