### PR TITLE
Make typing event work in DMs again

### DIFF
--- a/src/api/routes/channels/#channel_id/typing.ts
+++ b/src/api/routes/channels/#channel_id/typing.ts
@@ -20,6 +20,7 @@ import { Request, Response, Router } from "express";
 import { route } from "@spacebar/api/util/handlers/route";
 import { Channel, Member } from "@spacebar/database";
 import { emitEvent, TypingStartEvent } from "@spacebar/util";
+import { IsNull } from "typeorm";
 
 const router: Router = Router({ mergeParams: true });
 
@@ -41,7 +42,7 @@ router.post(
             where: { id: channel_id },
         });
         const member = await Member.findOne({
-            where: { id: user_id, guild_id: channel.guild_id },
+            where: { id: user_id, guild_id: channel.guild_id || IsNull() },
             relations: { roles: true, user: true },
         });
         await emitEvent({


### PR DESCRIPTION
Typeorm stared erroring out on `guild_id` being `null` for some reason
<img width="559" height="110" alt="image" src="https://github.com/user-attachments/assets/f3a98568-e839-4ce1-ad98-7135b04f3d74" />
