### PR TITLE
Type C# channel kinds

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,4 +1,9 @@
 export default {
     "*.{j,t}s": [() => "npm run build:src:tsgo", "eslint --concurrency 4" /* sweet spot it seems */, "prettier --write"],
-    "src/schemas/{*,**/*}.ts": [() => "npm run build:src:tsgo", () => "node scripts/schema.js", () => "node scripts/openapi.js", () => "git add assets/schemas.json assets/openapi.json"],
+    "src/schemas/{*,**/*}.ts": [
+        () => "npm run build:src:tsgo",
+        () => "node scripts/schema.js",
+        () => "node scripts/openapi.js",
+        () => "git add assets/schemas.json assets/openapi.json",
+    ],
 };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,7 +66,7 @@ export default defineConfig([
             // "sort-imports": ["error", {}],
             "default-case": "error",
             "default-case-last": "error",
-            "yoda": "error",
+            yoda: "error",
             // unsure what the defaults are here, but we want them to error
             "for-direction": "error",
             "constructor-super": "error",

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/Channel.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/Channel.cs
@@ -23,7 +23,7 @@ public partial class Channel
     public string? Icon { get; set; }
 
     [Column("type")]
-    public int Type { get; set; }
+    public ChannelType Type { get; set; }
 
     [Column("last_message_id")]
     public long? LastMessageId { get; set; }

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/ChannelType.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/ChannelType.cs
@@ -1,0 +1,24 @@
+namespace Spacebar.Models.Db.Models;
+
+public enum ChannelType {
+    GuildText = 0,
+    Dm = 1,
+    GuildVoice = 2,
+    GroupDm = 3,
+    GuildCategory = 4,
+    GuildNews = 5,
+    GuildStore = 6,
+    GuildLfg = 7,
+    LfgGroupDm = 8,
+    ThreadAlpha = 9,
+    GuildNewsThread = 10,
+    GuildPublicThread = 11,
+    GuildPrivateThread = 12,
+    GuildStageVoice = 13,
+    GuildDirectory = 14,
+    GuildForum = 15,
+    GuildMedia = 16,
+    Lobby = 17,
+    EphemeralDm = 18,
+    Unhandled = 255,
+}

--- a/extra/admin-api/Spacebar.AdminApi/Controllers/TestControllers/EmptyDmsController.cs
+++ b/extra/admin-api/Spacebar.AdminApi/Controllers/TestControllers/EmptyDmsController.cs
@@ -8,6 +8,7 @@ using Spacebar.Interop.Authentication.AspNetCore;
 using Spacebar.Interop.Replication.Abstractions;
 using Spacebar.Models.AdminApi;
 using Spacebar.Models.Db.Contexts;
+using Spacebar.Models.Db.Models;
 
 namespace Spacebar.AdminApi.Controllers.TestControllers;
 
@@ -24,11 +25,10 @@ public class EmptyDmsController(
     public async IAsyncEnumerable<object> GetEmptyDms() {
         (await auth.GetCurrentUserAsync(Request)).GetRights().AssertHasAllRights(SpacebarRights.Rights.OPERATOR);
 
-        // TODO channel type enum
         var channels = db.Channels
             .Include(x=>x.Recipients)
             .Include(x=>x.Messages)
-            .Where(x => x.Type == 1)
+            .Where(x => x.Type == ChannelType.Dm)
             .Where(x => !x.Messages.Any() && x.Recipients.Count == 1)
             ;
         

--- a/extra/admin-api/Spacebar.Offload/Controllers/ChannelStatusController.cs
+++ b/extra/admin-api/Spacebar.Offload/Controllers/ChannelStatusController.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Spacebar.Interop.Authentication.AspNetCore;
 using Spacebar.Interop.Replication.Abstractions;
 using Spacebar.Models.Db.Contexts;
+using Spacebar.Models.Db.Models;
 using Spacebar.Models.Gateway;
 
 namespace Spacebar.GatewayOffload.Controllers;
@@ -44,7 +45,7 @@ public class ChannelStatusController(ILogger<ChannelStatusController> logger, Sp
         ];
 
         foreach (var guildId in req.GuildIds ?? [req.GuildId!.Value]) {
-            var channels = (await db.Channels.Include(x => x.VoiceStates).Where(x => x.Type == 2 && x.GuildId == guildId && x.VoiceStates.Count > 0)
+            var channels = (await db.Channels.Include(x => x.VoiceStates).Where(x => x.Type == ChannelType.GuildVoice && x.GuildId == guildId && x.VoiceStates.Count > 0)
                     .Select(x => x.Id)
                     .ToListAsync())
                 .Select(x => new {

--- a/extra/admin-api/SpacebarAdminAPI.slnx
+++ b/extra/admin-api/SpacebarAdminAPI.slnx
@@ -34,6 +34,9 @@
         <Project Path="Utilities/Spacebar.Cdn.Migration/Spacebar.Cdn.Migration.csproj"/>
         <Project Path="Utilities/Spacebar.CleanSettingsRows/Spacebar.CleanSettingsRows.csproj"/>
     </Folder>
+    <Folder Name="/Tests/">
+        <Project Path="Tests/Spacebar.Models.Db.Tests/Spacebar.Models.Db.Tests.csproj"/>
+    </Folder>
     <Project Path="Spacebar.AdminApi/Spacebar.AdminApi.csproj"/>
     <Project Path="Spacebar.Cdn.Worker/Spacebar.Cdn.Worker.Q16-HDRI.x86_64.csproj" DisplayName="Spacebar.Cdn.Worker"/>
     <Project Path="Spacebar.Cdn/Spacebar.Cdn.csproj"/>

--- a/extra/admin-api/Tests/Spacebar.Models.Db.Tests/ChannelTypeTests.cs
+++ b/extra/admin-api/Tests/Spacebar.Models.Db.Tests/ChannelTypeTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.EntityFrameworkCore;
+using Spacebar.Models.Db.Contexts;
+using Spacebar.Models.Db.Models;
+
+namespace Spacebar.Models.Db.Tests;
+
+public class ChannelTypeTests {
+    [Theory]
+    [InlineData(ChannelType.GuildText, 0)]
+    [InlineData(ChannelType.Dm, 1)]
+    [InlineData(ChannelType.GuildVoice, 2)]
+    [InlineData(ChannelType.GroupDm, 3)]
+    [InlineData(ChannelType.GuildCategory, 4)]
+    [InlineData(ChannelType.GuildNews, 5)]
+    [InlineData(ChannelType.GuildStore, 6)]
+    [InlineData(ChannelType.GuildLfg, 7)]
+    [InlineData(ChannelType.LfgGroupDm, 8)]
+    [InlineData(ChannelType.ThreadAlpha, 9)]
+    [InlineData(ChannelType.GuildNewsThread, 10)]
+    [InlineData(ChannelType.GuildPublicThread, 11)]
+    [InlineData(ChannelType.GuildPrivateThread, 12)]
+    [InlineData(ChannelType.GuildStageVoice, 13)]
+    [InlineData(ChannelType.GuildDirectory, 14)]
+    [InlineData(ChannelType.GuildForum, 15)]
+    [InlineData(ChannelType.GuildMedia, 16)]
+    [InlineData(ChannelType.Lobby, 17)]
+    [InlineData(ChannelType.EphemeralDm, 18)]
+    [InlineData(ChannelType.Unhandled, 255)]
+    public void ValuesMatchDiscordChannelTypeIds(ChannelType channelType, int expectedValue) {
+        Assert.Equal(expectedValue, (int)channelType);
+    }
+
+    [Fact]
+    public void ChannelEntityUsesTypedChannelType() {
+        var channel = new Channel {
+            Type = ChannelType.Dm,
+        };
+
+        Assert.Equal(ChannelType.Dm, channel.Type);
+    }
+
+    [Fact]
+    public async Task ChannelTypeQueriesMatchStoredEnumValues() {
+        await using var db = new SpacebarDbContext(
+            new DbContextOptionsBuilder<SpacebarDbContext>()
+                .UseInMemoryDatabase($"{nameof(ChannelTypeQueriesMatchStoredEnumValues)}-{Guid.NewGuid()}")
+                .Options
+        );
+        db.Channels.AddRange(
+            new Channel { Id = 1, Type = ChannelType.Dm },
+            new Channel { Id = 2, Type = ChannelType.GroupDm },
+            new Channel { Id = 3, Type = ChannelType.GuildVoice }
+        );
+        await db.SaveChangesAsync();
+
+        var directMessageIds = await db.Channels
+            .Where(channel => channel.Type == ChannelType.Dm)
+            .Select(channel => channel.Id)
+            .ToListAsync();
+        var voiceChannelIds = await db.Channels
+            .Where(channel => channel.Type == ChannelType.GuildVoice)
+            .Select(channel => channel.Id)
+            .ToListAsync();
+
+        Assert.Equal([1], directMessageIds);
+        Assert.Equal([3], voiceChannelIds);
+    }
+}

--- a/extra/admin-api/Tests/Spacebar.Models.Db.Tests/ChannelTypeTests.cs
+++ b/extra/admin-api/Tests/Spacebar.Models.Db.Tests/ChannelTypeTests.cs
@@ -65,4 +65,29 @@ public class ChannelTypeTests {
         Assert.Equal([1], directMessageIds);
         Assert.Equal([3], voiceChannelIds);
     }
+
+    [Fact]
+    public void ChannelTypeUsesExistingIntegerDatabaseColumn() {
+        using var db = new SpacebarDbContext(
+            new DbContextOptionsBuilder<SpacebarDbContext>()
+                .UseNpgsql("Host=localhost;Database=spacebar;Username=spacebar;Password=spacebar")
+                .Options
+        );
+
+        var channelTypeProperty = db.Model
+            .FindEntityType(typeof(Channel))!
+            .FindProperty(nameof(Channel.Type))!;
+        var relationalMapping = channelTypeProperty.GetRelationalTypeMapping();
+
+        Assert.Equal(typeof(ChannelType), channelTypeProperty.ClrType);
+        Assert.Equal("integer", relationalMapping.StoreType);
+        Assert.Equal(typeof(int), relationalMapping.Converter?.ProviderClrType);
+        Assert.Contains(
+            "WHERE c.type = 1",
+            db.Channels
+                .Where(channel => channel.Type == ChannelType.Dm)
+                .Select(channel => channel.Id)
+                .ToQueryString()
+        );
+    }
 }

--- a/extra/admin-api/Tests/Spacebar.Models.Db.Tests/Spacebar.Models.Db.Tests.csproj
+++ b/extra/admin-api/Tests/Spacebar.Models.Db.Tests/Spacebar.Models.Db.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../../Models/Spacebar.Models.Db/Spacebar.Models.Db.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+</Project>

--- a/src/cdn/util/Storage.ts
+++ b/src/cdn/util/Storage.ts
@@ -86,7 +86,9 @@ if (process.env.STORAGE_PROVIDER === "file" || !process.env.STORAGE_PROVIDER) {
     const forcePathStyle = process.env.STORAGE_FORCE_PATH_STYLE === "true";
 
     if (process.env.STORAGE_FORCE_PATH_STYLE === undefined) {
-        console.warn(`[CDN] STORAGE_FORCE_PATH_STYLE is not set for S3 provider; defaulting to virtual-hosted style. Set STORAGE_FORCE_PATH_STYLE=true to enable path-style addressing.`);
+        console.warn(
+            `[CDN] STORAGE_FORCE_PATH_STYLE is not set for S3 provider; defaulting to virtual-hosted style. Set STORAGE_FORCE_PATH_STYLE=true to enable path-style addressing.`,
+        );
     }
 
     const { S3Storage } = require("./S3Storage");


### PR DESCRIPTION
## Summary

- Add a shared C# `ChannelType` enum for the DB `Channel.Type` model, aligned with Discord/Spacebar channel IDs.
- Replace Admin API/Offload channel-type magic-number checks with named enum values.
- Add .NET model tests covering enum values, typed entity usage, EF query behavior, and Npgsql integer-column mapping.

## Root cause

The Admin API TODO came from raw integer channel-kind checks (`1` for DM, `2` for guild voice). Keeping `Channel.Type` as an `int` allowed more magic-number drift; typing the DB model at the source keeps all C# callers on the same channel-kind contract while preserving the existing integer database column.

## Validation

- `git diff --check origin/master...HEAD`
- `dotnet test extra/admin-api/Tests/Spacebar.Models.Db.Tests/Spacebar.Models.Db.Tests.csproj --artifacts-path /tmp/spacebar-channel-type-test --nologo --verbosity minimal`
- `dotnet build extra/admin-api/Spacebar.AdminApi/Spacebar.AdminApi.csproj --artifacts-path /tmp/spacebar-channel-type-adminapi-build --nologo --verbosity minimal`
- `dotnet build extra/admin-api/Spacebar.Offload/Spacebar.Offload.csproj --artifacts-path /tmp/spacebar-channel-type-offload-build --nologo --verbosity minimal`
- `dotnet test extra/admin-api/SpacebarAdminAPI.slnx --artifacts-path /tmp/spacebar-channel-type-sln-test --nologo --verbosity quiet`

Addresses the channel-type enum TODO from #1610.
