### PR TITLE
Make recent mentions work without `before` again

### DIFF
--- a/src/api/routes/users/@me/mentions.ts
+++ b/src/api/routes/users/@me/mentions.ts
@@ -94,22 +94,23 @@ router.get(
             {
                 channel_id: In(visibleChannelIds),
                 mentions: { id: user.id },
-                id: before ? LessThan(before) : undefined,
             },
         ];
         if (everyone) {
             whereQuery.push({
                 channel_id: In(visibleChannelIds),
                 mention_everyone: true,
-                id: before ? LessThan(before) : undefined,
             });
         }
         if (roles) {
             whereQuery.push({
                 channel_id: In(visibleChannelIds),
                 mention_roles: { id: In(ownedMentionableRoleIds) },
-                id: before ? LessThan(before) : undefined,
             });
+        }
+
+        if (before) {
+            whereQuery.map((query) => (query.id = LessThan(before)));
         }
 
         const sw = Stopwatch.startNew();


### PR DESCRIPTION
Typeorm stared erroring out on `id` being `undefined` for some reason
<img width="1112" height="202" alt="image" src="https://github.com/user-attachments/assets/fd82a651-76a7-4747-a32d-60a2d1320017" />
