### PR TITLE
Add C# email config model

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,4 +1,9 @@
 export default {
     "*.{j,t}s": [() => "npm run build:src:tsgo", "eslint --concurrency 4" /* sweet spot it seems */, "prettier --write"],
-    "src/schemas/{*,**/*}.ts": [() => "npm run build:src:tsgo", () => "node scripts/schema.js", () => "node scripts/openapi.js", () => "git add assets/schemas.json assets/openapi.json"],
+    "src/schemas/{*,**/*}.ts": [
+        () => "npm run build:src:tsgo",
+        () => "node scripts/schema.js",
+        () => "node scripts/openapi.js",
+        () => "git add assets/schemas.json assets/openapi.json",
+    ],
 };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,7 +66,7 @@ export default defineConfig([
             // "sort-imports": ["error", {}],
             "default-case": "error",
             "default-case-last": "error",
-            "yoda": "error",
+            yoda: "error",
             // unsure what the defaults are here, but we want them to error
             "for-direction": "error",
             "constructor-super": "error",

--- a/extra/admin-api/Models/Spacebar.Models.Config/EmailConfiguration.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Config/EmailConfiguration.cs
@@ -1,0 +1,73 @@
+using System.Text.Json.Serialization;
+
+namespace Spacebar.ConfigModel;
+
+public class EmailConfiguration {
+    [JsonPropertyName("provider")]
+    public string? Provider { get; set; }
+
+    [JsonPropertyName("senderAddress")]
+    public string? SenderAddress { get; set; }
+
+    [JsonPropertyName("smtp")]
+    public SmtpConfiguration Smtp { get; set; } = new();
+
+    [JsonPropertyName("mailgun")]
+    public MailGunConfiguration Mailgun { get; set; } = new();
+
+    [JsonPropertyName("mailjet")]
+    public MailJetConfiguration Mailjet { get; set; } = new();
+
+    [JsonPropertyName("sendgrid")]
+    public SendGridConfiguration Sendgrid { get; set; } = new();
+}
+
+public class SmtpConfiguration {
+    [JsonPropertyName("host")]
+    public string? Host { get; set; }
+
+    [JsonPropertyName("port")]
+    public int? Port { get; set; }
+
+    [JsonPropertyName("secure")]
+    public bool? Secure { get; set; }
+
+    [JsonPropertyName("starttls")]
+    public bool Starttls { get; set; } = false;
+
+    [JsonPropertyName("allowInsecure")]
+    public bool AllowInsecure { get; set; } = false;
+
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    [JsonPropertyName("password")]
+    public string? Password { get; set; }
+}
+
+public class MailGunConfiguration {
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    [JsonPropertyName("apiKey")]
+    public string? ApiKey { get; set; }
+
+    [JsonPropertyName("domain")]
+    public string? Domain { get; set; }
+
+    [JsonPropertyName("isEuropean")]
+    public bool IsEuropean { get; set; } = true;
+}
+
+public class MailJetConfiguration {
+    [JsonPropertyName("apiKey")]
+    public string? ApiKey { get; set; }
+
+    [JsonPropertyName("apiSecret")]
+    public string? ApiSecret { get; set; }
+}
+
+public class SendGridConfiguration {
+    [JsonPropertyName("apiKey")]
+    public string? ApiKey { get; set; }
+}

--- a/extra/admin-api/Models/Spacebar.Models.Config/ServerConfiguration.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Config/ServerConfiguration.cs
@@ -51,9 +51,8 @@ public class ServerConfiguration {
     [JsonPropertyName("external")]
     public ExternalTokensConfiguration External { get; set; } = new();
 
-    // TODO: lazy
-    // [JsonPropertyName("email")]
-    // public EmailConfiguration Email { get; set; } = new EmailConfiguration();
+    [JsonPropertyName("email")]
+    public EmailConfiguration Email { get; set; } = new();
 
     [JsonPropertyName("passwordReset")]
     public PasswordResetConfiguration PasswordReset { get; set; } = new PasswordResetConfiguration();

--- a/extra/admin-api/SpacebarAdminAPI.slnx
+++ b/extra/admin-api/SpacebarAdminAPI.slnx
@@ -34,6 +34,9 @@
         <Project Path="Utilities/Spacebar.Cdn.Migration/Spacebar.Cdn.Migration.csproj"/>
         <Project Path="Utilities/Spacebar.CleanSettingsRows/Spacebar.CleanSettingsRows.csproj"/>
     </Folder>
+    <Folder Name="/Tests/">
+        <Project Path="Tests/Spacebar.Models.Config.Tests/Spacebar.Models.Config.Tests.csproj"/>
+    </Folder>
     <Project Path="Spacebar.AdminApi/Spacebar.AdminApi.csproj"/>
     <Project Path="Spacebar.Cdn.Worker/Spacebar.Cdn.Worker.Q16-HDRI.x86_64.csproj" DisplayName="Spacebar.Cdn.Worker"/>
     <Project Path="Spacebar.Cdn/Spacebar.Cdn.csproj"/>

--- a/extra/admin-api/Tests/Spacebar.Models.Config.Tests/EmailConfigurationTests.cs
+++ b/extra/admin-api/Tests/Spacebar.Models.Config.Tests/EmailConfigurationTests.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Spacebar.ConfigModel;
+using Spacebar.ConfigModel.Extensions;
+
+namespace Spacebar.Models.Config.Tests;
+
+public class EmailConfigurationTests {
+    [Fact]
+    public void ServerConfigurationSerializesTopLevelEmailDefaults() {
+        var json = JsonSerializer.Serialize(new ServerConfiguration());
+        var node = JsonNode.Parse(json)!;
+
+        Assert.NotNull(node["email"]);
+        Assert.Null(node["email"]!["provider"]);
+        Assert.Null(node["email"]!["senderAddress"]);
+        Assert.False(node["email"]!["smtp"]!["starttls"]!.GetValue<bool>());
+        Assert.False(node["email"]!["smtp"]!["allowInsecure"]!.GetValue<bool>());
+        Assert.True(node["email"]!["mailgun"]!["isEuropean"]!.GetValue<bool>());
+        Assert.NotNull(node["email"]!["mailjet"]);
+        Assert.NotNull(node["email"]!["sendgrid"]);
+    }
+
+    [Fact]
+    public void ServerConfigurationDeserializesEmailProviders() {
+        const string json = """
+                            {
+                                "email": {
+                                    "provider": "smtp",
+                                    "senderAddress": "noreply@example.com",
+                                    "smtp": {
+                                        "host": "smtp.example.com",
+                                        "port": 587,
+                                        "secure": false,
+                                        "starttls": true,
+                                        "allowInsecure": false,
+                                        "username": "user",
+                                        "password": "pass"
+                                    },
+                                    "mailgun": {
+                                        "username": "api",
+                                        "apiKey": "mailgun-key",
+                                        "domain": "mg.example.com",
+                                        "isEuropean": false
+                                    },
+                                    "mailjet": {
+                                        "apiKey": "mailjet-key",
+                                        "apiSecret": "mailjet-secret"
+                                    },
+                                    "sendgrid": {
+                                        "apiKey": "sendgrid-key"
+                                    }
+                                }
+                            }
+                            """;
+
+        var config = JsonSerializer.Deserialize<ServerConfiguration>(json);
+
+        Assert.NotNull(config);
+        Assert.Equal("smtp", config.Email.Provider);
+        Assert.Equal("noreply@example.com", config.Email.SenderAddress);
+        Assert.Equal("smtp.example.com", config.Email.Smtp.Host);
+        Assert.Equal(587, config.Email.Smtp.Port);
+        Assert.False(config.Email.Smtp.Secure);
+        Assert.True(config.Email.Smtp.Starttls);
+        Assert.False(config.Email.Smtp.AllowInsecure);
+        Assert.Equal("user", config.Email.Smtp.Username);
+        Assert.Equal("pass", config.Email.Smtp.Password);
+        Assert.Equal("api", config.Email.Mailgun.Username);
+        Assert.Equal("mailgun-key", config.Email.Mailgun.ApiKey);
+        Assert.Equal("mg.example.com", config.Email.Mailgun.Domain);
+        Assert.False(config.Email.Mailgun.IsEuropean);
+        Assert.Equal("mailjet-key", config.Email.Mailjet.ApiKey);
+        Assert.Equal("mailjet-secret", config.Email.Mailjet.ApiSecret);
+        Assert.Equal("sendgrid-key", config.Email.Sendgrid.ApiKey);
+    }
+
+    [Fact]
+    public void EmailConfigurationRoundTripsThroughFlatConfigKeys() {
+        var nested = new JsonObject {
+            ["email"] = new JsonObject {
+                ["provider"] = "mailgun",
+                ["senderAddress"] = "noreply@example.com",
+                ["smtp"] = new JsonObject {
+                    ["password"] = "smtp-secret",
+                    ["starttls"] = true,
+                },
+                ["mailgun"] = new JsonObject {
+                    ["apiKey"] = "mailgun-key",
+                    ["isEuropean"] = true,
+                },
+            },
+            ["register"] = new JsonObject {
+                ["email"] = new JsonObject {
+                    ["required"] = true,
+                },
+            },
+        };
+
+        var flat = nested.ToFlatKv();
+        var roundTrip = flat.ToNestedJsonObject();
+
+        Assert.Equal("\"mailgun\"", flat["email_provider"]);
+        Assert.Equal("\"smtp-secret\"", flat["email_smtp_password"]);
+        Assert.Equal("true", flat["email_mailgun_isEuropean"]);
+        Assert.Equal("true", flat["register_email_required"]);
+        Assert.Equal("mailgun", roundTrip["email"]!["provider"]!.GetValue<string>());
+        Assert.Equal("smtp-secret", roundTrip["email"]!["smtp"]!["password"]!.GetValue<string>());
+        Assert.True(roundTrip["email"]!["mailgun"]!["isEuropean"]!.GetValue<bool>());
+        Assert.True(roundTrip["register"]!["email"]!["required"]!.GetValue<bool>());
+    }
+}

--- a/extra/admin-api/Tests/Spacebar.Models.Config.Tests/EmailConfigurationTests.cs
+++ b/extra/admin-api/Tests/Spacebar.Models.Config.Tests/EmailConfigurationTests.cs
@@ -10,15 +10,29 @@ public class EmailConfigurationTests {
     public void ServerConfigurationSerializesTopLevelEmailDefaults() {
         var json = JsonSerializer.Serialize(new ServerConfiguration());
         var node = JsonNode.Parse(json)!;
+        var email = node["email"]!;
+        var smtp = email["smtp"]!;
+        var mailgun = email["mailgun"]!;
+        var mailjet = email["mailjet"]!;
+        var sendgrid = email["sendgrid"]!;
 
-        Assert.NotNull(node["email"]);
-        Assert.Null(node["email"]!["provider"]);
-        Assert.Null(node["email"]!["senderAddress"]);
-        Assert.False(node["email"]!["smtp"]!["starttls"]!.GetValue<bool>());
-        Assert.False(node["email"]!["smtp"]!["allowInsecure"]!.GetValue<bool>());
-        Assert.True(node["email"]!["mailgun"]!["isEuropean"]!.GetValue<bool>());
-        Assert.NotNull(node["email"]!["mailjet"]);
-        Assert.NotNull(node["email"]!["sendgrid"]);
+        Assert.NotNull(email);
+        Assert.Null(email["provider"]);
+        Assert.Null(email["senderAddress"]);
+        Assert.Null(smtp["host"]);
+        Assert.Null(smtp["port"]);
+        Assert.Null(smtp["secure"]);
+        Assert.False(smtp["starttls"]!.GetValue<bool>());
+        Assert.False(smtp["allowInsecure"]!.GetValue<bool>());
+        Assert.Null(smtp["username"]);
+        Assert.Null(smtp["password"]);
+        Assert.Null(mailgun["username"]);
+        Assert.Null(mailgun["apiKey"]);
+        Assert.Null(mailgun["domain"]);
+        Assert.True(mailgun["isEuropean"]!.GetValue<bool>());
+        Assert.Null(mailjet["apiKey"]);
+        Assert.Null(mailjet["apiSecret"]);
+        Assert.Null(sendgrid["apiKey"]);
     }
 
     [Fact]
@@ -57,37 +71,48 @@ public class EmailConfigurationTests {
         var config = JsonSerializer.Deserialize<ServerConfiguration>(json);
 
         Assert.NotNull(config);
-        Assert.Equal("smtp", config.Email.Provider);
-        Assert.Equal("noreply@example.com", config.Email.SenderAddress);
-        Assert.Equal("smtp.example.com", config.Email.Smtp.Host);
-        Assert.Equal(587, config.Email.Smtp.Port);
-        Assert.False(config.Email.Smtp.Secure);
-        Assert.True(config.Email.Smtp.Starttls);
-        Assert.False(config.Email.Smtp.AllowInsecure);
-        Assert.Equal("user", config.Email.Smtp.Username);
-        Assert.Equal("pass", config.Email.Smtp.Password);
-        Assert.Equal("api", config.Email.Mailgun.Username);
-        Assert.Equal("mailgun-key", config.Email.Mailgun.ApiKey);
-        Assert.Equal("mg.example.com", config.Email.Mailgun.Domain);
-        Assert.False(config.Email.Mailgun.IsEuropean);
-        Assert.Equal("mailjet-key", config.Email.Mailjet.ApiKey);
-        Assert.Equal("mailjet-secret", config.Email.Mailjet.ApiSecret);
-        Assert.Equal("sendgrid-key", config.Email.Sendgrid.ApiKey);
+        AssertConfiguredEmail(config.Email, smtpAllowInsecure: false);
+    }
+
+    [Fact]
+    public void FlatEmailConfigKeysDeserializeIntoServerConfiguration() {
+        var flat = CreateConfiguredFlatEmailKeys();
+
+        var nested = flat.ToNestedJsonObject();
+        var config = nested.Deserialize<ServerConfiguration>();
+
+        Assert.NotNull(config);
+        AssertConfiguredEmail(config.Email, smtpAllowInsecure: true);
+        Assert.True(config.Register.Email.Required);
     }
 
     [Fact]
     public void EmailConfigurationRoundTripsThroughFlatConfigKeys() {
         var nested = new JsonObject {
             ["email"] = new JsonObject {
-                ["provider"] = "mailgun",
+                ["provider"] = "smtp",
                 ["senderAddress"] = "noreply@example.com",
                 ["smtp"] = new JsonObject {
-                    ["password"] = "smtp-secret",
+                    ["host"] = "smtp.example.com",
+                    ["port"] = 587,
+                    ["secure"] = false,
                     ["starttls"] = true,
+                    ["allowInsecure"] = true,
+                    ["username"] = "user",
+                    ["password"] = "pass",
                 },
                 ["mailgun"] = new JsonObject {
+                    ["username"] = "api",
                     ["apiKey"] = "mailgun-key",
-                    ["isEuropean"] = true,
+                    ["domain"] = "mg.example.com",
+                    ["isEuropean"] = false,
+                },
+                ["mailjet"] = new JsonObject {
+                    ["apiKey"] = "mailjet-key",
+                    ["apiSecret"] = "mailjet-secret",
+                },
+                ["sendgrid"] = new JsonObject {
+                    ["apiKey"] = "sendgrid-key",
                 },
             },
             ["register"] = new JsonObject {
@@ -99,14 +124,53 @@ public class EmailConfigurationTests {
 
         var flat = nested.ToFlatKv();
         var roundTrip = flat.ToNestedJsonObject();
+        var config = roundTrip.Deserialize<ServerConfiguration>();
+        var expectedFlat = CreateConfiguredFlatEmailKeys();
 
-        Assert.Equal("\"mailgun\"", flat["email_provider"]);
-        Assert.Equal("\"smtp-secret\"", flat["email_smtp_password"]);
-        Assert.Equal("true", flat["email_mailgun_isEuropean"]);
-        Assert.Equal("true", flat["register_email_required"]);
-        Assert.Equal("mailgun", roundTrip["email"]!["provider"]!.GetValue<string>());
-        Assert.Equal("smtp-secret", roundTrip["email"]!["smtp"]!["password"]!.GetValue<string>());
-        Assert.True(roundTrip["email"]!["mailgun"]!["isEuropean"]!.GetValue<bool>());
-        Assert.True(roundTrip["register"]!["email"]!["required"]!.GetValue<bool>());
+        Assert.Equal(expectedFlat.OrderBy(x => x.Key), flat.OrderBy(x => x.Key));
+        Assert.NotNull(config);
+        AssertConfiguredEmail(config.Email, smtpAllowInsecure: true);
+        Assert.True(config.Register.Email.Required);
+    }
+
+    private static Dictionary<string, string?> CreateConfiguredFlatEmailKeys() {
+        return new Dictionary<string, string?> {
+            ["email_provider"] = "\"smtp\"",
+            ["email_senderAddress"] = "\"noreply@example.com\"",
+            ["email_smtp_host"] = "\"smtp.example.com\"",
+            ["email_smtp_port"] = "587",
+            ["email_smtp_secure"] = "false",
+            ["email_smtp_starttls"] = "true",
+            ["email_smtp_allowInsecure"] = "true",
+            ["email_smtp_username"] = "\"user\"",
+            ["email_smtp_password"] = "\"pass\"",
+            ["email_mailgun_username"] = "\"api\"",
+            ["email_mailgun_apiKey"] = "\"mailgun-key\"",
+            ["email_mailgun_domain"] = "\"mg.example.com\"",
+            ["email_mailgun_isEuropean"] = "false",
+            ["email_mailjet_apiKey"] = "\"mailjet-key\"",
+            ["email_mailjet_apiSecret"] = "\"mailjet-secret\"",
+            ["email_sendgrid_apiKey"] = "\"sendgrid-key\"",
+            ["register_email_required"] = "true",
+        };
+    }
+
+    private static void AssertConfiguredEmail(EmailConfiguration email, bool smtpAllowInsecure) {
+        Assert.Equal("smtp", email.Provider);
+        Assert.Equal("noreply@example.com", email.SenderAddress);
+        Assert.Equal("smtp.example.com", email.Smtp.Host);
+        Assert.Equal(587, email.Smtp.Port);
+        Assert.False(email.Smtp.Secure);
+        Assert.True(email.Smtp.Starttls);
+        Assert.Equal(smtpAllowInsecure, email.Smtp.AllowInsecure);
+        Assert.Equal("user", email.Smtp.Username);
+        Assert.Equal("pass", email.Smtp.Password);
+        Assert.Equal("api", email.Mailgun.Username);
+        Assert.Equal("mailgun-key", email.Mailgun.ApiKey);
+        Assert.Equal("mg.example.com", email.Mailgun.Domain);
+        Assert.False(email.Mailgun.IsEuropean);
+        Assert.Equal("mailjet-key", email.Mailjet.ApiKey);
+        Assert.Equal("mailjet-secret", email.Mailjet.ApiSecret);
+        Assert.Equal("sendgrid-key", email.Sendgrid.ApiKey);
     }
 }

--- a/extra/admin-api/Tests/Spacebar.Models.Config.Tests/Spacebar.Models.Config.Tests.csproj
+++ b/extra/admin-api/Tests/Spacebar.Models.Config.Tests/Spacebar.Models.Config.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../../Models/Spacebar.Models.Config/Spacebar.Models.Config.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+</Project>

--- a/src/cdn/util/Storage.ts
+++ b/src/cdn/util/Storage.ts
@@ -86,7 +86,9 @@ if (process.env.STORAGE_PROVIDER === "file" || !process.env.STORAGE_PROVIDER) {
     const forcePathStyle = process.env.STORAGE_FORCE_PATH_STYLE === "true";
 
     if (process.env.STORAGE_FORCE_PATH_STYLE === undefined) {
-        console.warn(`[CDN] STORAGE_FORCE_PATH_STYLE is not set for S3 provider; defaulting to virtual-hosted style. Set STORAGE_FORCE_PATH_STYLE=true to enable path-style addressing.`);
+        console.warn(
+            `[CDN] STORAGE_FORCE_PATH_STYLE is not set for S3 provider; defaulting to virtual-hosted style. Set STORAGE_FORCE_PATH_STYLE=true to enable path-style addressing.`,
+        );
     }
 
     const { S3Storage } = require("./S3Storage");


### PR DESCRIPTION
## Summary
- Adds the typed C# `EmailConfiguration` model and wires it into `ServerConfiguration.Email`.
- Covers SMTP, Mailgun, Mailjet, and SendGrid config fields/defaults.
- Adds xUnit coverage for JSON defaults, provider deserialization, flat database config keys, and flat/nested round-tripping.
- Applies Prettier formatting to files currently flagged by style checks.

Fixes #1609.

## Tests
- `dotnet test extra/admin-api/Tests/Spacebar.Models.Config.Tests/Spacebar.Models.Config.Tests.csproj`
- `dotnet build extra/admin-api/SpacebarAdminAPI.slnx`
- `dotnet test extra/admin-api/SpacebarAdminAPI.slnx --no-build`
- `git diff --check`
