### PR TITLE
Author is missing from referenced_messages

### DIFF
--- a/src/api/routes/channels/#channel_id/messages/#message_id/index.ts
+++ b/src/api/routes/channels/#channel_id/messages/#message_id/index.ts
@@ -265,7 +265,10 @@ router.get(
 
         const message = await Message.findOneOrFail({
             where: { id: message_id, channel_id },
-            relations: { attachments: true },
+            relations: {
+                attachments: true,
+                author: true,
+            },
         });
 
         const permissions = await getPermission(req.user_id, undefined, channel_id);


### PR DESCRIPTION
**Problem**

`author` is missing from referenced_messages (example: replies) causing discord.py to crash

**Solution**

Added `author` as a relation in the message query.