### PR TITLE
Bulk mention efficiency fixes

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -14507,7 +14507,11 @@
                         "type": "boolean"
                     },
                     "type": {
-                        "type": "integer"
+                        "enum": [
+                            0,
+                            1
+                        ],
+                        "type": "number"
                     }
                 }
             },

--- a/assets/schemas.json
+++ b/assets/schemas.json
@@ -15514,7 +15514,11 @@
                 "type": "boolean"
             },
             "type": {
-                "type": "integer"
+                "enum": [
+                    0,
+                    1
+                ],
+                "type": "number"
             }
         },
         "additionalProperties": false,

--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -16,46 +16,45 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { randomString, fillMessageUrlEmbeds } from "@spacebar/api";
+import { fillMessageUrlEmbeds, randomString } from "@spacebar/api";
 import {
     Application,
     Attachment,
     Channel,
+    CloudAttachment,
     Config,
+    DiscordApiErrors,
     emitEvent,
     EVERYONE_MENTION,
+    FieldErrors,
+    getDatabase,
     getPermission,
     getRights,
     Guild,
+    handleFile,
     HERE_MENTION,
+    Member,
     Message,
     MessageCreateEvent,
+    MessageFlags,
+    Permissions,
+    ReadState,
     Role,
     ROLE_MENTION,
-    Sticker,
-    User,
-    //CHANNEL_MENTION,
-    USER_MENTION,
-    Webhook,
-    handleFile,
-    Permissions,
-    DiscordApiErrors,
-    CloudAttachment,
-    ReadState,
-    Member,
     Session,
-    MessageFlags,
-    FieldErrors,
-    getDatabase,
-    ElapsedTime,
-    TraceRoot,
+    Sticker,
     Stopwatch,
     TraceNode,
+    TraceRoot,
+    User,
+    USER_MENTION,
+    Webhook,
 } from "@spacebar/util";
 import { HTTPError } from "lambert-server";
-import { In, Or, Equal, IsNull } from "typeorm";
+import { Equal, In, Or } from "typeorm";
 import {
     ActionRowComponent,
+    BaseMessageComponents,
     ButtonStyle,
     ChannelType,
     Embed,
@@ -64,14 +63,14 @@ import {
     MessageCreateAttachment,
     MessageCreateCloudAttachment,
     MessageCreateSchema,
+    MessageReferenceType,
     MessageType,
     Reaction,
     ReadStateType,
     UnfurledMediaItem,
-    BaseMessageComponents,
     v1CompTypes,
-    MessageReferenceType,
 } from "@spacebar/schemas";
+
 const allow_empty = false;
 // TODO: check webhook, application, system author, stickers
 // TODO: embed gifs/videos/images
@@ -770,6 +769,7 @@ async function handleMessageMentionsAsync(message: Message) {
         const states = await ReadState.findBy({
             user_id: In(ids),
             channel_id: channel.id,
+            read_state_type: ReadStateType.CHANNEL,
         });
         const users = new Set(ids);
         states.forEach((state) => users.delete(state.user_id));
@@ -806,9 +806,7 @@ async function handleMessageMentionsAsync(message: Message) {
             await fillInMissingIDs((await Member.find({ where: { guild_id: channel.guild_id } })).map((m) => m.id));
         }
         const repository = ReadState.getRepository();
-        const condition = { channel_id: channel.id, read_state_type: ReadStateType.CHANNEL };
-        await repository.update({ ...condition, mention_count: IsNull() }, { mention_count: 0 });
-        await repository.increment(condition, "mention_count", 1);
+        await repository.increment({ channel_id: channel.id, read_state_type: ReadStateType.CHANNEL }, "mention_count", 1);
         trace.calls.push("mentionEveryone", { micros: sw.getElapsedAndReset().totalMicroseconds });
     } else {
         const users = new Set<string>([

--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -721,6 +721,7 @@ async function handleMessageMentionsAsync(message: Message) {
             mention_role_id_set.clear();
             mentionedRoles.forEach((r) => mention_role_id_set.add(r.id));
         }
+
         contentTrace.calls.push("validateMentionRoles", { micros: sw.getElapsedAndReset().totalMicroseconds });
         contentTrace.micros = contentSw.elapsed().totalMicroseconds;
         trace.calls.push("parseContent", contentTrace);
@@ -764,25 +765,33 @@ async function handleMessageMentionsAsync(message: Message) {
     message.mention_everyone = mention_everyone;
     trace.calls.push("fillMessageMentionProperties", { micros: sw.getElapsedAndReset().totalMicroseconds });
 
-    async function fillInMissingIDs(ids: string[]) {
+    const fillInMissingIDs = async (ids: string[]) => {
         const fillMessageSw = Stopwatch.startNew();
-        const states = await ReadState.findBy({
-            user_id: In(ids),
-            channel_id: channel.id,
-            read_state_type: ReadStateType.CHANNEL,
+        const states = await ReadState.find({
+            where: {
+                user_id: In(ids),
+                channel_id: channel.id,
+                read_state_type: ReadStateType.CHANNEL,
+            },
+            select: { user_id: true },
         });
         const users = new Set(ids);
         states.forEach((state) => users.delete(state.user_id));
         if (!users.size) {
             return;
         }
-        // TODO: is there a more efficient way to do this? Additionally, could this be a .insert()?
-        await Promise.all(users.values().map((user_id) => ReadState.create({ user_id, channel_id: channel.id }).save()));
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        //@ts-expect-error
-        trace.calls.push(`fillInMissingIDs(${ids.count})`, { micros: fillMessageSw.getElapsedAndReset().totalMicroseconds });
-    }
+        const newReadStates = users
+            .values()
+            .map((user_id) => ({ user_id, channel_id: channel.id, read_state_type: ReadStateType.CHANNEL }))
+            .toArray();
+        await ReadState.insert(newReadStates).catch((e) => {
+            console.log("Failed to bulk insert", users.size, "new ReadStates, trying again (race condition?)...\nDetails:", e);
+            return fillInMissingIDs(users.values().toArray());
+        });
+
+        trace.calls.push(`fillInMissingIDs(${ids.length})`, { micros: fillMessageSw.getElapsedAndReset().totalMicroseconds });
+    };
 
     if ((message.flags & (1 << 6)) !== 0) {
         // ephemeral messages
@@ -803,7 +812,7 @@ async function handleMessageMentionsAsync(message: Message) {
                 await fillInMissingIDs(channel.recipients.map((r) => r.user_id));
             }
         } else {
-            await fillInMissingIDs((await Member.find({ where: { guild_id: channel.guild_id } })).map((m) => m.id));
+            await fillInMissingIDs((await Member.find({ where: { guild_id: channel.guild_id }, select: { id: true } })).map((m) => m.id));
         }
         const repository = ReadState.getRepository();
         await repository.increment({ channel_id: channel.id, read_state_type: ReadStateType.CHANNEL }, "mention_count", 1);
@@ -819,17 +828,18 @@ async function handleMessageMentionsAsync(message: Message) {
             ...message.mentions.map((user) => user.id),
         ]);
         trace.calls.push("getUsers", { micros: sw.getElapsedAndReset().totalMicroseconds });
+
         if (mention_here) {
             const ids = (await Member.find({ where: { guild_id: channel.guild_id } })).map((m) => m.id);
             (await Session.find({ where: { user_id: In(ids) } })).forEach((s) => users.add(s.user_id));
             trace.calls.push("mentionHere", { micros: sw.getElapsedAndReset().totalMicroseconds });
         }
+
         if (users.size) {
             const repository = ReadState.getRepository();
-            const condition = { user_id: In(users.values().toArray()), channel_id: channel.id, read_state_type: ReadStateType.CHANNEL };
 
             await fillInMissingIDs([...users]);
-            await repository.increment(condition, "mention_count", 1);
+            await repository.increment({ user_id: In(users.values().toArray()), channel_id: channel.id, read_state_type: ReadStateType.CHANNEL }, "mention_count", 1);
             trace.calls.push("updateMentionedUserReadStates", { micros: sw.getElapsedAndReset().totalMicroseconds });
         }
     }

--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -663,6 +663,7 @@ async function handleMessageMentionsAsync(message: Message) {
 
     let content = message.content;
 
+    // TODO: sets
     // root@Rory - 20/02/2023 - This breaks channel mentions in test client. We're not sure this was used in older clients.
     //const mention_channel_ids = [] as string[];
     const mention_role_ids = [] as string[];
@@ -684,7 +685,7 @@ async function handleMessageMentionsAsync(message: Message) {
         }
 
         await Promise.all(
-            Array.from(content.matchAll(ROLE_MENTION)).map(async ([, mention]) => {
+            content.matchAll(ROLE_MENTION).map(async ([, mention]) => {
                 const role = await Role.findOneOrFail({
                     where: { id: mention, guild_id: channel.guild_id },
                 });
@@ -732,14 +733,13 @@ async function handleMessageMentionsAsync(message: Message) {
     /*message.mention_channels = mention_channel_ids.map((x) =>
 		Channel.create({ id: x }),
 	);*/
-    message.mention_roles = (await Promise.all(mention_role_ids.map((x) => Role.findOne({ where: { id: x } })))).filter((role) => role !== null);
-
-    message.mentions = [...message.mentions, ...(await Promise.all(mention_user_ids.map((x) => User.findOne({ where: { id: x } })))).filter((user) => user !== null)];
-
+    message.mention_roles = await Role.find({ where: { id: In(mention_role_ids), guild_id: channel.guild_id } });
+    message.mentions = [...message.mentions, ...(await User.find({ where: { id: In(mention_user_ids) } }))];
     message.mention_everyone = mention_everyone;
+
     async function fillInMissingIDs(ids: string[]) {
         const states = await ReadState.findBy({
-            user_id: Or(...ids.map((id) => Equal(id))),
+            user_id: In(ids),
             channel_id: channel.id,
         });
         const users = new Set(ids);
@@ -747,14 +747,17 @@ async function handleMessageMentionsAsync(message: Message) {
         if (!users.size) {
             return;
         }
-        return Promise.all([...users].map((user_id) => ReadState.create({ user_id, channel_id: channel.id }).save()));
+        // TODO: is there a more efficient way to do this? Additionally, could this be a .insert()?
+        return Promise.all(users.values().map((user_id) => ReadState.create({ user_id, channel_id: channel.id }).save()));
     }
+
     if ((message.flags & (1 << 6)) !== 0) {
         // ephemeral messages
         const id = message.interaction_metadata?.user_id;
         if (id) {
             let pinged = mention_everyone || channel.type === ChannelType.DM || channel.type === ChannelType.GROUP_DM;
             if (!pinged) pinged = !!message.mentions.find((user) => user.id === id);
+            // TODO: can we somehow rewrite this into an In(...) query?
             if (!pinged) pinged = !!(await Member.find({ where: { id, roles: Or(...message.mention_roles.map(({ id }) => Equal(id))) } }));
             if (pinged) {
                 //stuff
@@ -763,10 +766,10 @@ async function handleMessageMentionsAsync(message: Message) {
     } else if ((!!message.content?.match(EVERYONE_MENTION) && permission?.has("MENTION_EVERYONE")) || channel.type === ChannelType.DM || channel.type === ChannelType.GROUP_DM) {
         if (channel.type === ChannelType.DM || channel.type === ChannelType.GROUP_DM) {
             if (channel.recipients) {
-                await fillInMissingIDs(channel.recipients.map(({ user_id }) => user_id));
+                await fillInMissingIDs(channel.recipients.map((r) => r.user_id));
             }
         } else {
-            await fillInMissingIDs((await Member.find({ where: { guild_id: channel.guild_id } })).map(({ id }) => id));
+            await fillInMissingIDs((await Member.find({ where: { guild_id: channel.guild_id } })).map((m) => m.id));
         }
         const repository = ReadState.getRepository();
         const condition = { channel_id: channel.id, read_state_type: ReadStateType.CHANNEL };
@@ -783,8 +786,8 @@ async function handleMessageMentionsAsync(message: Message) {
             ...message.mentions.map((user) => user.id),
         ]);
         if (!!message.content?.match(HERE_MENTION) && permission?.has("MENTION_EVERYONE")) {
-            const ids = (await Member.find({ where: { guild_id: channel.guild_id } })).map(({ id }) => id);
-            (await Session.find({ where: { user_id: Or(...ids.map((id) => Equal(id))) } })).forEach(({ user_id }) => users.add(user_id));
+            const ids = (await Member.find({ where: { guild_id: channel.guild_id } })).map((m) => m.id);
+            (await Session.find({ where: { user_id: In(ids) } })).map((s) => s.user_id).forEach(users.add);
         }
         if (users.size) {
             const repository = ReadState.getRepository();

--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -46,6 +46,7 @@ import {
     Stopwatch,
     TraceNode,
     TraceRoot,
+    TraceSubTree,
     User,
     USER_MENTION,
     Webhook,
@@ -765,32 +766,44 @@ async function handleMessageMentionsAsync(message: Message) {
     message.mention_everyone = mention_everyone;
     trace.calls.push("fillMessageMentionProperties", { micros: sw.getElapsedAndReset().totalMicroseconds });
 
-    const fillInMissingIDs = async (ids: string[]) => {
-        const fillMessageSw = Stopwatch.startNew();
-        const states = await ReadState.find({
-            where: {
-                user_id: In(ids),
-                channel_id: channel.id,
-                read_state_type: ReadStateType.CHANNEL,
-            },
-            select: { user_id: true },
-        });
-        const users = new Set(ids);
-        states.forEach((state) => users.delete(state.user_id));
-        if (!users.size) {
-            return;
+    const fillInMissingIDs = async (ids: string[], trace?: TraceSubTree) => {
+        const fillMessageSw = Stopwatch.startNew(),
+            subSw = Stopwatch.startNew();
+        const subTrace: TraceSubTree = { micros: 0, calls: [] };
+        try {
+            const states = await ReadState.find({
+                where: {
+                    user_id: In(ids),
+                    channel_id: channel.id,
+                    read_state_type: ReadStateType.CHANNEL,
+                },
+                select: { user_id: true },
+            });
+            subTrace.calls.push("findReadStates", { micros: subSw.getElapsedAndReset().totalMicroseconds });
+
+            const users = new Set(ids);
+            states.forEach((state) => users.delete(state.user_id));
+            subTrace.calls.push("collectMissingIds", { micros: subSw.getElapsedAndReset().totalMicroseconds });
+
+            if (!users.size) {
+                subTrace.calls.push("--noop--", { micros: subSw.getElapsedAndReset().totalMicroseconds });
+                return;
+            }
+
+            const newReadStates = users
+                .values()
+                .map((user_id) => ({ user_id, channel_id: channel.id, read_state_type: ReadStateType.CHANNEL }))
+                .toArray();
+            subTrace.calls.push("constructNewReadStates", { micros: subSw.getElapsedAndReset().totalMicroseconds });
+
+            await ReadState.insert(newReadStates).catch((e) => {
+                console.log("Failed to bulk insert", users.size, "new ReadStates, trying again (race condition?)...\nDetails:", e);
+                return fillInMissingIDs(users.values().toArray(), subTrace);
+            });
+            subTrace.calls.push("insertNewReadStates", { micros: subSw.getElapsedAndReset().totalMicroseconds });
+        } finally {
+            trace?.calls.push(`fillInMissingIDs(${ids.length})`, { micros: fillMessageSw.getElapsedAndReset().totalMicroseconds, calls: subTrace.calls });
         }
-
-        const newReadStates = users
-            .values()
-            .map((user_id) => ({ user_id, channel_id: channel.id, read_state_type: ReadStateType.CHANNEL }))
-            .toArray();
-        await ReadState.insert(newReadStates).catch((e) => {
-            console.log("Failed to bulk insert", users.size, "new ReadStates, trying again (race condition?)...\nDetails:", e);
-            return fillInMissingIDs(users.values().toArray());
-        });
-
-        trace.calls.push(`fillInMissingIDs(${ids.length})`, { micros: fillMessageSw.getElapsedAndReset().totalMicroseconds });
     };
 
     if ((message.flags & (1 << 6)) !== 0) {
@@ -809,10 +822,16 @@ async function handleMessageMentionsAsync(message: Message) {
     } else if (mention_everyone) {
         if (channel.type === ChannelType.DM || channel.type === ChannelType.GROUP_DM) {
             if (channel.recipients) {
-                await fillInMissingIDs(channel.recipients.map((r) => r.user_id));
+                await fillInMissingIDs(
+                    channel.recipients.map((r) => r.user_id),
+                    trace,
+                );
             }
         } else {
-            await fillInMissingIDs((await Member.find({ where: { guild_id: channel.guild_id }, select: { id: true } })).map((m) => m.id));
+            await fillInMissingIDs(
+                (await Member.find({ where: { guild_id: channel.guild_id }, select: { id: true } })).map((m) => m.id),
+                trace,
+            );
         }
         const repository = ReadState.getRepository();
         await repository.increment({ channel_id: channel.id, read_state_type: ReadStateType.CHANNEL }, "mention_count", 1);
@@ -830,6 +849,7 @@ async function handleMessageMentionsAsync(message: Message) {
         trace.calls.push("getUsers", { micros: sw.getElapsedAndReset().totalMicroseconds });
 
         if (mention_here) {
+            // TODO: incorporate sessions
             const ids = (await Member.find({ where: { guild_id: channel.guild_id } })).map((m) => m.id);
             (await Session.find({ where: { user_id: In(ids) } })).forEach((s) => users.add(s.user_id));
             trace.calls.push("mentionHere", { micros: sw.getElapsedAndReset().totalMicroseconds });
@@ -838,12 +858,12 @@ async function handleMessageMentionsAsync(message: Message) {
         if (users.size) {
             const repository = ReadState.getRepository();
 
-            await fillInMissingIDs([...users]);
+            await fillInMissingIDs([...users], trace);
             await repository.increment({ user_id: In(users.values().toArray()), channel_id: channel.id, read_state_type: ReadStateType.CHANNEL }, "mention_count", 1);
             trace.calls.push("updateMentionedUserReadStates", { micros: sw.getElapsedAndReset().totalMicroseconds });
         }
     }
 
     trace.micros = totalSw.elapsed().totalMicroseconds;
-    new console.Console({ stdout: process.stdout, inspectOptions: { depth: 20 } }).log("Mention handling trace:", trace);
+    if (process.env.LOG_MENTION_TRACE === "true") new console.Console({ stdout: process.stdout, inspectOptions: { depth: 20 } }).log("Mention handling trace:", trace);
 }

--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -490,139 +490,9 @@ export async function handleMessage(opts: MessageOptions): Promise<Message> {
         throw new HTTPError("Empty messages are not allowed", 50006);
     }
 
-    let content = opts.content;
+    message.content = opts.content?.trim();
 
-    // root@Rory - 20/02/2023 - This breaks channel mentions in test client. We're not sure this was used in older clients.
-    //const mention_channel_ids = [] as string[];
-    const mention_role_ids = [] as string[];
-    const mention_user_ids = [] as string[];
-    let mention_everyone = false;
-
-    if (content) {
-        // TODO: explicit-only mentions
-        // TODO: make mentions lazy
-        message.content = content.trim();
-        content = content.replace(/ *`[^)]*` */g, ""); // remove codeblocks
-        // root@Rory - 20/02/2023 - This breaks channel mentions in test client. We're not sure this was used in older clients.
-        /*for (const [, mention] of content.matchAll(CHANNEL_MENTION)) {
-			if (!mention_channel_ids.includes(mention))
-				mention_channel_ids.push(mention);
-		}*/
-
-        for (const [, mention] of content.matchAll(USER_MENTION)) {
-            if (!mention_user_ids.includes(mention)) mention_user_ids.push(mention);
-        }
-
-        await Promise.all(
-            Array.from(content.matchAll(ROLE_MENTION)).map(async ([, mention]) => {
-                const role = await Role.findOneOrFail({
-                    where: { id: mention, guild_id: channel.guild_id },
-                });
-                if (role.mentionable || opts.webhook_id || permission?.has("MANAGE_ROLES")) {
-                    mention_role_ids.push(mention);
-                }
-            }),
-        );
-
-        if (opts.webhook_id || permission?.has("MENTION_EVERYONE")) {
-            mention_everyone = !!content.match(EVERYONE_MENTION) || !!content.match(HERE_MENTION);
-        }
-    }
-
-    if (message.message_reference?.message_id) {
-        const referencedMessage = await Message.findOne({
-            where: {
-                id: message.message_reference.message_id,
-                channel_id: message.channel_id,
-            },
-            relations: {
-                mentions: true,
-                mention_roles: true,
-            },
-        });
-        if (referencedMessage && referencedMessage.author_id !== message.author_id) {
-            message.mentions.push(
-                // @ts-expect-error it does not like the .toPublicUser() lol
-                (await User.findOne({ where: { id: referencedMessage.author_id } }))!.toPublicUser(),
-            );
-        }
-
-        // FORWARD
-        if (message.message_reference.type === 1) {
-            message.type = MessageType.DEFAULT;
-
-            if (message.referenced_message) {
-                // TODO: mention_roles and mentions arrays - not needed it seems, but discord still returns that
-                message.message_snapshots = [message.referenced_message.toSnapshot()];
-            }
-        }
-    }
-
-    // root@Rory - 20/02/2023 - This breaks channel mentions in test client. We're not sure this was used in older clients.
-    /*message.mention_channels = mention_channel_ids.map((x) =>
-		Channel.create({ id: x }),
-	);*/
-    message.mention_roles = (await Promise.all(mention_role_ids.map((x) => Role.findOne({ where: { id: x } })))).filter((role) => role !== null);
-
-    message.mentions = [...message.mentions, ...(await Promise.all(mention_user_ids.map((x) => User.findOne({ where: { id: x } })))).filter((user) => user !== null)];
-
-    message.mention_everyone = mention_everyone;
-    async function fillInMissingIDs(ids: string[]) {
-        const states = await ReadState.findBy({
-            user_id: Or(...ids.map((id) => Equal(id))),
-            channel_id: channel.id,
-        });
-        const users = new Set(ids);
-        states.forEach((state) => users.delete(state.user_id));
-        if (!users.size) {
-            return;
-        }
-        return Promise.all([...users].map((user_id) => ReadState.create({ user_id, channel_id: channel.id }).save()));
-    }
-    if (ephermal) {
-        const id = message.interaction_metadata?.user_id;
-        if (id) {
-            let pinged = mention_everyone || channel.type === ChannelType.DM || channel.type === ChannelType.GROUP_DM;
-            if (!pinged) pinged = !!message.mentions.find((user) => user.id === id);
-            if (!pinged) pinged = !!(await Member.find({ where: { id, roles: Or(...message.mention_roles.map(({ id }) => Equal(id))) } }));
-            if (pinged) {
-                //stuff
-            }
-        }
-    } else if ((!!message.content?.match(EVERYONE_MENTION) && permission?.has("MENTION_EVERYONE")) || channel.type === ChannelType.DM || channel.type === ChannelType.GROUP_DM) {
-        if (channel.type === ChannelType.DM || channel.type === ChannelType.GROUP_DM) {
-            if (channel.recipients) {
-                await fillInMissingIDs(channel.recipients.map(({ user_id }) => user_id));
-            }
-        } else {
-            await fillInMissingIDs((await Member.find({ where: { guild_id: channel.guild_id } })).map(({ id }) => id));
-        }
-        const repository = ReadState.getRepository();
-        const condition = { channel_id: channel.id, read_state_type: ReadStateType.CHANNEL };
-        await repository.update({ ...condition, mention_count: IsNull() }, { mention_count: 0 });
-        await repository.increment(condition, "mention_count", 1);
-    } else {
-        const users = new Set<string>([
-            ...(message.mention_roles.length
-                ? await Member.find({
-                      where: [...message.mention_roles.map((role) => ({ roles: { id: role.id } }))],
-                  })
-                : []
-            ).map((member) => member.id),
-            ...message.mentions.map((user) => user.id),
-        ]);
-        if (!!message.content?.match(HERE_MENTION) && permission?.has("MENTION_EVERYONE")) {
-            const ids = (await Member.find({ where: { guild_id: channel.guild_id } })).map(({ id }) => id);
-            (await Session.find({ where: { user_id: Or(...ids.map((id) => Equal(id))) } })).forEach(({ user_id }) => users.add(user_id));
-        }
-        if (users.size) {
-            const repository = ReadState.getRepository();
-            const condition = { user_id: Or(...[...users].map((id) => Equal(id))), channel_id: channel.id, read_state_type: ReadStateType.CHANNEL };
-
-            await fillInMissingIDs([...users]);
-            await repository.increment(condition, "mention_count", 1);
-        }
-    }
+    await handleMessageMentionsAsync(message);
 
     const attachmentIndices = new Map(message.attachments?.map((attachment, index) => [`attachment://${attachment.filename}`, index]));
     const attachmentsToRemove = new Set<number>();
@@ -782,4 +652,146 @@ export async function convertCloudAttachmentToAttachment(cAtt: MessageCreateClou
     });
     console.log("[Message] Converted cloud attachment to", realAtt);
     return realAtt;
+}
+
+async function handleMessageMentionsAsync(message: Message) {
+    const channel = await Channel.findOneOrFail({
+        where: { id: message.channel_id },
+        relations: { recipients: true },
+    });
+    const permission = await getPermission(message.author_id ?? message.author?.id, channel.guild_id, channel);
+
+    let content = message.content;
+
+    // root@Rory - 20/02/2023 - This breaks channel mentions in test client. We're not sure this was used in older clients.
+    //const mention_channel_ids = [] as string[];
+    const mention_role_ids = [] as string[];
+    const mention_user_ids = [] as string[];
+    let mention_everyone = false;
+
+    if (content) {
+        // TODO: explicit-only mentions
+        // TODO: make mentions lazy
+        content = content.replace(/ *`[^)]*` */g, ""); // remove codeblocks
+        // root@Rory - 20/02/2023 - This breaks channel mentions in test client. We're not sure this was used in older clients.
+        /*for (const [, mention] of content.matchAll(CHANNEL_MENTION)) {
+			if (!mention_channel_ids.includes(mention))
+				mention_channel_ids.push(mention);
+		}*/
+
+        for (const [, mention] of content.matchAll(USER_MENTION)) {
+            if (!mention_user_ids.includes(mention)) mention_user_ids.push(mention);
+        }
+
+        await Promise.all(
+            Array.from(content.matchAll(ROLE_MENTION)).map(async ([, mention]) => {
+                const role = await Role.findOneOrFail({
+                    where: { id: mention, guild_id: channel.guild_id },
+                });
+                if (role.mentionable || message.webhook?.id || message.webhook_id || permission?.has("MANAGE_ROLES")) {
+                    mention_role_ids.push(mention);
+                }
+            }),
+        );
+
+        if (message.webhook?.id || message.webhook_id || permission?.has("MENTION_EVERYONE")) {
+            mention_everyone = !!content.match(EVERYONE_MENTION) || !!content.match(HERE_MENTION);
+        }
+    }
+
+    if (message.message_reference?.message_id) {
+        const referencedMessage = await Message.findOne({
+            where: {
+                id: message.message_reference.message_id,
+                channel_id: message.channel_id,
+            },
+            relations: {
+                mentions: true,
+                mention_roles: true,
+            },
+        });
+        if (referencedMessage && referencedMessage.author_id !== message.author_id) {
+            message.mentions.push(
+                // @ts-expect-error it does not like the .toPublicUser() lol
+                (await User.findOne({ where: { id: referencedMessage.author_id } }))!.toPublicUser(),
+            );
+        }
+
+        // FORWARD
+        if (message.message_reference.type === 1) {
+            message.type = MessageType.DEFAULT;
+
+            if (message.referenced_message) {
+                // TODO: mention_roles and mentions arrays - not needed it seems, but discord still returns that
+                message.message_snapshots = [message.referenced_message.toSnapshot()];
+            }
+        }
+    }
+
+    // root@Rory - 20/02/2023 - This breaks channel mentions in test client. We're not sure this was used in older clients.
+    /*message.mention_channels = mention_channel_ids.map((x) =>
+		Channel.create({ id: x }),
+	);*/
+    message.mention_roles = (await Promise.all(mention_role_ids.map((x) => Role.findOne({ where: { id: x } })))).filter((role) => role !== null);
+
+    message.mentions = [...message.mentions, ...(await Promise.all(mention_user_ids.map((x) => User.findOne({ where: { id: x } })))).filter((user) => user !== null)];
+
+    message.mention_everyone = mention_everyone;
+    async function fillInMissingIDs(ids: string[]) {
+        const states = await ReadState.findBy({
+            user_id: Or(...ids.map((id) => Equal(id))),
+            channel_id: channel.id,
+        });
+        const users = new Set(ids);
+        states.forEach((state) => users.delete(state.user_id));
+        if (!users.size) {
+            return;
+        }
+        return Promise.all([...users].map((user_id) => ReadState.create({ user_id, channel_id: channel.id }).save()));
+    }
+    if ((message.flags & (1 << 6)) !== 0) {
+        // ephemeral messages
+        const id = message.interaction_metadata?.user_id;
+        if (id) {
+            let pinged = mention_everyone || channel.type === ChannelType.DM || channel.type === ChannelType.GROUP_DM;
+            if (!pinged) pinged = !!message.mentions.find((user) => user.id === id);
+            if (!pinged) pinged = !!(await Member.find({ where: { id, roles: Or(...message.mention_roles.map(({ id }) => Equal(id))) } }));
+            if (pinged) {
+                //stuff
+            }
+        }
+    } else if ((!!message.content?.match(EVERYONE_MENTION) && permission?.has("MENTION_EVERYONE")) || channel.type === ChannelType.DM || channel.type === ChannelType.GROUP_DM) {
+        if (channel.type === ChannelType.DM || channel.type === ChannelType.GROUP_DM) {
+            if (channel.recipients) {
+                await fillInMissingIDs(channel.recipients.map(({ user_id }) => user_id));
+            }
+        } else {
+            await fillInMissingIDs((await Member.find({ where: { guild_id: channel.guild_id } })).map(({ id }) => id));
+        }
+        const repository = ReadState.getRepository();
+        const condition = { channel_id: channel.id, read_state_type: ReadStateType.CHANNEL };
+        await repository.update({ ...condition, mention_count: IsNull() }, { mention_count: 0 });
+        await repository.increment(condition, "mention_count", 1);
+    } else {
+        const users = new Set<string>([
+            ...(message.mention_roles.length
+                ? await Member.find({
+                      where: [...message.mention_roles.map((role) => ({ roles: { id: role.id } }))],
+                  })
+                : []
+            ).map((member) => member.id),
+            ...message.mentions.map((user) => user.id),
+        ]);
+        if (!!message.content?.match(HERE_MENTION) && permission?.has("MENTION_EVERYONE")) {
+            const ids = (await Member.find({ where: { guild_id: channel.guild_id } })).map(({ id }) => id);
+            (await Session.find({ where: { user_id: Or(...ids.map((id) => Equal(id))) } })).forEach(({ user_id }) => users.add(user_id));
+        }
+        if (users.size) {
+            const repository = ReadState.getRepository();
+            const condition = { user_id: Or(...[...users].map((id) => Equal(id))), channel_id: channel.id, read_state_type: ReadStateType.CHANNEL };
+
+            await fillInMissingIDs([...users]);
+            await repository.increment(condition, "mention_count", 1);
+        }
+    }
 }

--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -823,7 +823,7 @@ async function handleMessageMentionsAsync(message: Message) {
         trace.calls.push("getUsers", { micros: sw.getElapsedAndReset().totalMicroseconds });
         if (mention_here) {
             const ids = (await Member.find({ where: { guild_id: channel.guild_id } })).map((m) => m.id);
-            (await Session.find({ where: { user_id: In(ids) } })).map((s) => s.user_id).forEach(users.add);
+            (await Session.find({ where: { user_id: In(ids) } })).forEach((s) => users.add(s.user_id));
             trace.calls.push("mentionHere", { micros: sw.getElapsedAndReset().totalMicroseconds });
         }
         if (users.size) {

--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -19,6 +19,8 @@
 import { fillMessageUrlEmbeds, randomString } from "@spacebar/api";
 import {
     Application,
+    arrayDistributeSequentially,
+    arrayPartition,
     Attachment,
     Channel,
     CloudAttachment,
@@ -33,6 +35,7 @@ import {
     Guild,
     handleFile,
     HERE_MENTION,
+    mathLogBase,
     Member,
     Message,
     MessageCreateEvent,
@@ -42,6 +45,7 @@ import {
     Role,
     ROLE_MENTION,
     Session,
+    Snowflake,
     Sticker,
     Stopwatch,
     TraceNode,
@@ -790,17 +794,29 @@ async function handleMessageMentionsAsync(message: Message) {
                 return;
             }
 
-            const newReadStates = users
-                .values()
-                .map((user_id) => ({ user_id, channel_id: channel.id, read_state_type: ReadStateType.CHANNEL }))
-                .toArray();
-            subTrace.calls.push("constructNewReadStates", { micros: subSw.getElapsedAndReset().totalMicroseconds });
+            const newReadStateSeqs = arrayDistributeSequentially(users.values().toArray(), Math.max(1, mathLogBase(users.size, 2))).map((seq) =>
+                seq.map((user_id) => ({ id: Snowflake.generate(), user_id, channel_id: channel.id, read_state_type: ReadStateType.CHANNEL })),
+            );
+            subTrace.calls.push(`constructNewReadStatesChunked(${newReadStateSeqs.length})`, { micros: subSw.getElapsedAndReset().totalMicroseconds });
 
-            await ReadState.insert(newReadStates).catch((e) => {
-                console.log("Failed to bulk insert", users.size, "new ReadStates, trying again (race condition?)...\nDetails:", e);
-                return fillInMissingIDs(users.values().toArray(), subTrace);
-            });
-            subTrace.calls.push("insertNewReadStates", { micros: subSw.getElapsedAndReset().totalMicroseconds });
+            await Promise.all(
+                newReadStateSeqs.map((seq) =>
+                    // just a safety thing... handle postgres hard limit at 65535 parameters, at 4 params per object... 16384
+                    seq.length > 15000
+                        ? fillInMissingIDs(
+                              seq.map((rs) => rs.user_id),
+                              subTrace,
+                          )
+                        : ReadState.insert(seq).catch((e) => {
+                              console.log("Failed to bulk insert", seq.length, "new ReadStates, trying again (race condition/too many params?)...\nDetails:", e);
+                              return fillInMissingIDs(
+                                  seq.map((rs) => rs.user_id),
+                                  subTrace,
+                              );
+                          }),
+                ),
+            );
+            subTrace.calls.push("insertNewReadStatesChunked", { micros: subSw.getElapsedAndReset().totalMicroseconds });
         } finally {
             trace?.calls.push(`fillInMissingIDs(${ids.length})`, { micros: fillMessageSw.getElapsedAndReset().totalMicroseconds, calls: subTrace.calls });
         }

--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -680,10 +680,12 @@ async function handleMessageMentionsAsync(message: Message) {
     // root@Rory - 20/02/2023 - This breaks channel mentions in test client. We're not sure this was used in older clients.
     //const mention_channel_ids = [] as string[];
     let mention_everyone = false;
+    let mention_here = false;
     const mention_user_id_set = new Set<string>();
     const mention_role_id_set = new Set<string>();
 
     if (content) {
+        const contentSw = Stopwatch.startNew();
         const contentTrace: TraceNode = { micros: 0, calls: [] };
         // TODO: explicit-only mentions
         // TODO: make mentions lazy
@@ -697,8 +699,9 @@ async function handleMessageMentionsAsync(message: Message) {
 
         for (const [, mention] of content.matchAll(USER_MENTION)) mention_user_id_set.add(mention);
         for (const [, mention] of content.matchAll(ROLE_MENTION)) mention_role_id_set.add(mention);
-        if (message.webhook?.id || message.webhook_id || permission?.has("MENTION_EVERYONE")) {
-            mention_everyone = !!content.match(EVERYONE_MENTION) || !!content.match(HERE_MENTION);
+        if (message.webhook?.id || message.webhook_id || permission?.has("MENTION_EVERYONE") || channel.type === ChannelType.DM || channel.type === ChannelType.GROUP_DM) {
+            mention_everyone = !!content.match(EVERYONE_MENTION);
+            mention_here = !!content.match(HERE_MENTION);
         }
         contentTrace.calls.push("parseMentions", { micros: sw.getElapsedAndReset().totalMicroseconds });
 
@@ -720,6 +723,8 @@ async function handleMessageMentionsAsync(message: Message) {
             mentionedRoles.forEach((r) => mention_role_id_set.add(r.id));
         }
         contentTrace.calls.push("validateMentionRoles", { micros: sw.getElapsedAndReset().totalMicroseconds });
+        contentTrace.micros = contentSw.elapsed().totalMicroseconds;
+        trace.calls.push("parseContent", contentTrace);
     }
 
     if (message.message_reference?.message_id) {
@@ -748,6 +753,7 @@ async function handleMessageMentionsAsync(message: Message) {
                 message.message_snapshots = [message.referenced_message.toSnapshot()];
             }
         }
+        trace.calls.push("handleMessageReference", { micros: sw.getElapsedAndReset().totalMicroseconds });
     }
 
     // root@Rory - 20/02/2023 - This breaks channel mentions in test client. We're not sure this was used in older clients.
@@ -757,8 +763,10 @@ async function handleMessageMentionsAsync(message: Message) {
     message.mention_roles = await Role.find({ where: { id: In(mention_role_id_set.values().toArray()), guild_id: channel.guild_id } });
     message.mentions = [...message.mentions, ...(await User.find({ where: { id: In(mention_user_id_set.values().toArray()) } }))];
     message.mention_everyone = mention_everyone;
+    trace.calls.push("fillMessageMentionProperties", { micros: sw.getElapsedAndReset().totalMicroseconds });
 
     async function fillInMissingIDs(ids: string[]) {
+        const fillMessageSw = Stopwatch.startNew();
         const states = await ReadState.findBy({
             user_id: In(ids),
             channel_id: channel.id,
@@ -769,7 +777,11 @@ async function handleMessageMentionsAsync(message: Message) {
             return;
         }
         // TODO: is there a more efficient way to do this? Additionally, could this be a .insert()?
-        return Promise.all(users.values().map((user_id) => ReadState.create({ user_id, channel_id: channel.id }).save()));
+        await Promise.all(users.values().map((user_id) => ReadState.create({ user_id, channel_id: channel.id }).save()));
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        //@ts-expect-error
+        trace.calls.push(`fillInMissingIDs(${ids.count})`, { micros: fillMessageSw.getElapsedAndReset().totalMicroseconds });
     }
 
     if ((message.flags & (1 << 6)) !== 0) {
@@ -784,7 +796,8 @@ async function handleMessageMentionsAsync(message: Message) {
                 //stuff
             }
         }
-    } else if ((!!message.content?.match(EVERYONE_MENTION) && permission?.has("MENTION_EVERYONE")) || channel.type === ChannelType.DM || channel.type === ChannelType.GROUP_DM) {
+        trace.calls.push("ephemeralPinged", { micros: sw.getElapsedAndReset().totalMicroseconds });
+    } else if (mention_everyone) {
         if (channel.type === ChannelType.DM || channel.type === ChannelType.GROUP_DM) {
             if (channel.recipients) {
                 await fillInMissingIDs(channel.recipients.map((r) => r.user_id));
@@ -796,6 +809,7 @@ async function handleMessageMentionsAsync(message: Message) {
         const condition = { channel_id: channel.id, read_state_type: ReadStateType.CHANNEL };
         await repository.update({ ...condition, mention_count: IsNull() }, { mention_count: 0 });
         await repository.increment(condition, "mention_count", 1);
+        trace.calls.push("mentionEveryone", { micros: sw.getElapsedAndReset().totalMicroseconds });
     } else {
         const users = new Set<string>([
             ...(message.mention_roles.length
@@ -806,9 +820,11 @@ async function handleMessageMentionsAsync(message: Message) {
             ).map((member) => member.id),
             ...message.mentions.map((user) => user.id),
         ]);
-        if (!!message.content?.match(HERE_MENTION) && permission?.has("MENTION_EVERYONE")) {
+        trace.calls.push("getUsers", { micros: sw.getElapsedAndReset().totalMicroseconds });
+        if (mention_here) {
             const ids = (await Member.find({ where: { guild_id: channel.guild_id } })).map((m) => m.id);
             (await Session.find({ where: { user_id: In(ids) } })).map((s) => s.user_id).forEach(users.add);
+            trace.calls.push("mentionHere", { micros: sw.getElapsedAndReset().totalMicroseconds });
         }
         if (users.size) {
             const repository = ReadState.getRepository();
@@ -816,6 +832,10 @@ async function handleMessageMentionsAsync(message: Message) {
 
             await fillInMissingIDs([...users]);
             await repository.increment(condition, "mention_count", 1);
+            trace.calls.push("updateMentionedUserReadStates", { micros: sw.getElapsedAndReset().totalMicroseconds });
         }
     }
+
+    trace.micros = totalSw.elapsed().totalMicroseconds;
+    new console.Console({ stdout: process.stdout, inspectOptions: { depth: 20 } }).log("Mention handling trace:", trace);
 }

--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -788,7 +788,7 @@ async function handleMessageMentionsAsync(message: Message) {
         }
         if (users.size) {
             const repository = ReadState.getRepository();
-            const condition = { user_id: Or(...[...users].map((id) => Equal(id))), channel_id: channel.id, read_state_type: ReadStateType.CHANNEL };
+            const condition = { user_id: In(users.values().toArray()), channel_id: channel.id, read_state_type: ReadStateType.CHANNEL };
 
             await fillInMissingIDs([...users]);
             await repository.increment(condition, "mention_count", 1);

--- a/src/api/util/handlers/Message.ts
+++ b/src/api/util/handlers/Message.ts
@@ -47,6 +47,10 @@ import {
     MessageFlags,
     FieldErrors,
     getDatabase,
+    ElapsedTime,
+    TraceRoot,
+    Stopwatch,
+    TraceNode,
 } from "@spacebar/util";
 import { HTTPError } from "lambert-server";
 import { In, Or, Equal, IsNull } from "typeorm";
@@ -66,6 +70,7 @@ import {
     UnfurledMediaItem,
     BaseMessageComponents,
     v1CompTypes,
+    MessageReferenceType,
 } from "@spacebar/schemas";
 const allow_empty = false;
 // TODO: check webhook, application, system author, stickers
@@ -655,22 +660,31 @@ export async function convertCloudAttachmentToAttachment(cAtt: MessageCreateClou
 }
 
 async function handleMessageMentionsAsync(message: Message) {
+    const sw = Stopwatch.startNew(),
+        totalSw = Stopwatch.startNew();
+    const trace: TraceNode = { micros: 0, calls: [] };
+    const traceRoot: TraceRoot = ["handleMessageMentionsAsync", trace];
+
     const channel = await Channel.findOneOrFail({
         where: { id: message.channel_id },
         relations: { recipients: true },
     });
+    trace.calls.push(`getChannel(${channel.id})`, { micros: sw.getElapsedAndReset().totalMicroseconds });
+
     const permission = await getPermission(message.author_id ?? message.author?.id, channel.guild_id, channel);
+    trace.calls.push(`getPermissions`, { micros: sw.getElapsedAndReset().totalMicroseconds });
 
     let content = message.content;
 
     // TODO: sets
     // root@Rory - 20/02/2023 - This breaks channel mentions in test client. We're not sure this was used in older clients.
     //const mention_channel_ids = [] as string[];
-    const mention_role_ids = [] as string[];
-    const mention_user_ids = [] as string[];
     let mention_everyone = false;
+    const mention_user_id_set = new Set<string>();
+    const mention_role_id_set = new Set<string>();
 
     if (content) {
+        const contentTrace: TraceNode = { micros: 0, calls: [] };
         // TODO: explicit-only mentions
         // TODO: make mentions lazy
         content = content.replace(/ *`[^)]*` */g, ""); // remove codeblocks
@@ -679,25 +693,33 @@ async function handleMessageMentionsAsync(message: Message) {
 			if (!mention_channel_ids.includes(mention))
 				mention_channel_ids.push(mention);
 		}*/
+        contentTrace.calls.push("filterCodeblocks", { micros: sw.getElapsedAndReset().totalMicroseconds });
 
-        for (const [, mention] of content.matchAll(USER_MENTION)) {
-            if (!mention_user_ids.includes(mention)) mention_user_ids.push(mention);
-        }
-
-        await Promise.all(
-            content.matchAll(ROLE_MENTION).map(async ([, mention]) => {
-                const role = await Role.findOneOrFail({
-                    where: { id: mention, guild_id: channel.guild_id },
-                });
-                if (role.mentionable || message.webhook?.id || message.webhook_id || permission?.has("MANAGE_ROLES")) {
-                    mention_role_ids.push(mention);
-                }
-            }),
-        );
-
+        for (const [, mention] of content.matchAll(USER_MENTION)) mention_user_id_set.add(mention);
+        for (const [, mention] of content.matchAll(ROLE_MENTION)) mention_role_id_set.add(mention);
         if (message.webhook?.id || message.webhook_id || permission?.has("MENTION_EVERYONE")) {
             mention_everyone = !!content.match(EVERYONE_MENTION) || !!content.match(HERE_MENTION);
         }
+        contentTrace.calls.push("parseMentions", { micros: sw.getElapsedAndReset().totalMicroseconds });
+
+        let mentionedRoles = await Role.find({ where: { id: In(mention_role_id_set.values().toArray()), guild_id: channel.guild_id } });
+        contentTrace.calls.push("queryMentionRoles", { micros: sw.getElapsedAndReset().totalMicroseconds });
+
+        //TODO: should this throw at all?
+        if (mention_role_id_set.size != mentionedRoles.length) {
+            const missingRoles = mention_role_id_set
+                .values()
+                .filter((x) => !mentionedRoles.find((r) => r.id == x))
+                .toArray();
+            throw new HTTPError("Mentioned invalid roles: " + missingRoles.join(", "), 500);
+        }
+
+        if (!(message.webhook?.id || message.webhook_id || permission?.has("MANAGE_ROLES"))) {
+            mentionedRoles = mentionedRoles.filter((x) => x.mentionable);
+            mention_role_id_set.clear();
+            mentionedRoles.forEach((r) => mention_role_id_set.add(r.id));
+        }
+        contentTrace.calls.push("validateMentionRoles", { micros: sw.getElapsedAndReset().totalMicroseconds });
     }
 
     if (message.message_reference?.message_id) {
@@ -718,8 +740,7 @@ async function handleMessageMentionsAsync(message: Message) {
             );
         }
 
-        // FORWARD
-        if (message.message_reference.type === 1) {
+        if (message.message_reference.type === MessageReferenceType.FORWARD) {
             message.type = MessageType.DEFAULT;
 
             if (message.referenced_message) {
@@ -733,8 +754,8 @@ async function handleMessageMentionsAsync(message: Message) {
     /*message.mention_channels = mention_channel_ids.map((x) =>
 		Channel.create({ id: x }),
 	);*/
-    message.mention_roles = await Role.find({ where: { id: In(mention_role_ids), guild_id: channel.guild_id } });
-    message.mentions = [...message.mentions, ...(await User.find({ where: { id: In(mention_user_ids) } }))];
+    message.mention_roles = await Role.find({ where: { id: In(mention_role_id_set.values().toArray()), guild_id: channel.guild_id } });
+    message.mentions = [...message.mentions, ...(await User.find({ where: { id: In(mention_user_id_set.values().toArray()) } }))];
     message.mention_everyone = mention_everyone;
 
     async function fillInMissingIDs(ids: string[]) {

--- a/src/schemas/api/messages/Message.ts
+++ b/src/schemas/api/messages/Message.ts
@@ -238,5 +238,10 @@ export interface MessageReference {
     channel_id?: string;
     guild_id?: string;
     fail_if_not_exists?: boolean;
-    type?: number;
+    type?: MessageReferenceType;
+}
+
+export enum MessageReferenceType {
+    DEFAULT = 0,
+    FORWARD = 1,
 }

--- a/src/util/interfaces/Event.ts
+++ b/src/util/interfaces/Event.ts
@@ -153,7 +153,9 @@ export interface ReadyEventData {
     _trace?: string[]; // trace of the request, used for debugging
 }
 
-export type TraceNode = { micros: number; calls: TraceNode[] } | { micros: number } | string;
+export type TraceValue = { micros: number };
+export type TraceSubTree = { micros: number; calls: TraceNode[] };
+export type TraceNode = TraceSubTree | TraceValue | string;
 
 export type TraceRoot = [string, { micros: number; calls: TraceNode[] }];
 

--- a/src/util/util/extensions/Array.ts
+++ b/src/util/util/extensions/Array.ts
@@ -55,3 +55,22 @@ export function arrayGroupBy<T, M>(array: T[], selector: (elem: T) => M): Map<M,
 
     return map;
 }
+
+// https://github.com/TheArcaneBrony/ArcaneLibs/blob/ca7ce2bb57a5dffd891b0b86ec5f358df02735c0/ArcaneLibs/Extensions/CollectionExtensions.cs#L103
+export function arrayDistributeSequentially<T>(array: T[], count: number): T[][] {
+    if (count <= 0) throw new Error("Count must be greater than 0");
+    if (count == 1) return [array];
+
+    const list = array;
+    const groups: T[][] = [];
+    for (let i = 0; i < count; i++) groups.push([]);
+
+    // [1,2,3],[4,5,6],[7,8,9]...
+    for (let i = 0; i < list.length; i++) {
+        const idx: number = Math.floor((i / list.length) * count);
+        // console.log(`${i}/${list.length} -> ${idx}:${groups[idx].length}/{count}`);
+        groups[idx].push(list[i]);
+    }
+
+    return groups;
+}

--- a/src/util/util/extensions/Math.ts
+++ b/src/util/util/extensions/Math.ts
@@ -1,6 +1,6 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
-	Copyright (C) 2026 Spacebar and Spacebar Contributors
+	Copyright (C) 2025 Spacebar and Spacebar Contributors
 
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published
@@ -16,10 +16,7 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-export * from "./Array";
-export * from "./Math";
-
-// TODO: move to a separate file
-export async function sleep(ms: number) {
-    return new Promise((resolve) => void setTimeout(resolve, ms));
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log
+export function mathLogBase(num: number, base: number) {
+    return Math.log(num) / Math.log(base);
 }

--- a/src/util/util/extensions/Math.ts
+++ b/src/util/util/extensions/Math.ts
@@ -1,6 +1,6 @@
 /*
 	Spacebar: A FOSS re-implementation and extension of the Discord.com backend.
-	Copyright (C) 2025 Spacebar and Spacebar Contributors
+	Copyright (C) 2026 Spacebar and Spacebar Contributors
 
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published


### PR DESCRIPTION
Hint: view edits per commit, as all the mention handling code was moved to a separate function, which breaks the global diff view.

Didn't yet achieve proper async mentions, but most of the involved SQL queries have been rewritten to use `IN(...)` rather than `OR` chaining, and we now use bulk inserts for missing read states.
TL;DR it's now measurably and very noticeably faster.