### PR TITLE
Feature: Implement S3 force path-style support

### DIFF
--- a/src/cdn/util/S3Storage.ts
+++ b/src/cdn/util/S3Storage.ts
@@ -33,10 +33,11 @@ export class S3Storage implements Storage {
         private region: string,
         private bucket: string,
         private endpoint: string,
+        private forcePathStyle: boolean,
         private basePath?: string,
     ) {
         const { S3 } = require("@aws-sdk/client-s3");
-        this.client = new S3({ region: region, endpoint: endpoint });
+        this.client = new S3({ region: region, endpoint: endpoint, forcePathStyle: forcePathStyle });
     }
     isFile(path: string): Promise<boolean> {
         return this.exists(path);

--- a/src/cdn/util/Storage.ts
+++ b/src/cdn/util/Storage.ts
@@ -82,8 +82,15 @@ if (process.env.STORAGE_PROVIDER === "file" || !process.env.STORAGE_PROVIDER) {
         location = undefined;
     }
 
+    // if false, the bucket name is used as a subdomain
+    const forcePathStyle = process.env.STORAGE_FORCE_PATH_STYLE === "true";
+
+    if (process.env.STORAGE_FORCE_PATH_STYLE === undefined) {
+        console.warn(`[CDN] STORAGE_FORCE_PATH_STYLE unconfigured for S3 provider, defaulting to use virtual-hosted style...`);
+    }
+
     const { S3Storage } = require("./S3Storage");
-    storage = new S3Storage(region, bucket, endpoint, location);
+    storage = new S3Storage(region, bucket, endpoint, forcePathStyle, location);
 }
 
 export { storage };

--- a/src/cdn/util/Storage.ts
+++ b/src/cdn/util/Storage.ts
@@ -86,7 +86,7 @@ if (process.env.STORAGE_PROVIDER === "file" || !process.env.STORAGE_PROVIDER) {
     const forcePathStyle = process.env.STORAGE_FORCE_PATH_STYLE === "true";
 
     if (process.env.STORAGE_FORCE_PATH_STYLE === undefined) {
-        console.warn(`[CDN] STORAGE_FORCE_PATH_STYLE unconfigured for S3 provider, defaulting to use virtual-hosted style...`);
+        console.warn(`[CDN] STORAGE_FORCE_PATH_STYLE is not set for S3 provider; defaulting to virtual-hosted style. Set STORAGE_FORCE_PATH_STYLE=true to enable path-style addressing.`);
     }
 
     const { S3Storage } = require("./S3Storage");


### PR DESCRIPTION
The function adds flexibility when interacting with AWS-compatible S3 storage.

Introduces optional environment variable `STORAGE_FORCE_PATH_STYLE` to control `aws-sdk` DNS behavior. 

When set to `false` (default), the bucket name is used as a subdomain (e.g. bucket.s3.example.com).
When set to `true`, path-style addressing is used instead (no subdomain).

The default value preserves existing behavior.