### PR TITLE
Fix for reactions under discord.py and possibly other bots

### DIFF
--- a/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
+++ b/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
@@ -30,6 +30,7 @@ import {
     MessageReactionRemoveEvent,
     User,
     arrayRemove,
+    ReactionType,
 } from "@spacebar/util";
 import { Request, Response, Router } from "express";
 import { HTTPError } from "lambert-server";
@@ -224,14 +225,12 @@ router.put(
 
         await message.save();
 
-        const member =
-            channel.guild_id &&
-            (
-                await Member.findOneOrFail({
-                    where: { id: req.user_id },
-                    select: PublicMemberProjection,
-                })
-            ).toPublicMember();
+        const member = (
+            await Member.findOneOrFail({
+                where: { id: req.user_id },
+                select: PublicMemberProjection,
+            })
+        ).toPublicMember();
 
         await emitEvent({
             event: "MESSAGE_REACTION_ADD",
@@ -243,8 +242,9 @@ router.put(
                 guild_id: channel.guild_id,
                 emoji,
                 member,
+                type: ReactionType.normal,
             },
-        } as MessageReactionAddEvent);
+        } satisfies MessageReactionAddEvent);
 
         res.sendStatus(204);
     },

--- a/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
+++ b/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
@@ -300,8 +300,9 @@ router.delete(
                 message_id,
                 guild_id: channel.guild_id,
                 emoji,
+                type: ReactionType.normal,
             },
-        } as MessageReactionRemoveEvent);
+        } satisfies MessageReactionRemoveEvent);
 
         res.sendStatus(204);
     },
@@ -357,8 +358,9 @@ router.delete(
                 message_id,
                 guild_id: channel.guild_id,
                 emoji,
+                type: ReactionType.normal,
             },
-        } as MessageReactionRemoveEvent);
+        } satisfies MessageReactionRemoveEvent);
 
         res.sendStatus(204);
     },

--- a/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
+++ b/src/api/routes/channels/#channel_id/messages/#message_id/reactions.ts
@@ -228,7 +228,15 @@ router.put(
         const member = (
             await Member.findOneOrFail({
                 where: { id: req.user_id },
-                select: PublicMemberProjection,
+                relations: { roles: true, user: true },
+                select: {
+                    index: true,
+                    ...Object.fromEntries(PublicMemberProjection.map((x) => [x, true])),
+                    user: Object.fromEntries(PublicUserProjection.map((x) => [x, true])),
+                    roles: {
+                        id: true,
+                    },
+                },
             })
         ).toPublicMember();
 

--- a/src/util/interfaces/Event.ts
+++ b/src/util/interfaces/Event.ts
@@ -376,7 +376,10 @@ export interface MessageDeleteBulkEvent extends Event {
         guild_id?: string;
     };
 }
-
+export const enum ReactionType {
+    normal = 0,
+    burst = 1,
+}
 export interface MessageReactionAddEvent extends Event {
     event: "MESSAGE_REACTION_ADD";
     data: {
@@ -386,6 +389,7 @@ export interface MessageReactionAddEvent extends Event {
         guild_id?: string;
         member?: PublicMember;
         emoji: PartialEmoji;
+        type: ReactionType;
     };
 }
 

--- a/src/util/interfaces/Event.ts
+++ b/src/util/interfaces/Event.ts
@@ -401,6 +401,7 @@ export interface MessageReactionRemoveEvent extends Event {
         message_id: string;
         guild_id?: string;
         emoji: PartialEmoji;
+        type: ReactionType;
     };
 }
 


### PR DESCRIPTION
**Problem**

Gateway event `MESSAGE_REACTION_ADD` is missing:

- member.user
- member.roles
- type

This causes discord.py to break as keys that are expected in the v9 API are missing.

**Solution**

Add missing keys.

Based on work from @MathMan05 in this PR here: https://github.com/spacebarchat/server/pull/1576

This PR succeeds: https://github.com/spacebarchat/server/pull/1576