### PR TITLE
Add joined private archived thread listing

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,4 +1,9 @@
 export default {
     "*.{j,t}s": [() => "npm run build:src:tsgo", "eslint --concurrency 4" /* sweet spot it seems */, "prettier --write"],
-    "src/schemas/{*,**/*}.ts": [() => "npm run build:src:tsgo", () => "node scripts/schema.js", () => "node scripts/openapi.js", () => "git add assets/schemas.json assets/openapi.json"],
+    "src/schemas/{*,**/*}.ts": [
+        () => "npm run build:src:tsgo",
+        () => "node scripts/schema.js",
+        () => "node scripts/openapi.js",
+        () => "git add assets/schemas.json assets/openapi.json",
+    ],
 };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,7 +66,7 @@ export default defineConfig([
             // "sort-imports": ["error", {}],
             "default-case": "error",
             "default-case-last": "error",
-            "yoda": "error",
+            yoda: "error",
             // unsure what the defaults are here, but we want them to error
             "for-direction": "error",
             "constructor-super": "error",

--- a/src/api/routes/channels/#channel_id/users/@me/threads/archived/private.ts
+++ b/src/api/routes/channels/#channel_id/users/@me/threads/archived/private.ts
@@ -1,0 +1,112 @@
+/*
+	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
+	Copyright (C) 2026 Spacebar and Spacebar Contributors
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTIBILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { route } from "@spacebar/api";
+import { Channel, Member, ThreadMember } from "@spacebar/util";
+import { ChannelType } from "@spacebar/schemas";
+import { Request, Response, Router } from "express";
+import { HTTPError } from "lambert-server";
+import { In } from "typeorm";
+import {
+    applyJoinedPrivateArchivedThreadsQuery,
+    JOINED_PRIVATE_ARCHIVED_THREAD_PERMISSIONS,
+    parseJoinedPrivateArchivedThreadBefore,
+    parseJoinedPrivateArchivedThreadLimit,
+    selectReturnedJoinedPrivateArchivedThreads,
+    serializeJoinedPrivateArchivedThreadMember,
+} from "../../../../../../../util/utility/JoinedPrivateArchivedThreads";
+
+const router = Router({ mergeParams: true });
+
+router.get(
+    "/",
+    route({
+        permission: [...JOINED_PRIVATE_ARCHIVED_THREAD_PERMISSIONS],
+        query: {
+            before: {
+                type: "string",
+                required: false,
+                description: "Return joined private threads with ids before this thread id.",
+            },
+            limit: {
+                type: "number",
+                required: false,
+                description: "Maximum number of joined private archived threads to return.",
+            },
+        },
+        responses: {
+            200: {},
+            400: {
+                body: "APIErrorResponse",
+            },
+            403: {},
+            404: {},
+        },
+    }),
+    async (req: Request, res: Response) => {
+        const { channel_id } = req.params as { [key: string]: string };
+        const { before, limit } = req.query as Record<string, string | undefined>;
+
+        let parsedLimit: number;
+        let beforeThreadId: string | undefined;
+        try {
+            parsedLimit = parseJoinedPrivateArchivedThreadLimit(limit);
+            beforeThreadId = parseJoinedPrivateArchivedThreadBefore(before);
+        } catch (error) {
+            throw new HTTPError(error instanceof Error ? error.message : "Invalid joined private archived thread query", 400);
+        }
+
+        const parentChannel = await Channel.findOneOrFail({ where: { id: channel_id }, select: { guild_id: true, id: true } });
+        const member = await Member.findOneOrFail({ where: { guild_id: parentChannel.guild_id!, id: req.user_id }, select: { index: true } });
+
+        const threads = await applyJoinedPrivateArchivedThreadsQuery(
+            Channel.createQueryBuilder("thread"),
+            {
+                beforeThreadId,
+                channelId: channel_id,
+                memberIndex: member.index,
+                privateThreadType: ChannelType.GUILD_PRIVATE_THREAD,
+                take: parsedLimit + 1,
+            },
+            ThreadMember,
+        ).getMany();
+
+        const { threads: returnedThreads, hasMore } = selectReturnedJoinedPrivateArchivedThreads(threads, parsedLimit);
+        const threadIds = returnedThreads.map(({ id }) => id);
+        const members = threadIds.length
+            ? await ThreadMember.find({
+                  where: {
+                      member_idx: member.index,
+                      id: In(threadIds),
+                  },
+              })
+            : [];
+        const membersByThreadId = new Map(members.map((threadMember) => [threadMember.id, threadMember]));
+
+        return res.json({
+            threads: returnedThreads.map((thread) => thread.toJSON()),
+            members: threadIds
+                .map((threadId) => membersByThreadId.get(threadId))
+                .filter((threadMember): threadMember is ThreadMember => threadMember !== undefined)
+                .map((threadMember) => serializeJoinedPrivateArchivedThreadMember(threadMember, req.user_id)),
+            has_more: hasMore,
+        });
+    },
+);
+
+export default router;

--- a/src/api/util/utility/JoinedPrivateArchivedThreads.test.ts
+++ b/src/api/util/utility/JoinedPrivateArchivedThreads.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+    applyJoinedPrivateArchivedThreadsQuery,
+    DEFAULT_JOINED_PRIVATE_ARCHIVED_THREAD_LIMIT,
+    joinedPrivateArchivedThreadJsonTextExpression,
+    JOINED_PRIVATE_ARCHIVED_THREAD_PERMISSIONS,
+    MAX_JOINED_PRIVATE_ARCHIVED_THREAD_LIMIT,
+    parseJoinedPrivateArchivedThreadBefore,
+    parseJoinedPrivateArchivedThreadLimit,
+    selectReturnedJoinedPrivateArchivedThreads,
+    serializeJoinedPrivateArchivedThreadMember,
+} from "./JoinedPrivateArchivedThreads";
+
+describe("joined private archived thread helpers", () => {
+    test("requires channel visibility and message history before joined private archived threads can be read", () => {
+        assert.deepEqual(JOINED_PRIVATE_ARCHIVED_THREAD_PERMISSIONS, ["VIEW_CHANNEL", "READ_MESSAGE_HISTORY"]);
+    });
+
+    test("defaults joined private archived thread limit", () => {
+        assert.equal(parseJoinedPrivateArchivedThreadLimit(undefined), DEFAULT_JOINED_PRIVATE_ARCHIVED_THREAD_LIMIT);
+    });
+
+    test("accepts joined private archived thread limits in range", () => {
+        assert.equal(parseJoinedPrivateArchivedThreadLimit("1"), 1);
+        assert.equal(parseJoinedPrivateArchivedThreadLimit(String(MAX_JOINED_PRIVATE_ARCHIVED_THREAD_LIMIT)), MAX_JOINED_PRIVATE_ARCHIVED_THREAD_LIMIT);
+    });
+
+    test("rejects joined private archived thread limits outside range", () => {
+        assert.throws(() => parseJoinedPrivateArchivedThreadLimit("0"), RangeError);
+        assert.throws(() => parseJoinedPrivateArchivedThreadLimit(String(MAX_JOINED_PRIVATE_ARCHIVED_THREAD_LIMIT + 1)), RangeError);
+        assert.throws(() => parseJoinedPrivateArchivedThreadLimit("1.5"), RangeError);
+        assert.throws(() => parseJoinedPrivateArchivedThreadLimit("not-a-number"), RangeError);
+    });
+
+    test("parses optional before cursor", () => {
+        assert.equal(parseJoinedPrivateArchivedThreadBefore(undefined), undefined);
+        assert.equal(parseJoinedPrivateArchivedThreadBefore("123456789012345678"), "123456789012345678");
+    });
+
+    test("rejects invalid before cursor", () => {
+        assert.throws(() => parseJoinedPrivateArchivedThreadBefore("not-a-thread-id"), RangeError);
+        assert.throws(() => parseJoinedPrivateArchivedThreadBefore("123.4"), RangeError);
+    });
+
+    test("builds joined private archived thread queries with membership, jsonb predicates, and id ordering", () => {
+        const builder = createFakeQueryBuilder();
+        const threadMemberEntity = Symbol("ThreadMember");
+
+        assert.equal(
+            applyJoinedPrivateArchivedThreadsQuery(
+                builder,
+                {
+                    beforeThreadId: "123456789012345678",
+                    channelId: "channel-id",
+                    memberIndex: "member-index",
+                    privateThreadType: 12,
+                    take: 26,
+                },
+                threadMemberEntity,
+            ),
+            builder,
+        );
+
+        assert.deepEqual(builder.calls, [
+            ["innerJoin", threadMemberEntity, "thread_member", '"thread_member"."id" = "thread"."id"'],
+            ["where", '"thread"."parent_id" = :channelId', { channelId: "channel-id" }],
+            ["andWhere", '"thread"."type" = :privateThreadType', { privateThreadType: 12 }],
+            ["andWhere", '"thread_member"."member_idx" = :memberIndex', { memberIndex: "member-index" }],
+            ["andWhere", `${joinedPrivateArchivedThreadJsonTextExpression("archived")} = :archived`, { archived: "true" }],
+            ["andWhere", '"thread"."id" < :before', { before: "123456789012345678" }],
+            ["orderBy", '"thread"."id"', "DESC"],
+            ["take", 26],
+        ]);
+    });
+
+    test("omits before predicate when no cursor is provided", () => {
+        const builder = createFakeQueryBuilder();
+
+        applyJoinedPrivateArchivedThreadsQuery(
+            builder,
+            {
+                channelId: "channel-id",
+                memberIndex: "member-index",
+                privateThreadType: 12,
+                take: 51,
+            },
+            "ThreadMember",
+        );
+
+        assert.equal(
+            builder.calls.some(([method, condition]) => method === "andWhere" && typeof condition === "string" && condition.includes(":before")),
+            false,
+        );
+        assert.deepEqual(builder.calls.at(-2), ["orderBy", '"thread"."id"', "DESC"]);
+        assert.deepEqual(builder.calls.at(-1), ["take", 51]);
+    });
+
+    test("selects one extra joined private archived thread only to compute has_more", () => {
+        assert.deepEqual(selectReturnedJoinedPrivateArchivedThreads(["3", "2", "1"], 2), {
+            threads: ["3", "2"],
+            hasMore: true,
+        });
+        assert.deepEqual(selectReturnedJoinedPrivateArchivedThreads(["2", "1"], 2), {
+            threads: ["2", "1"],
+            hasMore: false,
+        });
+    });
+
+    test("serializes joined private archived thread members with public user ids instead of internal member indexes", () => {
+        const serialized = serializeJoinedPrivateArchivedThreadMember(
+            {
+                id: "thread-id",
+                join_timestamp: new Date("2026-05-06T09:00:00.000Z"),
+                flags: 2,
+            },
+            "user-id",
+        );
+
+        assert.deepEqual(serialized, {
+            id: "thread-id",
+            user_id: "user-id",
+            join_timestamp: "2026-05-06T09:00:00.000Z",
+            flags: 2,
+        });
+        assert.equal("member_idx" in serialized, false);
+    });
+});
+
+type FakeQueryBuilderCall = [string, unknown, string, string] | [string, string, Record<string, unknown>?] | [string, string, string] | [string, number];
+
+function createFakeQueryBuilder() {
+    return {
+        calls: [] as FakeQueryBuilderCall[],
+        innerJoin(entity: unknown, alias: string, condition: string) {
+            this.calls.push(["innerJoin", entity, alias, condition]);
+            return this;
+        },
+        where(condition: string, parameters?: Record<string, unknown>) {
+            this.calls.push(["where", condition, parameters]);
+            return this;
+        },
+        andWhere(condition: string, parameters?: Record<string, unknown>) {
+            this.calls.push(["andWhere", condition, parameters]);
+            return this;
+        },
+        orderBy(sort: string, order?: "ASC" | "DESC") {
+            this.calls.push(["orderBy", sort, order ?? "ASC"]);
+            return this;
+        },
+        take(take?: number) {
+            this.calls.push(["take", take ?? 0]);
+            return this;
+        },
+    };
+}

--- a/src/api/util/utility/JoinedPrivateArchivedThreads.ts
+++ b/src/api/util/utility/JoinedPrivateArchivedThreads.ts
@@ -1,0 +1,125 @@
+/*
+	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
+	Copyright (C) 2026 Spacebar and Spacebar Contributors
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTIBILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+export const DEFAULT_JOINED_PRIVATE_ARCHIVED_THREAD_LIMIT = 50;
+export const MAX_JOINED_PRIVATE_ARCHIVED_THREAD_LIMIT = 100;
+export const JOINED_PRIVATE_ARCHIVED_THREAD_PERMISSIONS = ["VIEW_CHANNEL", "READ_MESSAGE_HISTORY"] as const;
+
+const DEFAULT_THREAD_ALIAS = "thread";
+const DEFAULT_THREAD_MEMBER_ALIAS = "thread_member";
+
+export interface JoinedPrivateArchivedThreadMemberRecord {
+    id: string;
+    join_timestamp: Date | string;
+    flags: number;
+}
+
+export interface JoinedPrivateArchivedThreadMemberResponse {
+    id: string;
+    user_id: string;
+    join_timestamp: string;
+    flags: number;
+}
+
+export function parseJoinedPrivateArchivedThreadLimit(value: string | undefined) {
+    if (value === undefined) return DEFAULT_JOINED_PRIVATE_ARCHIVED_THREAD_LIMIT;
+
+    const limit = Number(value);
+    if (!Number.isInteger(limit) || limit < 1 || limit > MAX_JOINED_PRIVATE_ARCHIVED_THREAD_LIMIT) {
+        throw new RangeError(`limit must be between 1 and ${MAX_JOINED_PRIVATE_ARCHIVED_THREAD_LIMIT}`);
+    }
+
+    return limit;
+}
+
+export function parseJoinedPrivateArchivedThreadBefore(value: string | undefined) {
+    if (value === undefined) return undefined;
+
+    if (!/^\d+$/.test(value)) throw new RangeError("before must be a thread id");
+
+    return value;
+}
+
+type QueryParameters = Record<string, unknown>;
+
+export interface JoinedPrivateArchivedThreadsQueryBuilder<TBuilder> {
+    innerJoin(entity: unknown, alias: string, condition: string): TBuilder;
+    where(condition: string, parameters?: QueryParameters): TBuilder;
+    andWhere(condition: string, parameters?: QueryParameters): TBuilder;
+    orderBy(sort: string, order?: "ASC" | "DESC"): TBuilder;
+    take(take?: number): TBuilder;
+}
+
+export interface JoinedPrivateArchivedThreadsQueryOptions {
+    channelId: string;
+    memberIndex: string;
+    beforeThreadId?: string;
+    take: number;
+    privateThreadType: number;
+    threadAlias?: string;
+    threadMemberAlias?: string;
+}
+
+export function joinedPrivateArchivedThreadJsonTextExpression(key: "archived", alias = DEFAULT_THREAD_ALIAS) {
+    return `"${alias}"."thread_metadata" ->> '${key}'`;
+}
+
+export function selectReturnedJoinedPrivateArchivedThreads<TThread>(threads: TThread[], limit: number) {
+    return {
+        threads: threads.slice(0, limit),
+        hasMore: threads.length > limit,
+    };
+}
+
+export function serializeJoinedPrivateArchivedThreadMember(threadMember: JoinedPrivateArchivedThreadMemberRecord, userId: string): JoinedPrivateArchivedThreadMemberResponse {
+    const joinTimestamp = threadMember.join_timestamp instanceof Date ? threadMember.join_timestamp : new Date(threadMember.join_timestamp);
+
+    return {
+        id: threadMember.id,
+        user_id: userId,
+        join_timestamp: joinTimestamp.toISOString(),
+        flags: threadMember.flags,
+    };
+}
+
+export function applyJoinedPrivateArchivedThreadsQuery<TBuilder extends JoinedPrivateArchivedThreadsQueryBuilder<TBuilder>>(
+    query: TBuilder,
+    {
+        beforeThreadId,
+        channelId,
+        memberIndex,
+        privateThreadType,
+        take,
+        threadAlias = DEFAULT_THREAD_ALIAS,
+        threadMemberAlias = DEFAULT_THREAD_MEMBER_ALIAS,
+    }: JoinedPrivateArchivedThreadsQueryOptions,
+    threadMemberEntity: unknown,
+) {
+    const archivedExpression = joinedPrivateArchivedThreadJsonTextExpression("archived", threadAlias);
+
+    let builder = query
+        .innerJoin(threadMemberEntity, threadMemberAlias, `"${threadMemberAlias}"."id" = "${threadAlias}"."id"`)
+        .where(`"${threadAlias}"."parent_id" = :channelId`, { channelId })
+        .andWhere(`"${threadAlias}"."type" = :privateThreadType`, { privateThreadType })
+        .andWhere(`"${threadMemberAlias}"."member_idx" = :memberIndex`, { memberIndex })
+        .andWhere(`${archivedExpression} = :archived`, { archived: "true" });
+
+    if (beforeThreadId) builder = builder.andWhere(`"${threadAlias}"."id" < :before`, { before: beforeThreadId });
+
+    return builder.orderBy(`"${threadAlias}"."id"`, "DESC").take(take);
+}

--- a/src/cdn/util/Storage.ts
+++ b/src/cdn/util/Storage.ts
@@ -86,7 +86,9 @@ if (process.env.STORAGE_PROVIDER === "file" || !process.env.STORAGE_PROVIDER) {
     const forcePathStyle = process.env.STORAGE_FORCE_PATH_STYLE === "true";
 
     if (process.env.STORAGE_FORCE_PATH_STYLE === undefined) {
-        console.warn(`[CDN] STORAGE_FORCE_PATH_STYLE is not set for S3 provider; defaulting to virtual-hosted style. Set STORAGE_FORCE_PATH_STYLE=true to enable path-style addressing.`);
+        console.warn(
+            `[CDN] STORAGE_FORCE_PATH_STYLE is not set for S3 provider; defaulting to virtual-hosted style. Set STORAGE_FORCE_PATH_STYLE=true to enable path-style addressing.`,
+        );
     }
 
     const { S3Storage } = require("./S3Storage");


### PR DESCRIPTION
## Summary
- add `GET /channels/:channel_id/users/@me/threads/archived/private`
- filter archived private child threads to only those joined by the requesting guild member
- return Discord-compatible thread member objects for the current user and `has_more` pagination
- cover query construction, limit/before parsing, pagination, permissions, and member serialization with node:test

## Root cause
The server had thread creation/member APIs but no route for listing archived private threads joined by the current user, so clients could not page through their joined private archived threads for a parent channel.

Closes #125

## Validation
- `npm run node:tests`
- `npm run build:src -- --pretty false`
- `node -r dotenv/config -r module-alias/register --enable-source-maps --test dist/api/util/utility/JoinedPrivateArchivedThreads.test.js`
- `npx eslint src/api/routes/channels/#channel_id/users/@me/threads/archived/private.ts src/api/util/utility/JoinedPrivateArchivedThreads.ts src/api/util/utility/JoinedPrivateArchivedThreads.test.ts`
- `npx prettier --check src/api/routes/channels/#channel_id/users/@me/threads/archived/private.ts src/api/util/utility/JoinedPrivateArchivedThreads.ts src/api/util/utility/JoinedPrivateArchivedThreads.test.ts`
- `git diff --check`
