### PR TITLE
Parse OpenAPI additionalProperties

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,4 +1,9 @@
 export default {
     "*.{j,t}s": [() => "npm run build:src:tsgo", "eslint --concurrency 4" /* sweet spot it seems */, "prettier --write"],
-    "src/schemas/{*,**/*}.ts": [() => "npm run build:src:tsgo", () => "node scripts/schema.js", () => "node scripts/openapi.js", () => "git add assets/schemas.json assets/openapi.json"],
+    "src/schemas/{*,**/*}.ts": [
+        () => "npm run build:src:tsgo",
+        () => "node scripts/schema.js",
+        () => "node scripts/openapi.js",
+        () => "git add assets/schemas.json assets/openapi.json",
+    ],
 };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,7 +66,7 @@ export default defineConfig([
             // "sort-imports": ["error", {}],
             "default-case": "error",
             "default-case-last": "error",
-            "yoda": "error",
+            yoda: "error",
             // unsure what the defaults are here, but we want them to error
             "for-direction": "error",
             "constructor-super": "error",

--- a/extra/admin-api/SpacebarAdminAPI.slnx
+++ b/extra/admin-api/SpacebarAdminAPI.slnx
@@ -34,6 +34,9 @@
         <Project Path="Utilities/Spacebar.Cdn.Migration/Spacebar.Cdn.Migration.csproj"/>
         <Project Path="Utilities/Spacebar.CleanSettingsRows/Spacebar.CleanSettingsRows.csproj"/>
     </Folder>
+    <Folder Name="/Tests/">
+        <Project Path="Tests/Spacebar.AdminApi.TestClient.Tests/Spacebar.AdminApi.TestClient.Tests.csproj"/>
+    </Folder>
     <Project Path="Spacebar.AdminApi/Spacebar.AdminApi.csproj"/>
     <Project Path="Spacebar.Cdn.Worker/Spacebar.Cdn.Worker.Q16-HDRI.x86_64.csproj" DisplayName="Spacebar.Cdn.Worker"/>
     <Project Path="Spacebar.Cdn/Spacebar.Cdn.csproj"/>

--- a/extra/admin-api/Tests/Spacebar.AdminApi.TestClient.Tests/OpenApiSchemaRefConverterTests.cs
+++ b/extra/admin-api/Tests/Spacebar.AdminApi.TestClient.Tests/OpenApiSchemaRefConverterTests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Spacebar.AdminApi.TestClient.Classes.OpenAPI;
+
+namespace Spacebar.AdminApi.TestClient.Tests;
+
+public class OpenApiSchemaRefConverterTests {
+    [Fact]
+    public void DeserializesSchemaValuedAdditionalProperties() {
+        const string json = """
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+            """;
+
+        var schema = JsonSerializer.Deserialize<OpenApiSchemaRef>(json)!;
+
+        Assert.Equal("object", schema.Type);
+        Assert.Null(schema.AdditionalPropertiesAllowed);
+        Assert.NotNull(schema.AdditionalProperties);
+        Assert.Equal("array", schema.AdditionalProperties!.Type);
+        Assert.Equal("string", schema.AdditionalProperties.Items![0].Type);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DeserializesBooleanAdditionalProperties(bool allowed) {
+        var schema = JsonSerializer.Deserialize<OpenApiSchemaRef>($$"""
+            {
+              "type": "object",
+              "additionalProperties": {{allowed.ToString().ToLowerInvariant()}}
+            }
+            """)!;
+
+        Assert.Equal(allowed, schema.AdditionalPropertiesAllowed);
+        Assert.Null(schema.AdditionalProperties);
+    }
+
+    [Fact]
+    public void SerializesAdditionalPropertiesSchema() {
+        var schema = new OpenApiSchemaRef {
+            Type = "object",
+            AdditionalProperties = new OpenApiSchemaRef {
+                Type = "string",
+            },
+        };
+
+        var json = JsonSerializer.Serialize(schema);
+        var node = JsonNode.Parse(json)!;
+
+        Assert.Equal("object", node["type"]!.GetValue<string>());
+        Assert.Equal("string", node["additionalProperties"]!["type"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void DeserializesReferencedAdditionalPropertiesSchema() {
+        const string json = """
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/LocalizedString"
+              }
+            }
+            """;
+
+        var schema = JsonSerializer.Deserialize<OpenApiSchemaRef>(json)!;
+
+        Assert.Equal("#/components/schemas/LocalizedString", schema.AdditionalProperties!.Ref);
+    }
+}

--- a/extra/admin-api/Tests/Spacebar.AdminApi.TestClient.Tests/OpenApiSchemaRefConverterTests.cs
+++ b/extra/admin-api/Tests/Spacebar.AdminApi.TestClient.Tests/OpenApiSchemaRefConverterTests.cs
@@ -59,6 +59,22 @@ public class OpenApiSchemaRefConverterTests {
         Assert.Equal("string", node["additionalProperties"]!["type"]!.GetValue<string>());
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SerializesBooleanAdditionalProperties(bool allowed) {
+        var schema = new OpenApiSchemaRef {
+            Type = "object",
+            AdditionalPropertiesAllowed = allowed,
+        };
+
+        var json = JsonSerializer.Serialize(schema);
+        var node = JsonNode.Parse(json)!;
+
+        Assert.Equal("object", node["type"]!.GetValue<string>());
+        Assert.Equal(allowed, node["additionalProperties"]!.GetValue<bool>());
+    }
+
     [Fact]
     public void DeserializesReferencedAdditionalPropertiesSchema() {
         const string json = """
@@ -73,5 +89,19 @@ public class OpenApiSchemaRefConverterTests {
         var schema = JsonSerializer.Deserialize<OpenApiSchemaRef>(json)!;
 
         Assert.Equal("#/components/schemas/LocalizedString", schema.AdditionalProperties!.Ref);
+    }
+
+    [Fact]
+    public void RejectsUnsupportedAdditionalPropertiesValue() {
+        const string json = """
+            {
+              "type": "object",
+              "additionalProperties": []
+            }
+            """;
+
+        var ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<OpenApiSchemaRef>(json));
+
+        Assert.Contains("Expected bool|object in additionalProperties", ex.Message);
     }
 }

--- a/extra/admin-api/Tests/Spacebar.AdminApi.TestClient.Tests/Spacebar.AdminApi.TestClient.Tests.csproj
+++ b/extra/admin-api/Tests/Spacebar.AdminApi.TestClient.Tests/Spacebar.AdminApi.TestClient.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../../Utilities/Spacebar.AdminApi.TestClient/Spacebar.AdminApi.TestClient.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+</Project>

--- a/extra/admin-api/Utilities/Spacebar.AdminApi.TestClient/Classes/OpenAPI/OpenAPISchema.cs
+++ b/extra/admin-api/Utilities/Spacebar.AdminApi.TestClient/Classes/OpenAPI/OpenAPISchema.cs
@@ -2,7 +2,6 @@ using System.Collections.Frozen;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
-using ArcaneLibs.Extensions;
 
 namespace Spacebar.AdminApi.TestClient.Classes.OpenAPI;
 
@@ -190,6 +189,8 @@ public class OpenApiSchemaRef {
     public List<object>? Enum { get; set; }
     public string? Format { get; set; }
     public List<OpenApiSchemaRef>? Items { get; set; }
+    public bool? AdditionalPropertiesAllowed { get; set; }
+    public OpenApiSchemaRef? AdditionalProperties { get; set; }
     public Regex? Pattern { get; set; }
 
     public OpenApiSchemaRef? GetReferencedSchema(OpenApiSchema schema) {
@@ -275,7 +276,7 @@ public class OpenApiSchemaRefConverter : JsonConverter<OpenApiSchemaRef> {
                     else if (property.Value.ValueKind == JsonValueKind.Null)
                         schemaRef.Default = null;
                     else if (property.Value.ValueKind == JsonValueKind.Array)
-                        if (property.Value.GetArrayLength() > 0) throw new JsonException($"Expected empty array in default, got: {property.Value.ToJson()}");
+                        if (property.Value.GetArrayLength() > 0) throw new JsonException($"Expected empty array in default, got: {property.Value.GetRawText()}");
                         else schemaRef.Default = Array.Empty<object>();
                     else throw new JsonException($"Expected string|int|bool|null in default, got {property.Value.ValueKind}");
                     break;
@@ -304,15 +305,28 @@ public class OpenApiSchemaRefConverter : JsonConverter<OpenApiSchemaRef> {
                 case "format":
                     schemaRef.Format = property.Value.GetString();
                     break;
-                case "additionalProperties": //TODO
+                case "additionalProperties":
+                    switch (property.Value.ValueKind) {
+                        case JsonValueKind.True:
+                        case JsonValueKind.False:
+                            schemaRef.AdditionalPropertiesAllowed = property.Value.GetBoolean();
+                            break;
+                        case JsonValueKind.Object:
+                            schemaRef.AdditionalProperties = property.Value.Deserialize<OpenApiSchemaRef>(options);
+                            break;
+                        default:
+                            throw new JsonException($"Expected bool|object in additionalProperties, got {property.Value.ValueKind}");
+                    }
+
+                    break;
                 case "patternProperties": // Side effect of using JsonValue in typescript
                     break;
                 case "items":
-                    // Console.WriteLine($"Got 'items' property in OpenApiSchemaRef! NodeType: {property.Value.ValueKind}, Value: {property.Value.ToJson()}");
+                    // Console.WriteLine($"Got 'items' property in OpenApiSchemaRef! NodeType: {property.Value.ValueKind}, Value: {property.Value.GetRawText()}");
                     try {
                         schemaRef.Items = property.Value.ValueKind is JsonValueKind.Array ? property.Value.Deserialize<List<OpenApiSchemaRef>>(options) : [property.Value.Deserialize<OpenApiSchemaRef>(options)!];
                     } catch (Exception ex) {
-                        throw new JsonException($"Error deserializing 'items' property: {ex.Message}\nValue: {property.Value.ToJson()}", ex);
+                        throw new JsonException($"Error deserializing 'items' property: {ex.Message}\nValue: {property.Value.GetRawText()}", ex);
                     }
                     break;
                 case "pattern":
@@ -322,7 +336,7 @@ public class OpenApiSchemaRefConverter : JsonConverter<OpenApiSchemaRef> {
                     }
                     break;
                 default:
-                    Console.WriteLine($"Got unexpected prop {property.Name} in OpenApiSchemaRef! Value: {property.Value.ToJson()}");
+                    Console.WriteLine($"Got unexpected prop {property.Name} in OpenApiSchemaRef! Value: {property.Value.GetRawText()}");
                     break;
             }
         }
@@ -363,6 +377,14 @@ public class OpenApiSchemaRefConverter : JsonConverter<OpenApiSchemaRef> {
             }
 
             writer.WriteEndObject();
+        }
+
+        if (value.AdditionalProperties != null) {
+            writer.WritePropertyName("additionalProperties");
+            JsonSerializer.Serialize(writer, value.AdditionalProperties, options);
+        }
+        else if (value.AdditionalPropertiesAllowed.HasValue) {
+            writer.WriteBoolean("additionalProperties", value.AdditionalPropertiesAllowed.Value);
         }
 
         writer.WriteEndObject();

--- a/src/cdn/util/Storage.ts
+++ b/src/cdn/util/Storage.ts
@@ -86,7 +86,9 @@ if (process.env.STORAGE_PROVIDER === "file" || !process.env.STORAGE_PROVIDER) {
     const forcePathStyle = process.env.STORAGE_FORCE_PATH_STYLE === "true";
 
     if (process.env.STORAGE_FORCE_PATH_STYLE === undefined) {
-        console.warn(`[CDN] STORAGE_FORCE_PATH_STYLE is not set for S3 provider; defaulting to virtual-hosted style. Set STORAGE_FORCE_PATH_STYLE=true to enable path-style addressing.`);
+        console.warn(
+            `[CDN] STORAGE_FORCE_PATH_STYLE is not set for S3 provider; defaulting to virtual-hosted style. Set STORAGE_FORCE_PATH_STYLE=true to enable path-style addressing.`,
+        );
     }
 
     const { S3Storage } = require("./S3Storage");


### PR DESCRIPTION
## Summary
- Parse OpenAPI `additionalProperties` values in the admin API test client schema converter.
- Preserve both boolean and schema/reference object forms when deserializing and serializing.
- Add xUnit coverage for object, reference, boolean, serialization, and invalid-value cases.

Addresses the `OpenAPISchema.cs` `additionalProperties` TODO from #1608.

## Tests
- `dotnet test extra/admin-api/Tests/Spacebar.AdminApi.TestClient.Tests/Spacebar.AdminApi.TestClient.Tests.csproj`
- `dotnet build extra/admin-api/Utilities/Spacebar.AdminApi.TestClient/Spacebar.AdminApi.TestClient.csproj`
- `git diff --check`
