### PR TITLE
Reconcile bigint migrations with typeorm, name constraints explicitly

### DIFF
--- a/extra/admin-api/Models/Spacebar.Models.Db/Contexts/SpacebarDbContext.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Contexts/SpacebarDbContext.cs
@@ -67,6 +67,8 @@ public partial class SpacebarDbContext : DbContext
 
     public virtual DbSet<Relationship> Relationships { get; set; }
 
+    public virtual DbSet<ReportMenu> ReportMenus { get; set; }
+
     public virtual DbSet<Role> Roles { get; set; }
 
     public virtual DbSet<SecurityKey> SecurityKeys { get; set; }
@@ -115,17 +117,15 @@ public partial class SpacebarDbContext : DbContext
 
             entity.HasOne(d => d.BotUser).WithOne(p => p.ApplicationBotUser)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_2ce5a55796fe4c2f77ece57a647");
+                .HasConstraintName("FK_application_bot_user_id");
 
-            entity.HasOne(d => d.Guild).WithMany(p => p.Applications).HasConstraintName("FK_e5bf78cdbbe9ba91062d74c5aba");
+            entity.HasOne(d => d.Guild).WithMany(p => p.Applications).HasConstraintName("FK_application_guild_id");
 
-            entity.HasOne(d => d.Owner).WithMany(p => p.ApplicationOwners)
-                .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_e57508958bf92b9d9d25231b5e8");
+            entity.HasOne(d => d.Owner).WithMany(p => p.ApplicationOwners).HasConstraintName("FK_application_owner_id");
 
             entity.HasOne(d => d.Team).WithMany(p => p.Applications)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_a36ed02953077f408d0f3ebc424");
+                .HasConstraintName("FK_application_team_id");
         });
 
         modelBuilder.Entity<ApplicationCommand>(entity =>
@@ -136,9 +136,6 @@ public partial class SpacebarDbContext : DbContext
             entity.Property(e => e.DmPermission).HasDefaultValue(true);
             entity.Property(e => e.Options).HasDefaultValueSql("'[]'::jsonb");
             entity.Property(e => e.Type).HasDefaultValue(1);
-            entity.Property(e => e.Version).HasDefaultValueSql("(0)::bigint");
-
-            entity.HasOne(d => d.Application).WithMany(p => p.ApplicationCommands).HasConstraintName("application_commands_applications_fk");
         });
 
         modelBuilder.Entity<Attachment>(entity =>
@@ -149,11 +146,11 @@ public partial class SpacebarDbContext : DbContext
 
             entity.HasOne(d => d.Channel).WithMany(p => p.Attachments)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("attachments_channels_fk");
+                .HasConstraintName("FK_attachment_channel_id");
 
             entity.HasOne(d => d.Message).WithMany(p => p.Attachments)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_623e10eec51ada466c5038979e3");
+                .HasConstraintName("FK_attachment_message_id");
         });
 
         modelBuilder.Entity<AuditLog>(entity =>
@@ -162,9 +159,9 @@ public partial class SpacebarDbContext : DbContext
 
             entity.Property(e => e.Id).ValueGeneratedNever();
 
-            entity.HasOne(d => d.Target).WithMany(p => p.AuditLogTargets).HasConstraintName("FK_3cd01cd3ae7aab010310d96ac8e");
+            entity.HasOne(d => d.Target).WithMany(p => p.AuditLogTargets).HasConstraintName("FK_audit_log_target_user_id");
 
-            entity.HasOne(d => d.User).WithMany(p => p.AuditLogUsers).HasConstraintName("FK_bd2726fd31b35443f2245b93ba0");
+            entity.HasOne(d => d.User).WithMany(p => p.AuditLogUsers).HasConstraintName("FK_audit_log_source_user_id");
         });
 
         modelBuilder.Entity<AutomodRule>(entity =>
@@ -175,9 +172,7 @@ public partial class SpacebarDbContext : DbContext
 
             entity.HasOne(d => d.Creator).WithMany(p => p.AutomodRules)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_12d3d60b961393d310429c062b7");
-
-            entity.HasOne(d => d.Guild).WithMany(p => p.AutomodRules).HasConstraintName("automod_rules_guilds_fk");
+                .HasConstraintName("FK_automod_rule_creator_id");
         });
 
         modelBuilder.Entity<BackupCode>(entity =>
@@ -188,14 +183,12 @@ public partial class SpacebarDbContext : DbContext
 
             entity.HasOne(d => d.User).WithMany(p => p.BackupCodes)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_70066ea80d2f4b871beda32633b");
+                .HasConstraintName("FK_backup_code_user_id");
         });
 
         modelBuilder.Entity<Badge>(entity =>
         {
             entity.HasKey(e => e.Id).HasName("PK_8a651318b8de577e8e217676466");
-
-            entity.Property(e => e.Id).ValueGeneratedNever();
         });
 
         modelBuilder.Entity<Ban>(entity =>
@@ -204,15 +197,15 @@ public partial class SpacebarDbContext : DbContext
 
             entity.Property(e => e.Id).ValueGeneratedNever();
 
-            entity.HasOne(d => d.Executor).WithMany(p => p.BanExecutors).HasConstraintName("FK_07ad88c86d1f290d46748410d58");
+            entity.HasOne(d => d.Executor).WithMany(p => p.BanExecutors).HasConstraintName("FK_ban_executor_id");
 
             entity.HasOne(d => d.Guild).WithMany(p => p.Bans)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_9d3ab7dd180ebdd245cdb66ecad");
+                .HasConstraintName("FK_ban_guild_id");
 
             entity.HasOne(d => d.User).WithMany(p => p.BanUsers)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_5999e8e449f80a236ff72023559");
+                .HasConstraintName("FK_ban_user_id");
         });
 
         modelBuilder.Entity<Category>(entity =>
@@ -230,11 +223,11 @@ public partial class SpacebarDbContext : DbContext
 
             entity.HasOne(d => d.Guild).WithMany(p => p.Channels)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_c253dafe5f3a03ec00cd8fb4581");
+                .HasConstraintName("FK_channel_guild_id");
 
-            entity.HasOne(d => d.Owner).WithMany(p => p.Channels).HasConstraintName("FK_3873ed438575cce703ecff4fc7b");
+            entity.HasOne(d => d.Owner).WithMany(p => p.Channels).HasConstraintName("FK_channel_owner_id");
 
-            entity.HasOne(d => d.Parent).WithMany(p => p.InverseParent).HasConstraintName("FK_3274522d14af40540b1a883fc80");
+            entity.HasOne(d => d.Parent).WithMany(p => p.InverseParent).HasConstraintName("FK_channel_parent_id");
         });
 
         modelBuilder.Entity<ClientRelease>(entity =>
@@ -252,11 +245,11 @@ public partial class SpacebarDbContext : DbContext
 
             entity.HasOne(d => d.Channel).WithMany(p => p.CloudAttachments)
                 .OnDelete(DeleteBehavior.SetNull)
-                .HasConstraintName("FK_998d5fe91008ba5b09e1322104c");
+                .HasConstraintName("FK_cloud_attachment_channel_id");
 
             entity.HasOne(d => d.User).WithMany(p => p.CloudAttachments)
                 .OnDelete(DeleteBehavior.SetNull)
-                .HasConstraintName("FK_8bf8cc8767e48cb482ff644fce6");
+                .HasConstraintName("FK_cloud_attachment_user_id");
         });
 
         modelBuilder.Entity<Config>(entity =>
@@ -272,7 +265,7 @@ public partial class SpacebarDbContext : DbContext
 
             entity.HasOne(d => d.User).WithMany(p => p.ConnectedAccounts)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_f47244225a6a1eac04a3463dd90");
+                .HasConstraintName("FK_connected_account_user_id");
         });
 
         modelBuilder.Entity<ConnectionConfig>(entity =>
@@ -302,7 +295,7 @@ public partial class SpacebarDbContext : DbContext
                 .OnDelete(DeleteBehavior.Cascade)
                 .HasConstraintName("FK_emoji_guild_id");
 
-            entity.HasOne(d => d.User).WithMany(p => p.Emojis).HasConstraintName("FK_fa7ddd5f9a214e28ce596548421");
+            entity.HasOne(d => d.User).WithMany(p => p.Emojis).HasConstraintName("FK_emoji_user_id");
         });
 
         modelBuilder.Entity<Guild>(entity =>
@@ -311,43 +304,37 @@ public partial class SpacebarDbContext : DbContext
 
             entity.Property(e => e.Id).ValueGeneratedNever();
 
-            entity.HasOne(d => d.AfkChannel).WithMany(p => p.GuildAfkChannels).HasConstraintName("FK_f591a66b8019d87b0fe6c12dad6");
+            entity.HasOne(d => d.AfkChannel).WithMany(p => p.GuildAfkChannels).HasConstraintName("FK_guild_afk_channel_id");
 
-            entity.HasOne(d => d.Owner).WithMany(p => p.Guilds)
-                .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_fc1a451727e3643ca572a3bb394");
+            entity.HasOne(d => d.Owner).WithMany(p => p.Guilds).HasConstraintName("FK_guild_owner_id");
 
-            entity.HasOne(d => d.PrimaryCategory).WithMany(p => p.Guilds)
-                .OnDelete(DeleteBehavior.SetNull)
-                .HasConstraintName("guilds_categories_fk");
+            entity.HasOne(d => d.PublicUpdatesChannel).WithMany(p => p.GuildPublicUpdatesChannels).HasConstraintName("FK_guild_public_updates_channel_id");
 
-            entity.HasOne(d => d.PublicUpdatesChannel).WithMany(p => p.GuildPublicUpdatesChannels).HasConstraintName("FK_8d450b016dc8bec35f36729e4b0");
+            entity.HasOne(d => d.RulesChannel).WithMany(p => p.GuildRulesChannels).HasConstraintName("FK_guild_rules_channel_id");
 
-            entity.HasOne(d => d.RulesChannel).WithMany(p => p.GuildRulesChannels).HasConstraintName("FK_95828668aa333460582e0ca6396");
+            entity.HasOne(d => d.SystemChannel).WithMany(p => p.GuildSystemChannels).HasConstraintName("FK_guild_system_channel_id");
 
-            entity.HasOne(d => d.SystemChannel).WithMany(p => p.GuildSystemChannels).HasConstraintName("FK_cfc3d3ad260f8121c95b31a1fce");
+            entity.HasOne(d => d.Template).WithMany(p => p.Guilds).HasConstraintName("FK_guild_template_id");
 
-            entity.HasOne(d => d.Template).WithMany(p => p.Guilds).HasConstraintName("FK_e2a2f873a64a5cf62526de42325");
-
-            entity.HasOne(d => d.WidgetChannel).WithMany(p => p.GuildWidgetChannels).HasConstraintName("FK_9d1d665379eefde7876a17afa99");
+            entity.HasOne(d => d.WidgetChannel).WithMany(p => p.GuildWidgetChannels).HasConstraintName("FK_guild_widget_channel_id");
         });
 
         modelBuilder.Entity<InstanceBan>(entity =>
         {
             entity.HasKey(e => e.Id).HasName("PK_3aa6e80a6d325601054892b1340");
 
-            entity.HasIndex(e => e.Fingerprint, "instance_bans_fingerprint_idx").HasMethod("hash");
+            entity.HasIndex(e => e.Fingerprint, "IDX_instance_ban_fingerprint").HasMethod("hash");
 
-            entity.HasIndex(e => e.IpAddress, "instance_bans_ip_address_idx").HasMethod("hash");
+            entity.HasIndex(e => e.IpAddress, "IDX_instance_ban_ip_address").HasMethod("hash");
 
-            entity.HasIndex(e => e.UserId, "instance_bans_user_id_idx").HasMethod("hash");
+            entity.HasIndex(e => e.UserId, "IDX_instance_ban_user_id").HasMethod("hash");
 
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
 
             entity.HasOne(d => d.OriginInstanceBan).WithOne(p => p.InverseOriginInstanceBan)
                 .OnDelete(DeleteBehavior.SetNull)
-                .HasConstraintName("FK_0b02d18d0d830f160c921192a30");
+                .HasConstraintName("FK_origin_instance_ban_id");
         });
 
         modelBuilder.Entity<Invite>(entity =>
@@ -356,38 +343,38 @@ public partial class SpacebarDbContext : DbContext
 
             entity.HasOne(d => d.Channel).WithMany(p => p.Invites)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_6a15b051fe5050aa00a4b9ff0f6");
+                .HasConstraintName("FK_invite_channel_id");
 
             entity.HasOne(d => d.Guild).WithMany(p => p.Invites)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_3f4939aa1461e8af57fea3fb05d");
+                .HasConstraintName("FK_invite_guild_id");
 
             entity.HasOne(d => d.Inviter).WithMany(p => p.InviteInviters)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_15c35422032e0b22b4ada95f48f");
+                .HasConstraintName("FK_invite_inviter_id");
 
             entity.HasOne(d => d.TargetUser).WithMany(p => p.InviteTargetUsers)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_11a0d394f8fc649c19ce5f16b59");
+                .HasConstraintName("FK_invite_target_user_id");
         });
 
         modelBuilder.Entity<Member>(entity =>
         {
             entity.HasKey(e => e.Index).HasName("PK_b4a6b8c2478e5df990909c6cf6a");
 
-            entity.HasOne(d => d.Guild).WithMany(p => p.Members).HasConstraintName("FK_16aceddd5b89825b8ed6029ad1c");
+            entity.HasOne(d => d.Guild).WithMany(p => p.Members).HasConstraintName("FK_member_guild_id");
 
-            entity.HasOne(d => d.IdNavigation).WithMany(p => p.Members).HasConstraintName("FK_28b53062261b996d9c99fa12404");
+            entity.HasOne(d => d.IdNavigation).WithMany(p => p.Members).HasConstraintName("FK_member_user_id");
 
             entity.HasMany(d => d.Roles).WithMany(p => p.Indices)
                 .UsingEntity<Dictionary<string, object>>(
                     "MemberRole",
                     r => r.HasOne<Role>().WithMany()
                         .HasForeignKey("RoleId")
-                        .HasConstraintName("FK_e9080e7a7997a0170026d5139c1"),
+                        .HasConstraintName("FK_member_role_role_id"),
                     l => l.HasOne<Member>().WithMany()
                         .HasForeignKey("Index")
-                        .HasConstraintName("FK_5d7ddc8a5f9c167f548625e772e"),
+                        .HasConstraintName("FK_member_role_member_index"),
                     j =>
                     {
                         j.HasKey("Index", "RoleId").HasName("PK_951c1d72a0fd1da8760b4a1fd66");
@@ -407,108 +394,108 @@ public partial class SpacebarDbContext : DbContext
             entity.Property(e => e.MessageSnapshots).HasDefaultValueSql("'[]'::jsonb");
             entity.Property(e => e.Timestamp).HasDefaultValueSql("now()");
 
-            entity.HasOne(d => d.Application).WithMany(p => p.Messages).HasConstraintName("FK_5d3ec1cb962de6488637fd779d6");
+            entity.HasOne(d => d.Application).WithMany(p => p.Messages).HasConstraintName("FK_message_application_id");
 
             entity.HasOne(d => d.Author).WithMany(p => p.MessageAuthors)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_05535bc695e9f7ee104616459d3");
+                .HasConstraintName("FK_message_author_id");
 
             entity.HasOne(d => d.Channel).WithMany(p => p.MessageChannels)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_86b9109b155eb70c0a2ca3b4b6d");
+                .HasConstraintName("FK_message_channel_id");
 
             entity.HasOne(d => d.Guild).WithMany(p => p.Messages)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_b193588441b085352a4c0109423");
+                .HasConstraintName("FK_message_guild_id");
 
             entity.HasOne(d => d.Member).WithMany(p => p.MessageMembers)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_b0525304f2262b7014245351c76");
+                .HasConstraintName("FK_message_member_id");
 
             entity.HasOne(d => d.MessageReferenceNavigation).WithMany(p => p.InverseMessageReferenceNavigation)
                 .OnDelete(DeleteBehavior.SetNull)
-                .HasConstraintName("FK_61a92bb65b302a76d9c1fcd3174");
+                .HasConstraintName("FK_message_message_reference_id");
 
             entity.HasOne(d => d.Thread).WithMany(p => p.MessageThreads)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_bb3af7f695d50083e6523290d41");
+                .HasConstraintName("FK_message_thread_id");
 
-            entity.HasOne(d => d.Webhook).WithMany(p => p.Messages).HasConstraintName("FK_f83c04bcf1df4e5c0e7a52ed348");
+            entity.HasOne(d => d.Webhook).WithMany(p => p.Messages).HasConstraintName("FK_message_webhook_id");
 
             entity.HasMany(d => d.Channels).WithMany(p => p.Messages)
                 .UsingEntity<Dictionary<string, object>>(
                     "MessageChannelMention",
                     r => r.HasOne<Channel>().WithMany()
-                        .HasForeignKey("ChannelsId")
-                        .HasConstraintName("FK_bdb8c09e1464cabf62105bf4b9d"),
+                        .HasForeignKey("ChannelId")
+                        .HasConstraintName("FK_message_channel_mentions_channel_id"),
                     l => l.HasOne<Message>().WithMany()
-                        .HasForeignKey("MessagesId")
-                        .HasConstraintName("FK_2a27102ecd1d81b4582a4360921"),
+                        .HasForeignKey("MessageId")
+                        .HasConstraintName("FK_message_channel_mentions_message_id"),
                     j =>
                     {
-                        j.HasKey("MessagesId", "ChannelsId").HasName("PK_85cb45351497cd9d06a79ced65e");
+                        j.HasKey("MessageId", "ChannelId").HasName("PK_85cb45351497cd9d06a79ced65e");
                         j.ToTable("message_channel_mentions");
-                        j.HasIndex(new[] { "MessagesId" }, "IDX_2a27102ecd1d81b4582a436092");
-                        j.HasIndex(new[] { "ChannelsId" }, "IDX_bdb8c09e1464cabf62105bf4b9");
-                        j.IndexerProperty<long>("MessagesId").HasColumnName("messagesId");
-                        j.IndexerProperty<long>("ChannelsId").HasColumnName("channelsId");
+                        j.HasIndex(new[] { "ChannelId" }, "IDX_32f530caa79d0e7d295eb59f62");
+                        j.HasIndex(new[] { "MessageId" }, "IDX_900f52a6d0f53bdcb2e9079017");
+                        j.IndexerProperty<long>("MessageId").HasColumnName("message_id");
+                        j.IndexerProperty<long>("ChannelId").HasColumnName("channel_id");
                     });
 
             entity.HasMany(d => d.Roles).WithMany(p => p.Messages)
                 .UsingEntity<Dictionary<string, object>>(
                     "MessageRoleMention",
                     r => r.HasOne<Role>().WithMany()
-                        .HasForeignKey("RolesId")
-                        .HasConstraintName("FK_29d63eb1a458200851bc37d074b"),
+                        .HasForeignKey("RoleId")
+                        .HasConstraintName("FK_message_role_mentions_role_id"),
                     l => l.HasOne<Message>().WithMany()
-                        .HasForeignKey("MessagesId")
-                        .HasConstraintName("FK_a8242cf535337a490b0feaea0b4"),
+                        .HasForeignKey("MessageId")
+                        .HasConstraintName("FK_message_role_mentions_message_id"),
                     j =>
                     {
-                        j.HasKey("MessagesId", "RolesId").HasName("PK_74dba92cc300452a6e14b83ed44");
+                        j.HasKey("MessageId", "RoleId").HasName("PK_74dba92cc300452a6e14b83ed44");
                         j.ToTable("message_role_mentions");
-                        j.HasIndex(new[] { "RolesId" }, "IDX_29d63eb1a458200851bc37d074");
-                        j.HasIndex(new[] { "MessagesId" }, "IDX_a8242cf535337a490b0feaea0b");
-                        j.IndexerProperty<long>("MessagesId").HasColumnName("messagesId");
-                        j.IndexerProperty<long>("RolesId").HasColumnName("rolesId");
+                        j.HasIndex(new[] { "MessageId" }, "IDX_30114cbe788f0affbd8b8bf1f1");
+                        j.HasIndex(new[] { "RoleId" }, "IDX_ce866308ad8ddf9b6abce06b33");
+                        j.IndexerProperty<long>("MessageId").HasColumnName("message_id");
+                        j.IndexerProperty<long>("RoleId").HasColumnName("role_id");
                     });
 
             entity.HasMany(d => d.Stickers).WithMany(p => p.Messages)
                 .UsingEntity<Dictionary<string, object>>(
                     "MessageSticker",
                     r => r.HasOne<Sticker>().WithMany()
-                        .HasForeignKey("StickersId")
-                        .HasConstraintName("FK_e22a70819d07659c7a71c112a1f"),
+                        .HasForeignKey("StickerId")
+                        .HasConstraintName("FK_message_stickers_sticker_id"),
                     l => l.HasOne<Message>().WithMany()
-                        .HasForeignKey("MessagesId")
-                        .HasConstraintName("FK_40bb6f23e7cc133292e92829d28"),
+                        .HasForeignKey("MessageId")
+                        .HasConstraintName("FK_message_stickers_message_id"),
                     j =>
                     {
-                        j.HasKey("MessagesId", "StickersId").HasName("PK_ed820c4093d0b8cd1d2bcf66087");
+                        j.HasKey("MessageId", "StickerId").HasName("PK_ed820c4093d0b8cd1d2bcf66087");
                         j.ToTable("message_stickers");
-                        j.HasIndex(new[] { "MessagesId" }, "IDX_40bb6f23e7cc133292e92829d2");
-                        j.HasIndex(new[] { "StickersId" }, "IDX_e22a70819d07659c7a71c112a1");
-                        j.IndexerProperty<long>("MessagesId").HasColumnName("messagesId");
-                        j.IndexerProperty<long>("StickersId").HasColumnName("stickersId");
+                        j.HasIndex(new[] { "StickerId" }, "IDX_2b34e1145cafb79c6c5c193d12");
+                        j.HasIndex(new[] { "MessageId" }, "IDX_724f8b11056c706429933bdf87");
+                        j.IndexerProperty<long>("MessageId").HasColumnName("message_id");
+                        j.IndexerProperty<long>("StickerId").HasColumnName("sticker_id");
                     });
 
             entity.HasMany(d => d.Users).WithMany(p => p.Messages)
                 .UsingEntity<Dictionary<string, object>>(
                     "MessageUserMention",
                     r => r.HasOne<User>().WithMany()
-                        .HasForeignKey("UsersId")
-                        .HasConstraintName("FK_b831eb18ceebd28976239b1e2f8"),
+                        .HasForeignKey("UserId")
+                        .HasConstraintName("FK_message_mentions_user_id"),
                     l => l.HasOne<Message>().WithMany()
-                        .HasForeignKey("MessagesId")
-                        .HasConstraintName("FK_a343387fc560ef378760681c236"),
+                        .HasForeignKey("MessageId")
+                        .HasConstraintName("FK_message_mentions_message_id"),
                     j =>
                     {
-                        j.HasKey("MessagesId", "UsersId").HasName("PK_9b9b6e245ad47a48dbd7605d4fb");
+                        j.HasKey("MessageId", "UserId").HasName("PK_9b9b6e245ad47a48dbd7605d4fb");
                         j.ToTable("message_user_mentions");
-                        j.HasIndex(new[] { "MessagesId" }, "IDX_a343387fc560ef378760681c23");
-                        j.HasIndex(new[] { "UsersId" }, "IDX_b831eb18ceebd28976239b1e2f");
-                        j.IndexerProperty<long>("MessagesId").HasColumnName("messagesId");
-                        j.IndexerProperty<long>("UsersId").HasColumnName("usersId");
+                        j.HasIndex(new[] { "UserId" }, "IDX_16395c9069e88c5f93cd658e9a");
+                        j.HasIndex(new[] { "MessageId" }, "IDX_972e8e013af7698f8aa8bc3fc8");
+                        j.IndexerProperty<long>("MessageId").HasColumnName("message_id");
+                        j.IndexerProperty<long>("UserId").HasColumnName("user_id");
                     });
         });
 
@@ -525,11 +512,11 @@ public partial class SpacebarDbContext : DbContext
 
             entity.HasOne(d => d.Owner).WithMany(p => p.NoteOwners)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_f9e103f8ae67cb1787063597925");
+                .HasConstraintName("FK_note_owner_id");
 
             entity.HasOne(d => d.Target).WithMany(p => p.NoteTargets)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_23e08e5b4481711d573e1abecdc");
+                .HasConstraintName("FK_note_target_id");
         });
 
         modelBuilder.Entity<RateLimit>(entity =>
@@ -545,9 +532,9 @@ public partial class SpacebarDbContext : DbContext
 
             entity.Property(e => e.Id).ValueGeneratedNever();
 
-            entity.HasOne(d => d.Channel).WithMany(p => p.ReadStates).HasConstraintName("FK_40da2fca4e0eaf7a23b5bfc5d34");
+            entity.HasOne(d => d.Channel).WithMany(p => p.ReadStates).HasConstraintName("FK_read_state_channel_id");
 
-            entity.HasOne(d => d.User).WithMany(p => p.ReadStates).HasConstraintName("FK_195f92e4dd1254a4e348c043763");
+            entity.HasOne(d => d.User).WithMany(p => p.ReadStates).HasConstraintName("FK_read_state_user_id");
         });
 
         modelBuilder.Entity<Recipient>(entity =>
@@ -556,9 +543,9 @@ public partial class SpacebarDbContext : DbContext
 
             entity.Property(e => e.Id).ValueGeneratedNever();
 
-            entity.HasOne(d => d.Channel).WithMany(p => p.Recipients).HasConstraintName("FK_2f18ee1ba667f233ae86c0ea60e");
+            entity.HasOne(d => d.Channel).WithMany(p => p.Recipients).HasConstraintName("FK_recipient_channel_id");
 
-            entity.HasOne(d => d.User).WithMany(p => p.Recipients).HasConstraintName("FK_6157e8b6ba4e6e3089616481fe2");
+            entity.HasOne(d => d.User).WithMany(p => p.Recipients).HasConstraintName("FK_recipient_user_id");
         });
 
         modelBuilder.Entity<Relationship>(entity =>
@@ -567,9 +554,16 @@ public partial class SpacebarDbContext : DbContext
 
             entity.Property(e => e.Id).ValueGeneratedNever();
 
-            entity.HasOne(d => d.From).WithMany(p => p.RelationshipFroms).HasConstraintName("FK_9af4194bab1250b1c584ae4f1d7");
+            entity.HasOne(d => d.From).WithMany(p => p.RelationshipFroms).HasConstraintName("FK_relationship_from_id");
 
-            entity.HasOne(d => d.To).WithMany(p => p.RelationshipTos).HasConstraintName("FK_9c7f6b98a9843b76dce1b0c878b");
+            entity.HasOne(d => d.To).WithMany(p => p.RelationshipTos).HasConstraintName("FK_relationship_to_id");
+        });
+
+        modelBuilder.Entity<ReportMenu>(entity =>
+        {
+            entity.HasKey(e => e.Id).HasName("PK_1b5d649a189d57579d558ace79f");
+
+            entity.Property(e => e.Id).ValueGeneratedNever();
         });
 
         modelBuilder.Entity<Role>(entity =>
@@ -578,7 +572,7 @@ public partial class SpacebarDbContext : DbContext
 
             entity.Property(e => e.Id).ValueGeneratedNever();
 
-            entity.HasOne(d => d.Guild).WithMany(p => p.Roles).HasConstraintName("FK_c32c1ab1c4dc7dcb0278c4b1b8b");
+            entity.HasOne(d => d.Guild).WithMany(p => p.Roles).HasConstraintName("FK_role_guild_id");
         });
 
         modelBuilder.Entity<SecurityKey>(entity =>
@@ -589,7 +583,7 @@ public partial class SpacebarDbContext : DbContext
 
             entity.HasOne(d => d.User).WithMany(p => p.SecurityKeys)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_24c97d0771cafedce6d7163eaad");
+                .HasConstraintName("FK_security_key_user_id");
         });
 
         modelBuilder.Entity<SecuritySetting>(entity =>
@@ -606,7 +600,7 @@ public partial class SpacebarDbContext : DbContext
             entity.Property(e => e.Activities).HasDefaultValueSql("'[]'::jsonb");
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
 
-            entity.HasOne(d => d.User).WithMany(p => p.Sessions).HasConstraintName("FK_085d540d9f418cfbdc7bd55bb19");
+            entity.HasOne(d => d.User).WithMany(p => p.Sessions).HasConstraintName("FK_session_user_id");
         });
 
         modelBuilder.Entity<Sticker>(entity =>
@@ -617,15 +611,15 @@ public partial class SpacebarDbContext : DbContext
 
             entity.HasOne(d => d.Guild).WithMany(p => p.Stickers)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_193d551d852aca5347ef5c9f205");
+                .HasConstraintName("FK_sticker_guild_id");
 
             entity.HasOne(d => d.Pack).WithMany(p => p.Stickers)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_e7cfa5cefa6661b3fb8fda8ce69");
+                .HasConstraintName("FK_sticker_pack_id");
 
             entity.HasOne(d => d.User).WithMany(p => p.Stickers)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_8f4ee73f2bb2325ff980502e158");
+                .HasConstraintName("FK_sticker_user_id");
         });
 
         modelBuilder.Entity<StickerPack>(entity =>
@@ -634,7 +628,7 @@ public partial class SpacebarDbContext : DbContext
 
             entity.Property(e => e.Id).ValueGeneratedNever();
 
-            entity.HasOne(d => d.CoverStickerId1Navigation).WithMany(p => p.StickerPacks).HasConstraintName("FK_448fafba4355ee1c837bbc865f1");
+            entity.HasOne(d => d.CoverStickerId1Navigation).WithMany(p => p.StickerPacks).HasConstraintName("FK_sticker_pack_cover_sticker_id");
         });
 
         modelBuilder.Entity<Stream>(entity =>
@@ -643,9 +637,9 @@ public partial class SpacebarDbContext : DbContext
 
             entity.Property(e => e.Id).ValueGeneratedNever();
 
-            entity.HasOne(d => d.Channel).WithMany(p => p.Streams).HasConstraintName("FK_5101f0cded27ff0aae78fc4eed7");
+            entity.HasOne(d => d.Channel).WithMany(p => p.Streams).HasConstraintName("FK_stream_channel_id");
 
-            entity.HasOne(d => d.Owner).WithMany(p => p.Streams).HasConstraintName("FK_1b566f9b54d1cda271da53ac82f");
+            entity.HasOne(d => d.Owner).WithMany(p => p.Streams).HasConstraintName("FK_stream_owner_id");
         });
 
         modelBuilder.Entity<StreamSession>(entity =>
@@ -654,9 +648,9 @@ public partial class SpacebarDbContext : DbContext
 
             entity.Property(e => e.Id).ValueGeneratedNever();
 
-            entity.HasOne(d => d.Stream).WithMany(p => p.StreamSessions).HasConstraintName("FK_8b5a028a34dae9ee54af37c9c32");
+            entity.HasOne(d => d.Stream).WithMany(p => p.StreamSessions).HasConstraintName("FK_stream_session_stream_id");
 
-            entity.HasOne(d => d.User).WithMany(p => p.StreamSessions).HasConstraintName("FK_13ae5c29aff4d0890c54179511a");
+            entity.HasOne(d => d.User).WithMany(p => p.StreamSessions).HasConstraintName("FK_stream_session_user_id");
         });
 
         modelBuilder.Entity<Tag>(entity =>
@@ -665,7 +659,7 @@ public partial class SpacebarDbContext : DbContext
 
             entity.Property(e => e.Id).ValueGeneratedNever();
 
-            entity.HasOne(d => d.Channel).WithMany(p => p.Tags).HasConstraintName("FK_2e2df07f6dacc12e1932b361fe4");
+            entity.HasOne(d => d.Channel).WithMany(p => p.Tags).HasConstraintName("FK_tag_channel_id");
         });
 
         modelBuilder.Entity<Team>(entity =>
@@ -674,7 +668,7 @@ public partial class SpacebarDbContext : DbContext
 
             entity.Property(e => e.Id).ValueGeneratedNever();
 
-            entity.HasOne(d => d.OwnerUser).WithMany(p => p.Teams).HasConstraintName("FK_13f00abf7cb6096c43ecaf8c108");
+            entity.HasOne(d => d.OwnerUser).WithMany(p => p.Teams).HasConstraintName("FK_team_owner_user_id");
         });
 
         modelBuilder.Entity<TeamMember>(entity =>
@@ -685,11 +679,11 @@ public partial class SpacebarDbContext : DbContext
 
             entity.HasOne(d => d.Team).WithMany(p => p.TeamMembers)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_fdad7d5768277e60c40e01cdcea");
+                .HasConstraintName("FK_team_member_team_id");
 
             entity.HasOne(d => d.User).WithMany(p => p.TeamMembers)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_c2bf4967c8c2a6b845dadfbf3d4");
+                .HasConstraintName("FK_team_member_user_id");
         });
 
         modelBuilder.Entity<Template>(entity =>
@@ -698,20 +692,20 @@ public partial class SpacebarDbContext : DbContext
 
             entity.Property(e => e.Id).ValueGeneratedNever();
 
-            entity.HasOne(d => d.Creator).WithMany(p => p.Templates).HasConstraintName("FK_d7374b7f8f5fbfdececa4fb62e1");
+            entity.HasOne(d => d.Creator).WithMany(p => p.Templates).HasConstraintName("FK_template_creator_id");
 
             entity.HasOne(d => d.SourceGuild).WithMany(p => p.Templates)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_445d00eaaea0e60a017a5ed0c11");
+                .HasConstraintName("FK_template_source_guild_id");
         });
 
         modelBuilder.Entity<ThreadMember>(entity =>
         {
             entity.HasKey(e => e.Index).HasName("PK_22232a9f7a08fb9967a9c78da53");
 
-            entity.HasOne(d => d.IdNavigation).WithMany(p => p.ThreadMembers).HasConstraintName("FK_cf20e37d71b0e1bf1ab633861c8");
+            entity.HasOne(d => d.IdNavigation).WithMany(p => p.ThreadMembers).HasConstraintName("FK_thread_member_channel_id");
 
-            entity.HasOne(d => d.MemberIdxNavigation).WithMany(p => p.ThreadMembers).HasConstraintName("FK_4721015b4e24ad29da55dbd2de0");
+            entity.HasOne(d => d.MemberIdxNavigation).WithMany(p => p.ThreadMembers).HasConstraintName("FK_thread_member_member_id");
         });
 
         modelBuilder.Entity<User>(entity =>
@@ -720,7 +714,7 @@ public partial class SpacebarDbContext : DbContext
 
             entity.Property(e => e.Id).ValueGeneratedNever();
 
-            entity.HasOne(d => d.SettingsIndexNavigation).WithOne(p => p.User).HasConstraintName("FK_0c14beb78d8c5ccba66072adbc7");
+            entity.HasOne(d => d.SettingsIndexNavigation).WithOne(p => p.User).HasConstraintName("FK_user_settings_index");
         });
 
         modelBuilder.Entity<UserSetting>(entity =>
@@ -736,7 +730,7 @@ public partial class SpacebarDbContext : DbContext
 
             entity.HasOne(d => d.User).WithOne(p => p.UserSettingsProto)
                 .OnDelete(DeleteBehavior.ClientSetNull)
-                .HasConstraintName("FK_8ff3d1961a48b693810c9f99853");
+                .HasConstraintName("FK_user_settings_proto_user_id");
         });
 
         modelBuilder.Entity<ValidRegistrationToken>(entity =>
@@ -752,15 +746,15 @@ public partial class SpacebarDbContext : DbContext
 
             entity.HasOne(d => d.Channel).WithMany(p => p.VoiceStates)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_9f8d389866b40b6657edd026dd4");
+                .HasConstraintName("FK_voice_state_channel_id");
 
             entity.HasOne(d => d.Guild).WithMany(p => p.VoiceStates)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_03779ef216d4b0358470d9cb748");
+                .HasConstraintName("FK_voice_state_guild_id");
 
             entity.HasOne(d => d.User).WithMany(p => p.VoiceStates)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_5fe1d5f931a67e85039c640001b");
+                .HasConstraintName("FK_voice_state_user_id");
         });
 
         modelBuilder.Entity<Webhook>(entity =>
@@ -769,27 +763,29 @@ public partial class SpacebarDbContext : DbContext
 
             entity.Property(e => e.Id).ValueGeneratedNever();
 
-            entity.HasOne(d => d.Application).WithMany(p => p.Webhooks).HasConstraintName("FK_c3e5305461931763b56aa905f1c");
+            entity.HasOne(d => d.Application).WithMany(p => p.Webhooks)
+                .OnDelete(DeleteBehavior.Cascade)
+                .HasConstraintName("FK_webhook_application_id");
 
             entity.HasOne(d => d.Channel).WithMany(p => p.WebhookChannels)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_df528cf77e82f8032230e7e37d8");
+                .HasConstraintName("FK_webhook_channel_id");
 
             entity.HasOne(d => d.Guild).WithMany(p => p.WebhookGuilds)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_487a7af59d189f744fe394368fc");
+                .HasConstraintName("FK_webhook_guild_id");
 
             entity.HasOne(d => d.SourceChannel).WithMany(p => p.WebhookSourceChannels)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_4495b7032a33c6b8b605d030398");
+                .HasConstraintName("FK_webhook_source_channel_id");
 
             entity.HasOne(d => d.SourceGuild).WithMany(p => p.WebhookSourceGuilds)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_3a285f4f49c40e0706d3018bc9f");
+                .HasConstraintName("FK_webhook_source_guild_id");
 
             entity.HasOne(d => d.User).WithMany(p => p.Webhooks)
                 .OnDelete(DeleteBehavior.Cascade)
-                .HasConstraintName("FK_0d523f6f997c86e052c49b1455f");
+                .HasConstraintName("FK_webhook_user_id");
         });
 
         OnModelCreatingPartial(modelBuilder);

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/Application.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/Application.cs
@@ -87,7 +87,7 @@ public partial class Application
     public string? PrivacyPolicyUrl { get; set; }
 
     [Column("owner_id")]
-    public long? OwnerId { get; set; }
+    public long OwnerId { get; set; }
 
     [Column("bot_user_id")]
     public long? BotUserId { get; set; }
@@ -100,9 +100,6 @@ public partial class Application
 
     [Column("custom_install_url", TypeName = "character varying")]
     public string? CustomInstallUrl { get; set; }
-
-    [InverseProperty("Application")]
-    public virtual ICollection<ApplicationCommand> ApplicationCommands { get; set; } = new List<ApplicationCommand>();
 
     [ForeignKey("BotUserId")]
     [InverseProperty("ApplicationBotUser")]
@@ -120,7 +117,7 @@ public partial class Application
 
     [ForeignKey("OwnerId")]
     [InverseProperty("ApplicationOwners")]
-    public virtual User? Owner { get; set; }
+    public virtual User Owner { get; set; } = null!;
 
     [ForeignKey("TeamId")]
     [InverseProperty("Applications")]

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/ApplicationCommand.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/ApplicationCommand.cs
@@ -19,13 +19,13 @@ public partial class ApplicationCommand
     [Column("application_id")]
     public long ApplicationId { get; set; }
 
-    [Column("guild_id", TypeName = "character varying")]
-    public string? GuildId { get; set; }
+    [Column("guild_id")]
+    public long? GuildId { get; set; }
 
     [Column("name", TypeName = "character varying")]
     public string Name { get; set; } = null!;
 
-    [Column("name_localizations")]
+    [Column("name_localizations", TypeName = "jsonb")]
     public string? NameLocalizations { get; set; }
 
     [Column("description", TypeName = "character varying")]
@@ -63,8 +63,4 @@ public partial class ApplicationCommand
 
     [Column("handler")]
     public int Handler { get; set; }
-
-    [ForeignKey("ApplicationId")]
-    [InverseProperty("ApplicationCommands")]
-    public virtual Application Application { get; set; } = null!;
 }

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/AutomodRule.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/AutomodRule.cs
@@ -49,8 +49,4 @@ public partial class AutomodRule
     [ForeignKey("CreatorId")]
     [InverseProperty("AutomodRules")]
     public virtual User? Creator { get; set; }
-
-    [ForeignKey("GuildId")]
-    [InverseProperty("AutomodRules")]
-    public virtual Guild Guild { get; set; } = null!;
 }

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/Badge.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/Badge.cs
@@ -10,8 +10,8 @@ namespace Spacebar.Models.Db.Models;
 public partial class Badge
 {
     [Key]
-    [Column("id")]
-    public long Id { get; set; }
+    [Column("id", TypeName = "character varying")]
+    public string Id { get; set; } = null!;
 
     [Column("description", TypeName = "character varying")]
     public string Description { get; set; } = null!;

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/Category.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/Category.cs
@@ -11,7 +11,7 @@ public partial class Category
 {
     [Key]
     [Column("id")]
-    public long Id { get; set; }
+    public int Id { get; set; }
 
     [Column("name", TypeName = "character varying")]
     public string? Name { get; set; }
@@ -24,7 +24,4 @@ public partial class Category
 
     [Column("icon", TypeName = "character varying")]
     public string? Icon { get; set; }
-
-    [InverseProperty("PrimaryCategory")]
-    public virtual ICollection<Guild> Guilds { get; set; } = new List<Guild>();
 }

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/Channel.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/Channel.cs
@@ -160,7 +160,7 @@ public partial class Channel
     [InverseProperty("SourceChannel")]
     public virtual ICollection<Webhook> WebhookSourceChannels { get; set; } = new List<Webhook>();
 
-    [ForeignKey("ChannelsId")]
+    [ForeignKey("ChannelId")]
     [InverseProperty("Channels")]
     public virtual ICollection<Message> Messages { get; set; } = new List<Message>();
 }

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/EmbedCache.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/EmbedCache.cs
@@ -20,7 +20,7 @@ public partial class EmbedCache
     public string? Embed { get; set; }
 
     [Column("created_at")]
-    public DateTime? CreatedAt { get; set; }
+    public DateTime CreatedAt { get; set; }
 
     [Column("embeds", TypeName = "jsonb")]
     public string? Embeds { get; set; }

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/Guild.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/Guild.cs
@@ -144,9 +144,6 @@ public partial class Guild
     public virtual ICollection<Application> Applications { get; set; } = new List<Application>();
 
     [InverseProperty("Guild")]
-    public virtual ICollection<AutomodRule> AutomodRules { get; set; } = new List<AutomodRule>();
-
-    [InverseProperty("Guild")]
     public virtual ICollection<Ban> Bans { get; set; } = new List<Ban>();
 
     [InverseProperty("Guild")]
@@ -167,10 +164,6 @@ public partial class Guild
     [ForeignKey("OwnerId")]
     [InverseProperty("Guilds")]
     public virtual User? Owner { get; set; }
-
-    [ForeignKey("PrimaryCategoryId")]
-    [InverseProperty("Guilds")]
-    public virtual Category? PrimaryCategory { get; set; }
 
     [ForeignKey("PublicUpdatesChannelId")]
     [InverseProperty("GuildPublicUpdatesChannels")]

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/Message.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/Message.cs
@@ -138,19 +138,19 @@ public partial class Message
     [InverseProperty("Messages")]
     public virtual Webhook? Webhook { get; set; }
 
-    [ForeignKey("MessagesId")]
+    [ForeignKey("MessageId")]
     [InverseProperty("Messages")]
     public virtual ICollection<Channel> Channels { get; set; } = new List<Channel>();
 
-    [ForeignKey("MessagesId")]
+    [ForeignKey("MessageId")]
     [InverseProperty("Messages")]
     public virtual ICollection<Role> Roles { get; set; } = new List<Role>();
 
-    [ForeignKey("MessagesId")]
+    [ForeignKey("MessageId")]
     [InverseProperty("Messages")]
     public virtual ICollection<Sticker> Stickers { get; set; } = new List<Sticker>();
 
-    [ForeignKey("MessagesId")]
+    [ForeignKey("MessageId")]
     [InverseProperty("Messages")]
     public virtual ICollection<User> Users { get; set; } = new List<User>();
 }

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/ReportMenu.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/ReportMenu.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Spacebar.Models.Db.Models;
+
+[Table("report_menus")]
+public partial class ReportMenu
+{
+    [Key]
+    [Column("id")]
+    public long Id { get; set; }
+
+    [Column("type")]
+    public int Type { get; set; }
+
+    [Column("variant", TypeName = "character varying")]
+    public string Variant { get; set; } = null!;
+
+    [Column("isCurrent")]
+    public bool IsCurrent { get; set; }
+
+    [Column("inherits", TypeName = "character varying")]
+    public string? Inherits { get; set; }
+
+    [Column("content", TypeName = "jsonb")]
+    public string Content { get; set; } = null!;
+}

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/Role.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/Role.cs
@@ -60,7 +60,7 @@ public partial class Role
     [InverseProperty("Roles")]
     public virtual ICollection<Member> Indices { get; set; } = new List<Member>();
 
-    [ForeignKey("RolesId")]
+    [ForeignKey("RoleId")]
     [InverseProperty("Roles")]
     public virtual ICollection<Message> Messages { get; set; } = new List<Message>();
 }

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/SecuritySetting.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/SecuritySetting.cs
@@ -22,12 +22,12 @@ public partial class SecuritySetting
     [Column("encryption_permission_mask")]
     public int EncryptionPermissionMask { get; set; }
 
-    [Column("allowed_algorithms")]
-    public string AllowedAlgorithms { get; set; } = null!;
-
     [Column("current_algorithm", TypeName = "character varying")]
     public string CurrentAlgorithm { get; set; } = null!;
 
     [Column("used_since_message", TypeName = "character varying")]
     public string? UsedSinceMessage { get; set; }
+
+    [Column("allowed_algorithms", TypeName = "character varying[]")]
+    public List<string> AllowedAlgorithms { get; set; } = null!;
 }

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/Sticker.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/Sticker.cs
@@ -55,7 +55,7 @@ public partial class Sticker
     [InverseProperty("Stickers")]
     public virtual User? User { get; set; }
 
-    [ForeignKey("StickersId")]
+    [ForeignKey("StickerId")]
     [InverseProperty("Stickers")]
     public virtual ICollection<Message> Messages { get; set; } = new List<Message>();
 }

--- a/extra/admin-api/Models/Spacebar.Models.Db/Models/User.cs
+++ b/extra/admin-api/Models/Spacebar.Models.Db/Models/User.cs
@@ -240,7 +240,7 @@ public partial class User
     [InverseProperty("User")]
     public virtual ICollection<Webhook> Webhooks { get; set; } = new List<Webhook>();
 
-    [ForeignKey("UsersId")]
+    [ForeignKey("UserId")]
     [InverseProperty("Users")]
     public virtual ICollection<Message> Messages { get; set; } = new List<Message>();
 }

--- a/extra/admin-api/outputs.nix
+++ b/extra/admin-api/outputs.nix
@@ -82,6 +82,11 @@ nixpkgs.lib.recursiveUpdate (
         };
 
         # Models
+        Spacebar-Models-Api = buildSpacebarDotnetModule {
+          name = "Spacebar.Models.Api";
+          projectFile = "Spacebar.Models.Api.csproj";
+          srcRoot = Models/Spacebar.Models.Api;
+        };
         Spacebar-Models-AdminApi = buildSpacebarDotnetModule {
           name = "Spacebar.Models.AdminApi";
           projectFile = "Spacebar.Models.AdminApi.csproj";
@@ -189,6 +194,7 @@ nixpkgs.lib.recursiveUpdate (
             proj.Spacebar-Interop-Authentication-AspNetCore
             proj.Spacebar-Interop-Replication-Abstractions
             proj.Spacebar-Interop-Replication-UnixSocket
+            proj.Spacebar-Models-Api
             proj.Spacebar-Models-Config
             proj.Spacebar-Models-Db
             proj.Spacebar-Models-Gateway

--- a/src/database/entities/Application.ts
+++ b/src/database/entities/Application.ts
@@ -54,7 +54,7 @@ export class Application extends BaseClass {
     @Column()
     verify_key: string;
 
-    @JoinColumn({ name: "owner_id" })
+    @JoinColumn({ name: "owner_id", foreignKeyConstraintName: "FK_application_owner_id" })
     @ManyToOne(() => User, { onDelete: "CASCADE" })
     owner: User;
 
@@ -66,7 +66,7 @@ export class Application extends BaseClass {
     @Column()
     flags: number = 0;
 
-    @Column({ type: "varchar", nullable: true })
+    @Column({ type: "varchar", nullable: true, array: true })
     redirect_uris: string[] = [];
 
     @Column({ nullable: true })
@@ -93,7 +93,7 @@ export class Application extends BaseClass {
     @Column({ nullable: true })
     discovery_eligibility_flags: number = 2240;
 
-    @JoinColumn({ name: "bot_user_id" })
+    @JoinColumn({ name: "bot_user_id", foreignKeyConstraintName: "FK_application_bot_user_id" })
     @OneToOne(() => User, { onDelete: "CASCADE" })
     bot?: User;
 
@@ -116,7 +116,7 @@ export class Application extends BaseClass {
     @RelationId((application: Application) => application.guild)
     guild_id?: string;
 
-    @JoinColumn({ name: "guild_id" })
+    @JoinColumn({ name: "guild_id", foreignKeyConstraintName: "FK_application_guild_id" })
     @ManyToOne(() => Guild)
     guild?: Guild; // guild to which the app is linked, e.g. a developer support server
 
@@ -134,7 +134,7 @@ export class Application extends BaseClass {
     //@Column({ nullable: true })
     //slug?: string; // if this application is a game sold, this field will be the URL slug that links to the store page
 
-    @JoinColumn({ name: "team_id" })
+    @JoinColumn({ name: "team_id", foreignKeyConstraintName: "FK_application_team_id" })
     @ManyToOne(() => Team, {
         onDelete: "CASCADE",
         nullable: true,

--- a/src/database/entities/ApplicationCommand.ts
+++ b/src/database/entities/ApplicationCommand.ts
@@ -35,10 +35,10 @@ export class ApplicationCommand extends BaseClass {
     @Column({ default: ApplicationCommandType.CHAT_INPUT })
     type?: ApplicationCommandType;
 
-    @Column()
+    @Column({ type: "int8" })
     application_id: Snowflake;
 
-    @Column({ nullable: true })
+    @Column({ type: "int8", nullable: true })
     guild_id?: Snowflake;
 
     @Column()
@@ -80,8 +80,8 @@ export class ApplicationCommand extends BaseClass {
     @Column({ nullable: true, type: "jsonb" })
     contexts?: InteractionContextType[];
 
-    @Column({ default: 0 })
-    version: Snowflake;
+    @Column({ type: "int8", default: "0::bigint" })
+    version: Snowflake; // Is this really a snowflake though? "An autoincrementing version identifier updated during substantial record changes"
 
     @Column({ default: 0 })
     handler?: ApplicationCommandHandlerType;

--- a/src/database/entities/ApplicationCommand.ts
+++ b/src/database/entities/ApplicationCommand.ts
@@ -80,7 +80,7 @@ export class ApplicationCommand extends BaseClass {
     @Column({ nullable: true, type: "jsonb" })
     contexts?: InteractionContextType[];
 
-    @Column({ type: "int8", default: "0::bigint" })
+    @Column({ type: "int8", default: 0n })
     version: Snowflake; // Is this really a snowflake though? "An autoincrementing version identifier updated during substantial record changes"
 
     @Column({ default: 0 })

--- a/src/database/entities/Attachment.ts
+++ b/src/database/entities/Attachment.ts
@@ -41,21 +41,21 @@ export class Attachment extends BaseClass {
     @Column({ nullable: true })
     content_type?: string;
 
-    @Column({ nullable: true })
+    @Column({ nullable: true, foreignKeyConstraintName: "FK_attachment_message_id" })
     @RelationId((attachment: Attachment) => attachment.message)
     message_id: string;
 
-    @Column({ nullable: true })
+    @Column({ nullable: true, foreignKeyConstraintName: "FK_attachment_channel_id" })
     @RelationId((attachment: Attachment) => attachment.channel)
     channel_id: string;
 
-    @JoinColumn({ name: "message_id" })
+    @JoinColumn({ name: "message_id", foreignKeyConstraintName: "FK_attachment_message_id" })
     @ManyToOne(() => require("./Message").Message, (message: import("./Message").Message) => message.attachments, {
         onDelete: "CASCADE",
     })
     message: import("./Message").Message;
 
-    @JoinColumn({ name: "channel_id" })
+    @JoinColumn({ name: "channel_id", foreignKeyConstraintName: "FK_attachment_channel_id" })
     @ManyToOne(() => require("./Channel").Channel, {
         onDelete: "CASCADE",
     })

--- a/src/database/entities/AuditLog.ts
+++ b/src/database/entities/AuditLog.ts
@@ -25,7 +25,7 @@ import { AuditLogChange, AuditLogEvents } from "@spacebar/schemas";
     name: "audit_logs",
 })
 export class AuditLog extends BaseClass {
-    @JoinColumn({ name: "target_id" })
+    @JoinColumn({ name: "target_id", foreignKeyConstraintName: "FK_audit_log_target_user_id" })
     @ManyToOne(() => User)
     target?: User;
 
@@ -33,7 +33,7 @@ export class AuditLog extends BaseClass {
     @RelationId((auditlog: AuditLog) => auditlog.user)
     user_id: string;
 
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_audit_log_source_user_id" })
     @ManyToOne(() => User, (user: User) => user.id)
     user: User;
 

--- a/src/database/entities/AutomodRule.ts
+++ b/src/database/entities/AutomodRule.ts
@@ -25,7 +25,7 @@ import { AutomodAction, AutomodRuleEventType, AutomodRuleTriggerMetadata, Automo
     name: "automod_rules",
 })
 export class AutomodRule extends BaseClass {
-    @JoinColumn({ name: "creator_id" })
+    @JoinColumn({ name: "creator_id", foreignKeyConstraintName: "FK_automod_rule_creator_id" })
     @ManyToOne(() => User, { onDelete: "CASCADE" })
     creator: User;
 
@@ -41,7 +41,7 @@ export class AutomodRule extends BaseClass {
     @Column({ type: "int8", array: true })
     exempt_roles: string[];
 
-    @Column()
+    @Column({ type: "int8" })
     guild_id: string;
 
     @Column()

--- a/src/database/entities/BackupCodes.ts
+++ b/src/database/entities/BackupCodes.ts
@@ -26,7 +26,7 @@ import { Config } from "@spacebar/util/util";
     name: "backup_codes",
 })
 export class BackupCode extends BaseClass {
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_backup_code_user_id" })
     @ManyToOne(() => User, { onDelete: "CASCADE" })
     user: User;
 

--- a/src/database/entities/Ban.ts
+++ b/src/database/entities/Ban.ts
@@ -29,7 +29,7 @@ export class Ban extends BaseClass {
     @RelationId((ban: Ban) => ban.user)
     user_id: string;
 
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_ban_user_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })
@@ -39,7 +39,7 @@ export class Ban extends BaseClass {
     @RelationId((ban: Ban) => ban.guild)
     guild_id: string;
 
-    @JoinColumn({ name: "guild_id" })
+    @JoinColumn({ name: "guild_id", foreignKeyConstraintName: "FK_ban_guild_id" })
     @ManyToOne(() => Guild, {
         onDelete: "CASCADE",
     })
@@ -49,7 +49,7 @@ export class Ban extends BaseClass {
     @RelationId((ban: Ban) => ban.executor)
     executor_id: string;
 
-    @JoinColumn({ name: "executor_id" })
+    @JoinColumn({ name: "executor_id", foreignKeyConstraintName: "FK_ban_executor_id" })
     @ManyToOne(() => User)
     executor: User;
 

--- a/src/database/entities/Categories.ts
+++ b/src/database/entities/Categories.ts
@@ -39,7 +39,7 @@ import { BaseClassWithoutId } from "./BaseClass";
 export class Categories extends BaseClassWithoutId {
     // Not using snowflake
 
-    @PrimaryColumn()
+    @PrimaryColumn({ type: "int4" })
     id: number;
 
     @Column({ nullable: true })

--- a/src/database/entities/Channel.ts
+++ b/src/database/entities/Channel.ts
@@ -65,14 +65,14 @@ export class Channel extends BaseClass {
     })
     thread_members?: ThreadMember[];
 
-    @Column({ nullable: true })
+    @Column({ type: "int8", nullable: true })
     last_message_id?: string;
 
     @Column({ nullable: true })
     @RelationId((channel: Channel) => channel.guild)
     guild_id?: string;
 
-    @JoinColumn({ name: "guild_id" })
+    @JoinColumn({ name: "guild_id", foreignKeyConstraintName: "FK_channel_guild_id" })
     @ManyToOne(() => Guild, (guild) => guild.channels, {
         onDelete: "CASCADE",
         nullable: true,
@@ -83,7 +83,7 @@ export class Channel extends BaseClass {
     @RelationId((channel: Channel) => channel.parent)
     parent_id: string | null;
 
-    @JoinColumn({ name: "parent_id" })
+    @JoinColumn({ name: "parent_id", foreignKeyConstraintName: "FK_channel_parent_id" })
     @ManyToOne(() => Channel)
     parent?: Channel;
 
@@ -92,7 +92,7 @@ export class Channel extends BaseClass {
     @RelationId((channel: Channel) => channel.owner)
     owner_id?: string;
 
-    @JoinColumn({ name: "owner_id" })
+    @JoinColumn({ name: "owner_id", foreignKeyConstraintName: "FK_channel_owner_id" })
     @ManyToOne(() => User)
     owner: User;
 
@@ -174,7 +174,7 @@ export class Channel extends BaseClass {
     @Column({ nullable: true })
     total_message_sent?: number;
 
-    @JoinColumn({ name: "available_tags_ids" })
+    @JoinColumn({ name: "available_tags_ids", foreignKeyConstraintName: "FK_channel_available_tag_ids" })
     @OneToMany(() => Tag, (tag: Tag) => tag.channel, {
         cascade: true,
         orphanedRowAction: "delete",

--- a/src/database/entities/CloudAttachment.ts
+++ b/src/database/entities/CloudAttachment.ts
@@ -30,7 +30,7 @@ export class CloudAttachment extends BaseClass {
     @RelationId((att: CloudAttachment) => att.user)
     userId: string;
 
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_cloud_attachment_user_id" })
     @ManyToOne(() => User, { nullable: true, onDelete: "SET NULL" })
     user?: User;
 
@@ -38,7 +38,7 @@ export class CloudAttachment extends BaseClass {
     @RelationId((att: CloudAttachment) => att.channel)
     channelId?: string; // channel the file is uploaded to
 
-    @JoinColumn({ name: "channel_id" })
+    @JoinColumn({ name: "channel_id", foreignKeyConstraintName: "FK_cloud_attachment_channel_id" })
     @ManyToOne(() => Channel, { nullable: true, onDelete: "SET NULL" })
     channel?: Channel; // channel the file is uploaded to
 

--- a/src/database/entities/ConnectedAccount.ts
+++ b/src/database/entities/ConnectedAccount.ts
@@ -32,7 +32,7 @@ export class ConnectedAccount extends BaseClass {
     @RelationId((account: ConnectedAccount) => account.user)
     user_id: string;
 
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_connected_account_user_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })

--- a/src/database/entities/EmbedCache.ts
+++ b/src/database/entities/EmbedCache.ts
@@ -17,7 +17,7 @@
 */
 
 import { BaseClass } from "./BaseClass";
-import { Entity, Column } from "typeorm";
+import { Entity, Column, CreateDateColumn } from "typeorm";
 import { Embed } from "@spacebar/schemas";
 
 @Entity({
@@ -33,6 +33,6 @@ export class EmbedCache extends BaseClass {
     @Column({ type: "jsonb", nullable: true })
     embeds?: Embed[];
 
-    @Column({ name: "created_at", type: "timestamp with time zone" })
+    @CreateDateColumn({ name: "created_at", type: "timestamp with time zone" })
     createdAt: Date;
 }

--- a/src/database/entities/Emoji.ts
+++ b/src/database/entities/Emoji.ts
@@ -55,7 +55,7 @@ export class Emoji extends BaseClass {
     @RelationId((emoji: Emoji) => emoji.user)
     user_id: string;
 
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_emoji_user_id" })
     @ManyToOne(() => User)
     user: User;
 

--- a/src/database/entities/Encryption.ts
+++ b/src/database/entities/Encryption.ts
@@ -23,10 +23,10 @@ import { BaseClass } from "./BaseClass";
     name: "security_settings",
 })
 export class SecuritySettings extends BaseClass {
-    @Column({ nullable: true })
+    @Column({ type: "int8", nullable: true })
     guild_id: string;
 
-    @Column({ nullable: true })
+    @Column({ type: "int8", nullable: true })
     channel_id: string;
 
     @Column()

--- a/src/database/entities/Guild.ts
+++ b/src/database/entities/Guild.ts
@@ -67,7 +67,7 @@ export class Guild extends BaseClass {
     @RelationId((guild: Guild) => guild.afk_channel)
     afk_channel_id?: string | null;
 
-    @JoinColumn({ name: "afk_channel_id" })
+    @JoinColumn({ name: "afk_channel_id", foreignKeyConstraintName: "FK_guild_afk_channel_id" })
     @ManyToOne(() => Channel)
     afk_channel?: Channel;
 
@@ -79,7 +79,7 @@ export class Guild extends BaseClass {
     // @Column({ nullable: true })
     // application?: string;
 
-    @JoinColumn({ name: "ban_ids" })
+    @JoinColumn({ name: "ban_ids", foreignKeyConstraintName: "FK_guild_ban_ids" })
     @OneToMany(() => Ban, (ban: Ban) => ban.guild, {
         cascade: true,
         orphanedRowAction: "delete",
@@ -105,7 +105,7 @@ export class Guild extends BaseClass {
     features: string[] = []; //TODO use enum
     //TODO: https://discord.com/developers/docs/resources/guild#guild-object-guild-features
 
-    @Column({ nullable: true })
+    @Column({ type: "int8", nullable: true })
     primary_category_id?: string; // TODO: this was number?
 
     @Column({ nullable: true })
@@ -136,7 +136,7 @@ export class Guild extends BaseClass {
     })
     members: Member[];
 
-    @JoinColumn({ name: "role_ids" })
+    @JoinColumn({ name: "role_ids", foreignKeyConstraintName: "FK_guild_role_ids" })
     @OneToMany(() => Role, (role: Role) => role.guild, {
         cascade: true,
         orphanedRowAction: "delete",
@@ -144,7 +144,7 @@ export class Guild extends BaseClass {
     })
     roles: Role[];
 
-    @JoinColumn({ name: "channel_ids" })
+    @JoinColumn({ name: "channel_ids", foreignKeyConstraintName: "FK_guild_channel_ids" })
     @OneToMany(() => Channel, (channel: Channel) => channel.guild, {
         cascade: true,
         orphanedRowAction: "delete",
@@ -155,11 +155,11 @@ export class Guild extends BaseClass {
     @RelationId((guild: Guild) => guild.template)
     template_id?: string;
 
-    @JoinColumn({ name: "template_id", referencedColumnName: "id" })
+    @JoinColumn({ name: "template_id", referencedColumnName: "id", foreignKeyConstraintName: "FK_guild_template_id" })
     @ManyToOne(() => Template)
     template: Template;
 
-    @JoinColumn({ name: "emoji_ids" })
+    @JoinColumn({ name: "emoji_ids", foreignKeyConstraintName: "FK_guild_emoji_ids" })
     @OneToMany(() => Emoji, (emoji: Emoji) => emoji.guild, {
         cascade: true,
         orphanedRowAction: "delete",
@@ -167,7 +167,7 @@ export class Guild extends BaseClass {
     })
     emojis: Emoji[];
 
-    @JoinColumn({ name: "sticker_ids" })
+    @JoinColumn({ name: "sticker_ids", foreignKeyConstraintName: "FK_guild_sticker_ids" })
     @OneToMany(() => Sticker, (sticker: Sticker) => sticker.guild, {
         cascade: true,
         orphanedRowAction: "delete",
@@ -175,7 +175,7 @@ export class Guild extends BaseClass {
     })
     stickers: Sticker[];
 
-    @JoinColumn({ name: "invite_ids" })
+    @JoinColumn({ name: "invite_ids", foreignKeyConstraintName: "FK_guild_invite_ids" })
     @OneToMany(() => Invite, (invite: Invite) => invite.guild, {
         cascade: true,
         orphanedRowAction: "delete",
@@ -183,7 +183,7 @@ export class Guild extends BaseClass {
     })
     invites: Invite[];
 
-    @JoinColumn({ name: "voice_state_ids" })
+    @JoinColumn({ name: "voice_state_ids", foreignKeyConstraintName: "FK_guild_voice_state_ids" })
     @OneToMany(() => VoiceState, (voicestate: VoiceState) => voicestate.guild, {
         cascade: true,
         orphanedRowAction: "delete",
@@ -191,7 +191,7 @@ export class Guild extends BaseClass {
     })
     voice_states: VoiceState[];
 
-    @JoinColumn({ name: "webhook_ids" })
+    @JoinColumn({ name: "webhook_ids", foreignKeyConstraintName: "FK_guild_webhook_ids" })
     @OneToMany(() => Webhook, (webhook: Webhook) => webhook.guild, {
         cascade: true,
         orphanedRowAction: "delete",
@@ -209,7 +209,7 @@ export class Guild extends BaseClass {
     @RelationId((guild: Guild) => guild.owner)
     owner_id?: string; // optional to allow for ownerless guilds
 
-    @JoinColumn({ name: "owner_id", referencedColumnName: "id" })
+    @JoinColumn({ name: "owner_id", referencedColumnName: "id", foreignKeyConstraintName: "FK_guild_owner_id" })
     @ManyToOne(() => User)
     owner?: User; // optional to allow for ownerless guilds
 
@@ -226,7 +226,7 @@ export class Guild extends BaseClass {
     @RelationId((guild: Guild) => guild.public_updates_channel)
     public_updates_channel_id: string | null;
 
-    @JoinColumn({ name: "public_updates_channel_id" })
+    @JoinColumn({ name: "public_updates_channel_id", foreignKeyConstraintName: "FK_guild_public_updates_channel_id" })
     @ManyToOne(() => Channel)
     public_updates_channel?: Channel;
 
@@ -234,7 +234,7 @@ export class Guild extends BaseClass {
     @RelationId((guild: Guild) => guild.rules_channel)
     rules_channel_id?: string | null;
 
-    @JoinColumn({ name: "rules_channel_id" })
+    @JoinColumn({ name: "rules_channel_id", foreignKeyConstraintName: "FK_guild_rules_channel_id" })
     @ManyToOne(() => Channel)
     rules_channel?: string;
 
@@ -248,7 +248,7 @@ export class Guild extends BaseClass {
     @RelationId((guild: Guild) => guild.system_channel)
     system_channel_id?: string | null;
 
-    @JoinColumn({ name: "system_channel_id" })
+    @JoinColumn({ name: "system_channel_id", foreignKeyConstraintName: "FK_guild_system_channel_id" })
     @ManyToOne(() => Channel)
     system_channel?: Channel;
 
@@ -271,7 +271,7 @@ export class Guild extends BaseClass {
     @RelationId((guild: Guild) => guild.widget_channel)
     widget_channel_id?: string;
 
-    @JoinColumn({ name: "widget_channel_id" })
+    @JoinColumn({ name: "widget_channel_id", foreignKeyConstraintName: "FK_guild_widget_channel_id" })
     @ManyToOne(() => Channel)
     widget_channel?: Channel;
 
@@ -298,10 +298,10 @@ export class Guild extends BaseClass {
     @Column({ select: false, type: "int8", array: true })
     channel_ordering: string[];
 
-    @Column()
+    @Column({ default: 0 })
     discovery_weight: number = 0;
 
-    @Column()
+    @Column({ default: false })
     discovery_excluded: boolean = false;
 
     async ToGuildSource() {

--- a/src/database/entities/InstanceBan.ts
+++ b/src/database/entities/InstanceBan.ts
@@ -30,15 +30,15 @@ export class InstanceBan extends BaseClass {
     @Column()
     reason: string;
 
-    @Index("instance_bans_user_id_idx", { type: "hash" })
+    @Index("IDX_instance_ban_user_id", { type: "hash" })
     @Column({ type: "int8", nullable: true })
     user_id?: string;
 
-    @Index("instance_bans_fingerprint_idx", { type: "hash" })
+    @Index("IDX_instance_ban_fingerprint", { type: "hash" })
     @Column({ nullable: true })
     fingerprint?: string;
 
-    @Index("instance_bans_ip_address_idx", { type: "hash" })
+    @Index("IDX_instance_ban_ip_address", { type: "hash" })
     @Column({ nullable: true })
     ip_address?: string;
 
@@ -54,7 +54,7 @@ export class InstanceBan extends BaseClass {
     @RelationId((instance_ban: InstanceBan) => instance_ban.origin_instance_ban)
     origin_instance_ban_id?: string;
 
-    @JoinColumn({ name: "origin_instance_ban_id" })
+    @JoinColumn({ name: "origin_instance_ban_id", foreignKeyConstraintName: "FK_origin_instance_ban_id" })
     @OneToOne(() => InstanceBan, { nullable: true, onDelete: "SET NULL" })
     origin_instance_ban?: InstanceBan;
 

--- a/src/database/entities/InstanceBan.ts
+++ b/src/database/entities/InstanceBan.ts
@@ -30,15 +30,15 @@ export class InstanceBan extends BaseClass {
     @Column()
     reason: string;
 
-    @Index()
-    @Column({ nullable: true })
+    @Index("instance_bans_user_id_idx", { type: "hash" })
+    @Column({ type: "int8", nullable: true })
     user_id?: string;
 
-    @Index()
+    @Index("instance_bans_fingerprint_idx", { type: "hash" })
     @Column({ nullable: true })
     fingerprint?: string;
 
-    @Index()
+    @Index("instance_bans_ip_address_idx", { type: "hash" })
     @Column({ nullable: true })
     ip_address?: string;
 

--- a/src/database/entities/Invite.ts
+++ b/src/database/entities/Invite.ts
@@ -54,7 +54,7 @@ export class Invite extends BaseClassWithoutId {
     @RelationId((invite: Invite) => invite.guild)
     guild_id: string;
 
-    @JoinColumn({ name: "guild_id" })
+    @JoinColumn({ name: "guild_id", foreignKeyConstraintName: "FK_invite_guild_id" })
     @ManyToOne(() => Guild, (guild) => guild.invites, {
         onDelete: "CASCADE",
     })
@@ -64,7 +64,7 @@ export class Invite extends BaseClassWithoutId {
     @RelationId((invite: Invite) => invite.channel)
     channel_id: string;
 
-    @JoinColumn({ name: "channel_id" })
+    @JoinColumn({ name: "channel_id", foreignKeyConstraintName: "FK_invite_channel_id" })
     @ManyToOne(() => Channel, {
         onDelete: "CASCADE",
     })
@@ -74,7 +74,7 @@ export class Invite extends BaseClassWithoutId {
     @RelationId((invite: Invite) => invite.inviter)
     inviter_id?: string;
 
-    @JoinColumn({ name: "inviter_id" })
+    @JoinColumn({ name: "inviter_id", foreignKeyConstraintName: "FK_invite_inviter_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })
@@ -84,7 +84,7 @@ export class Invite extends BaseClassWithoutId {
     @RelationId((invite: Invite) => invite.target_user)
     target_user_id: string;
 
-    @JoinColumn({ name: "target_user_id" })
+    @JoinColumn({ name: "target_user_id", foreignKeyConstraintName: "FK_invite_target_user_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })

--- a/src/database/entities/Member.ts
+++ b/src/database/entities/Member.ts
@@ -65,7 +65,7 @@ export class Member extends BaseClassWithoutId {
     @RelationId((member: Member) => member.user)
     id: string;
 
-    @JoinColumn({ name: "id" })
+    @JoinColumn({ name: "id", foreignKeyConstraintName: "FK_member_user_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })
@@ -75,7 +75,7 @@ export class Member extends BaseClassWithoutId {
     @RelationId((member: Member) => member.guild)
     guild_id: string;
 
-    @JoinColumn({ name: "guild_id" })
+    @JoinColumn({ name: "guild_id", foreignKeyConstraintName: "FK_member_guild_id" })
     @ManyToOne(() => Guild, {
         onDelete: "CASCADE",
     })
@@ -86,10 +86,15 @@ export class Member extends BaseClassWithoutId {
 
     @JoinTable({
         name: "member_roles",
-        joinColumn: { name: "index", referencedColumnName: "index" },
+        joinColumn: {
+            name: "index",
+            referencedColumnName: "index",
+            foreignKeyConstraintName: "FK_member_role_member_index",
+        },
         inverseJoinColumn: {
             name: "role_id",
             referencedColumnName: "id",
+            foreignKeyConstraintName: "FK_member_role_role_id",
         },
     })
     @ManyToMany(() => Role, { cascade: true })
@@ -113,7 +118,7 @@ export class Member extends BaseClassWithoutId {
     @Column({ type: "jsonb", select: false })
     settings: UserGuildSettings;
 
-    @Column({ nullable: true })
+    @Column({ type: "int8", nullable: true })
     last_message_id?: string;
 
     /**

--- a/src/database/entities/Message.ts
+++ b/src/database/entities/Message.ts
@@ -56,7 +56,7 @@ export class Message extends BaseClass {
     @Index()
     channel_id?: string;
 
-    @JoinColumn({ name: "channel_id" })
+    @JoinColumn({ name: "channel_id", foreignKeyConstraintName: "FK_message_channel_id" })
     @ManyToOne(() => Channel, {
         onDelete: "CASCADE",
     })
@@ -67,7 +67,7 @@ export class Message extends BaseClass {
     @JsonRemoveEmpty
     thread_id?: string;
 
-    @JoinColumn({ name: "thread_id" })
+    @JoinColumn({ name: "thread_id", foreignKeyConstraintName: "FK_message_thread_id" })
     @ManyToOne(() => Channel, {
         onDelete: "CASCADE",
     })
@@ -79,7 +79,7 @@ export class Message extends BaseClass {
     @JsonRemoveEmpty
     guild_id?: string;
 
-    @JoinColumn({ name: "guild_id" })
+    @JoinColumn({ name: "guild_id", foreignKeyConstraintName: "FK_message_guild_id" })
     @ManyToOne(() => Guild, {
         onDelete: "CASCADE",
     })
@@ -90,7 +90,7 @@ export class Message extends BaseClass {
     @Index()
     author_id?: string;
 
-    @JoinColumn({ name: "author_id", referencedColumnName: "id" })
+    @JoinColumn({ name: "author_id", referencedColumnName: "id", foreignKeyConstraintName: "FK_message_author_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })
@@ -100,7 +100,7 @@ export class Message extends BaseClass {
     @RelationId((message: Message) => message.member)
     member_id?: string;
 
-    @JoinColumn({ name: "member_id", referencedColumnName: "id" })
+    @JoinColumn({ name: "member_id", referencedColumnName: "id", foreignKeyConstraintName: "FK_message_member_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })
@@ -111,7 +111,7 @@ export class Message extends BaseClass {
     @JsonRemoveEmpty
     webhook_id?: string;
 
-    @JoinColumn({ name: "webhook_id" })
+    @JoinColumn({ name: "webhook_id", foreignKeyConstraintName: "FK_message_webhook_id" })
     @ManyToOne(() => Webhook)
     webhook?: Webhook;
 
@@ -119,7 +119,7 @@ export class Message extends BaseClass {
     @RelationId((message: Message) => message.application)
     application_id?: string;
 
-    @JoinColumn({ name: "application_id" })
+    @JoinColumn({ name: "application_id", foreignKeyConstraintName: "FK_message_application_id" })
     @ManyToOne(() => Application)
     application?: Application;
 
@@ -251,7 +251,7 @@ export class Message extends BaseClass {
         type?: number; // 0 = DEFAULT, 1 = FORWARD
     };
 
-    @JoinColumn({ name: "message_reference_id" })
+    @JoinColumn({ name: "message_reference_id", foreignKeyConstraintName: "FK_message_message_reference_id" })
     @ManyToOne(() => Message, { onDelete: "SET NULL" })
     referenced_message?: Message | null;
 

--- a/src/database/entities/Message.ts
+++ b/src/database/entities/Message.ts
@@ -139,20 +139,68 @@ export class Message extends BaseClass {
     @Column({ nullable: true })
     mention_everyone?: boolean;
 
-    @JoinTable({ name: "message_user_mentions" })
+    @JoinTable({
+        name: "message_user_mentions",
+        joinColumn: {
+            name: "message_id",
+            referencedColumnName: "id",
+            foreignKeyConstraintName: "FK_message_mentions_message_id",
+        },
+        inverseJoinColumn: {
+            name: "user_id",
+            referencedColumnName: "id",
+            foreignKeyConstraintName: "FK_message_mentions_user_id",
+        },
+    })
     @ManyToMany(() => User)
     mentions: User[];
 
-    @JoinTable({ name: "message_role_mentions" })
+    @JoinTable({
+        name: "message_role_mentions",
+        joinColumn: {
+            name: "message_id",
+            referencedColumnName: "id",
+            foreignKeyConstraintName: "FK_message_role_mentions_message_id",
+        },
+        inverseJoinColumn: {
+            name: "role_id",
+            referencedColumnName: "id",
+            foreignKeyConstraintName: "FK_message_role_mentions_role_id",
+        },
+    })
     @ManyToMany(() => Role)
     mention_roles: Role[];
 
-    @JoinTable({ name: "message_channel_mentions" })
+    @JoinTable({
+        name: "message_channel_mentions",
+        joinColumn: {
+            name: "message_id",
+            referencedColumnName: "id",
+            foreignKeyConstraintName: "FK_message_channel_mentions_message_id",
+        },
+        inverseJoinColumn: {
+            name: "channel_id",
+            referencedColumnName: "id",
+            foreignKeyConstraintName: "FK_message_channel_mentions_channel_id",
+        },
+    })
     @ManyToMany(() => Channel)
     @JsonRemoveEmpty
     mention_channels: Channel[];
 
-    @JoinTable({ name: "message_stickers" })
+    @JoinTable({
+        name: "message_stickers",
+        joinColumn: {
+            name: "message_id",
+            referencedColumnName: "id",
+            foreignKeyConstraintName: "FK_message_stickers_message_id",
+        },
+        inverseJoinColumn: {
+            name: "sticker_id",
+            referencedColumnName: "id",
+            foreignKeyConstraintName: "FK_message_stickers_sticker_id",
+        },
+    })
     @ManyToMany(() => Sticker, { cascade: true, onDelete: "CASCADE" })
     @JsonRemoveEmpty
     sticker_items?: Sticker[];

--- a/src/database/entities/Note.ts
+++ b/src/database/entities/Note.ts
@@ -25,11 +25,11 @@ import { User } from "./User";
 })
 @Unique(["owner", "target"])
 export class Note extends BaseClass {
-    @JoinColumn({ name: "owner_id" })
+    @JoinColumn({ name: "owner_id", foreignKeyConstraintName: "FK_note_owner_id" })
     @ManyToOne(() => User, { onDelete: "CASCADE" })
     owner: User;
 
-    @JoinColumn({ name: "target_id" })
+    @JoinColumn({ name: "target_id", foreignKeyConstraintName: "FK_note_target_id" })
     @ManyToOne(() => User, { onDelete: "CASCADE" })
     target: User;
 

--- a/src/database/entities/ReadState.ts
+++ b/src/database/entities/ReadState.ts
@@ -31,30 +31,30 @@ import { ReadStateFlags, ReadStateType } from "@spacebar/schemas";
 })
 @Index(["channel_id", "user_id"], { unique: true })
 export class ReadState extends BaseClass {
-    @Column()
+    @Column({ type: "int8" })
     @RelationId((read_state: ReadState) => read_state.channel)
     channel_id: string;
 
-    @JoinColumn({ name: "channel_id" })
+    @JoinColumn({ name: "channel_id", foreignKeyConstraintName: "FK_read_state_channel_id" })
     @ManyToOne(() => Channel, {
         onDelete: "CASCADE",
     })
     channel: Channel;
 
-    @Column()
+    @Column({ type: "int8" })
     @RelationId((read_state: ReadState) => read_state.user)
     user_id: string;
 
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_read_state_user_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })
     user: User;
 
-    @Column({ nullable: true })
+    @Column({ type: "int8", nullable: true })
     last_message_id?: string;
 
-    @Column({ nullable: true })
+    @Column({ type: "int8", nullable: true })
     last_acked_id?: string;
 
     @Column({ nullable: true })

--- a/src/database/entities/Recipient.ts
+++ b/src/database/entities/Recipient.ts
@@ -27,7 +27,7 @@ export class Recipient extends BaseClass {
     @RelationId((recipient: Recipient) => recipient.channel)
     channel_id: string;
 
-    @JoinColumn({ name: "channel_id" })
+    @JoinColumn({ name: "channel_id", foreignKeyConstraintName: "FK_recipient_channel_id" })
     @ManyToOne(() => require("./Channel").Channel, {
         onDelete: "CASCADE",
     })
@@ -37,7 +37,7 @@ export class Recipient extends BaseClass {
     @RelationId((recipient: Recipient) => recipient.user)
     user_id: string;
 
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_recipient_user_id" })
     @ManyToOne(() => require("./User").User, {
         onDelete: "CASCADE",
     })

--- a/src/database/entities/Relationship.ts
+++ b/src/database/entities/Relationship.ts
@@ -30,7 +30,7 @@ export class Relationship extends BaseClass {
     @RelationId((relationship: Relationship) => relationship.from)
     from_id: string;
 
-    @JoinColumn({ name: "from_id" })
+    @JoinColumn({ name: "from_id", foreignKeyConstraintName: "FK_relationship_from_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })
@@ -40,7 +40,7 @@ export class Relationship extends BaseClass {
     @RelationId((relationship: Relationship) => relationship.to)
     to_id: string;
 
-    @JoinColumn({ name: "to_id" })
+    @JoinColumn({ name: "to_id", foreignKeyConstraintName: "FK_relationship_to_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })

--- a/src/database/entities/Role.ts
+++ b/src/database/entities/Role.ts
@@ -30,7 +30,7 @@ export class Role extends BaseClass {
     @RelationId((role: Role) => role.guild)
     guild_id: string;
 
-    @JoinColumn({ name: "guild_id" })
+    @JoinColumn({ name: "guild_id", foreignKeyConstraintName: "FK_role_guild_id" })
     @ManyToOne(() => Guild, (guild) => guild.roles, {
         onDelete: "CASCADE",
     })

--- a/src/database/entities/SecurityKey.ts
+++ b/src/database/entities/SecurityKey.ts
@@ -28,7 +28,7 @@ export class SecurityKey extends BaseClass {
     @RelationId((key: SecurityKey) => key.user)
     user_id: string;
 
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_security_key_user_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })

--- a/src/database/entities/Session.ts
+++ b/src/database/entities/Session.ts
@@ -36,7 +36,7 @@ export class Session extends BaseClassWithoutId {
     @Index({})
     user_id: string;
 
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_session_user_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })

--- a/src/database/entities/Sticker.ts
+++ b/src/database/entities/Sticker.ts
@@ -42,7 +42,7 @@ export class Sticker extends BaseClass {
     @RelationId((sticker: Sticker) => sticker.pack)
     pack_id?: string;
 
-    @JoinColumn({ name: "pack_id" })
+    @JoinColumn({ name: "pack_id", foreignKeyConstraintName: "FK_sticker_pack_id" })
     @ManyToOne(() => require("./StickerPack").StickerPack, {
         onDelete: "CASCADE",
         nullable: true,
@@ -52,7 +52,7 @@ export class Sticker extends BaseClass {
     @Column({ nullable: true })
     guild_id?: string;
 
-    @JoinColumn({ name: "guild_id" })
+    @JoinColumn({ name: "guild_id", foreignKeyConstraintName: "FK_sticker_guild_id" })
     @ManyToOne(() => Guild, (guild) => guild.stickers, {
         onDelete: "CASCADE",
     })
@@ -61,7 +61,7 @@ export class Sticker extends BaseClass {
     @Column({ nullable: true })
     user_id?: string;
 
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_sticker_user_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })

--- a/src/database/entities/StickerPack.ts
+++ b/src/database/entities/StickerPack.ts
@@ -46,6 +46,6 @@ export class StickerPack extends BaseClass {
     cover_sticker_id?: string;
 
     @ManyToOne(() => Sticker, { nullable: true })
-    @JoinColumn()
+    @JoinColumn({ foreignKeyConstraintName: "FK_sticker_pack_cover_sticker_id" })
     cover_sticker?: Sticker;
 }

--- a/src/database/entities/Stream.ts
+++ b/src/database/entities/Stream.ts
@@ -11,7 +11,7 @@ export class Stream extends BaseClass {
     @RelationId((stream: Stream) => stream.owner)
     owner_id: string;
 
-    @JoinColumn({ name: "owner_id" })
+    @JoinColumn({ name: "owner_id", foreignKeyConstraintName: "FK_stream_owner_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })
@@ -21,7 +21,7 @@ export class Stream extends BaseClass {
     @RelationId((stream: Stream) => stream.channel)
     channel_id: string;
 
-    @JoinColumn({ name: "channel_id" })
+    @JoinColumn({ name: "channel_id", foreignKeyConstraintName: "FK_stream_channel_id" })
     @ManyToOne(() => Channel, {
         onDelete: "CASCADE",
     })

--- a/src/database/entities/StreamSession.ts
+++ b/src/database/entities/StreamSession.ts
@@ -11,7 +11,7 @@ export class StreamSession extends BaseClass {
     @RelationId((session: StreamSession) => session.stream)
     stream_id: string;
 
-    @JoinColumn({ name: "stream_id" })
+    @JoinColumn({ name: "stream_id", foreignKeyConstraintName: "FK_stream_session_stream_id" })
     @ManyToOne(() => Stream, {
         onDelete: "CASCADE",
     })
@@ -21,7 +21,7 @@ export class StreamSession extends BaseClass {
     @RelationId((session: StreamSession) => session.user)
     user_id: string;
 
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_stream_session_user_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })

--- a/src/database/entities/Tag.ts
+++ b/src/database/entities/Tag.ts
@@ -24,10 +24,10 @@ import { Channel } from "./Channel";
     name: "tags",
 })
 export class Tag extends BaseClass {
-    @Column()
+    @Column({ type: "int8" })
     channel_id: string;
 
-    @JoinColumn({ name: "channel_id" })
+    @JoinColumn({ name: "channel_id", foreignKeyConstraintName: "FK_tag_channel_id" })
     @ManyToOne(() => Channel, (channel) => channel.available_tags, {
         onDelete: "CASCADE",
     })
@@ -39,7 +39,7 @@ export class Tag extends BaseClass {
     @Column()
     moderated: boolean = false;
 
-    @Column({ nullable: true })
+    @Column({ nullable: true, type: "int8" })
     emoji_id?: string;
 
     @Column({ nullable: true })

--- a/src/database/entities/Team.ts
+++ b/src/database/entities/Team.ts
@@ -28,7 +28,7 @@ export class Team extends BaseClass {
     @Column({ nullable: true })
     icon?: string;
 
-    @JoinColumn({ name: "member_ids" })
+    @JoinColumn({ name: "member_ids", foreignKeyConstraintName: "FK_team_member_ids" })
     @OneToMany(() => TeamMember, (member: TeamMember) => member.team, {
         orphanedRowAction: "delete",
     })
@@ -41,7 +41,7 @@ export class Team extends BaseClass {
     @RelationId((team: Team) => team.owner_user)
     owner_user_id: string;
 
-    @JoinColumn({ name: "owner_user_id" })
+    @JoinColumn({ name: "owner_user_id", foreignKeyConstraintName: "FK_team_owner_user_id" })
     @ManyToOne(() => User)
     owner_user: User;
 }

--- a/src/database/entities/TeamMember.ts
+++ b/src/database/entities/TeamMember.ts
@@ -38,7 +38,7 @@ export class TeamMember extends BaseClass {
     @RelationId((member: TeamMember) => member.team)
     team_id: string;
 
-    @JoinColumn({ name: "team_id" })
+    @JoinColumn({ name: "team_id", foreignKeyConstraintName: "FK_team_member_team_id" })
     @ManyToOne(() => require("./Team").Team, (team: import("./Team").Team) => team.members, {
         onDelete: "CASCADE",
     })
@@ -48,7 +48,7 @@ export class TeamMember extends BaseClass {
     @RelationId((member: TeamMember) => member.user)
     user_id: string;
 
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_team_member_user_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })

--- a/src/database/entities/Template.ts
+++ b/src/database/entities/Template.ts
@@ -41,7 +41,7 @@ export class Template extends BaseClass {
     @RelationId((template: Template) => template.creator)
     creator_id: string;
 
-    @JoinColumn({ name: "creator_id" })
+    @JoinColumn({ name: "creator_id", foreignKeyConstraintName: "FK_template_creator_id" })
     @ManyToOne(() => User)
     creator: User;
 
@@ -55,7 +55,7 @@ export class Template extends BaseClass {
     @RelationId((template: Template) => template.source_guild)
     source_guild_id: string;
 
-    @JoinColumn({ name: "source_guild_id" })
+    @JoinColumn({ name: "source_guild_id", foreignKeyConstraintName: "FK_template_source_guild_id" })
     @ManyToOne(() => Guild, { onDelete: "CASCADE" })
     source_guild: Guild;
 

--- a/src/database/entities/ThreadMember.ts
+++ b/src/database/entities/ThreadMember.ts
@@ -49,7 +49,7 @@ export class ThreadMember extends BaseClassWithoutId {
     @RelationId((member: ThreadMember) => member.channel)
     id: string;
 
-    @JoinColumn({ name: "id" })
+    @JoinColumn({ name: "id", foreignKeyConstraintName: "FK_thread_member_channel_id" })
     @ManyToOne(() => Channel, {
         onDelete: "CASCADE",
     })
@@ -59,7 +59,7 @@ export class ThreadMember extends BaseClassWithoutId {
     @RelationId((member: ThreadMember) => member.member)
     member_idx: string;
 
-    @JoinColumn({ name: "member_idx" })
+    @JoinColumn({ name: "member_idx", foreignKeyConstraintName: "FK_thread_member_member_id" })
     @ManyToOne(() => Member, {
         onDelete: "CASCADE",
     })

--- a/src/database/entities/User.ts
+++ b/src/database/entities/User.ts
@@ -147,14 +147,14 @@ export class User extends BaseClass {
     @OneToMany(() => Session, (session: Session) => session.user)
     sessions: Session[];
 
-    @JoinColumn({ name: "relationship_ids" })
+    @JoinColumn({ name: "relationship_ids", foreignKeyConstraintName: "FK_user_relationship_ids" })
     @OneToMany(() => Relationship, (relationship: Relationship) => relationship.from, {
         cascade: true,
         orphanedRowAction: "delete",
     })
     relationships: Relationship[];
 
-    @JoinColumn({ name: "connected_account_ids" })
+    @JoinColumn({ name: "connected_account_ids", foreignKeyConstraintName: "FK_user_connected_account_ids" })
     @OneToMany(() => ConnectedAccount, (account: ConnectedAccount) => account.user, {
         cascade: true,
         orphanedRowAction: "delete",
@@ -175,7 +175,7 @@ export class User extends BaseClass {
         orphanedRowAction: "delete",
         nullable: true,
     })
-    @JoinColumn()
+    @JoinColumn({ foreignKeyConstraintName: "FK_user_settings_index" })
     settings?: UserSettings;
 
     @OneToMany(() => SecurityKey, (key: SecurityKey) => key.user)

--- a/src/database/entities/UserSettingsProtos.ts
+++ b/src/database/entities/UserSettingsProtos.ts
@@ -30,7 +30,7 @@ export class UserSettingsProtos extends BaseClassWithoutId {
         orphanedRowAction: "delete",
         eager: false,
     })
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_user_settings_proto_user_id" })
     user: User;
 
     @PrimaryColumn({ type: "text" })

--- a/src/database/entities/VoiceState.ts
+++ b/src/database/entities/VoiceState.ts
@@ -33,7 +33,7 @@ export class VoiceState extends BaseClass {
     @RelationId((voice_state: VoiceState) => voice_state.guild)
     guild_id: string;
 
-    @JoinColumn({ name: "guild_id" })
+    @JoinColumn({ name: "guild_id", foreignKeyConstraintName: "FK_voice_state_guild_id" })
     @ManyToOne(() => Guild, (guild) => guild.voice_states, {
         onDelete: "CASCADE",
     })
@@ -43,7 +43,7 @@ export class VoiceState extends BaseClass {
     @RelationId((voice_state: VoiceState) => voice_state.channel)
     channel_id: string;
 
-    @JoinColumn({ name: "channel_id" })
+    @JoinColumn({ name: "channel_id", foreignKeyConstraintName: "FK_voice_state_channel_id" })
     @ManyToOne(() => Channel, {
         onDelete: "CASCADE",
     })
@@ -53,7 +53,7 @@ export class VoiceState extends BaseClass {
     @RelationId((voice_state: VoiceState) => voice_state.user)
     user_id: string;
 
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_voice_state_user_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })

--- a/src/database/entities/Webhook.ts
+++ b/src/database/entities/Webhook.ts
@@ -44,7 +44,7 @@ export class Webhook extends BaseClass {
     @RelationId((webhook: Webhook) => webhook.guild)
     guild_id?: string;
 
-    @JoinColumn({ name: "guild_id" })
+    @JoinColumn({ name: "guild_id", foreignKeyConstraintName: "FK_webhook_guild_id" })
     @ManyToOne(() => Guild, {
         onDelete: "CASCADE",
     })
@@ -54,7 +54,7 @@ export class Webhook extends BaseClass {
     @RelationId((webhook: Webhook) => webhook.channel)
     channel_id: string;
 
-    @JoinColumn({ name: "channel_id" })
+    @JoinColumn({ name: "channel_id", foreignKeyConstraintName: "FK_webhook_channel_id" })
     @ManyToOne(() => Channel, {
         onDelete: "CASCADE",
     })
@@ -64,7 +64,7 @@ export class Webhook extends BaseClass {
     @RelationId((webhook: Webhook) => webhook.application)
     application_id: string;
 
-    @JoinColumn({ name: "application_id" })
+    @JoinColumn({ name: "application_id", foreignKeyConstraintName: "FK_webhook_application_id" })
     @ManyToOne(() => Application, {
         onDelete: "CASCADE",
     })
@@ -74,7 +74,7 @@ export class Webhook extends BaseClass {
     @RelationId((webhook: Webhook) => webhook.user)
     user_id: string;
 
-    @JoinColumn({ name: "user_id" })
+    @JoinColumn({ name: "user_id", foreignKeyConstraintName: "FK_webhook_user_id" })
     @ManyToOne(() => User, {
         onDelete: "CASCADE",
     })
@@ -84,7 +84,7 @@ export class Webhook extends BaseClass {
     @RelationId((webhook: Webhook) => webhook.guild)
     source_guild_id?: string;
 
-    @JoinColumn({ name: "source_guild_id" })
+    @JoinColumn({ name: "source_guild_id", foreignKeyConstraintName: "FK_webhook_source_guild_id" })
     @ManyToOne(() => Guild, {
         onDelete: "CASCADE",
     })
@@ -94,7 +94,7 @@ export class Webhook extends BaseClass {
     @RelationId((webhook: Webhook) => webhook.channel)
     source_channel_id: string;
 
-    @JoinColumn({ name: "source_channel_id" })
+    @JoinColumn({ name: "source_channel_id", foreignKeyConstraintName: "FK_webhook_source_channel_id" })
     @ManyToOne(() => Channel, {
         onDelete: "CASCADE",
     })

--- a/src/database/migration/postgres/1782925307187-MoreInt8Fixes.ts
+++ b/src/database/migration/postgres/1782925307187-MoreInt8Fixes.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MoreInt8Fixes17829253071887 implements MigrationInterface {
+    name = "MoreInt8Fixes1782925307187";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE application_commands ALTER COLUMN guild_id TYPE int8 USING guild_id::int8`);
+        await queryRunner.query(`ALTER TABLE application_commands ALTER COLUMN name_localizations TYPE jsonb USING name_localizations::jsonb`);
+        // oops, this one wasnt supposed to be an int8
+        await queryRunner.query(`ALTER TABLE badges ALTER COLUMN id TYPE character varying USING id::character varying`);
+        await queryRunner.query(`ALTER TABLE categories ALTER COLUMN id TYPE int4 USING id::int4`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE application_commands ALTER COLUMN guild_id TYPE character varying USING guild_id::character varying`);
+        await queryRunner.query(`ALTER TABLE application_commands ALTER COLUMN name_localizations TYPE character varying USING name_localizations::character varying`);
+        await queryRunner.query(`ALTER TABLE badges ALTER COLUMN id TYPE int8 USING id::int8`);
+        await queryRunner.query(`ALTER TABLE categories ALTER COLUMN id TYPE int8 USING id::int8`);
+    }
+}

--- a/src/database/migration/postgres/1782925307188-NameConstraints.ts
+++ b/src/database/migration/postgres/1782925307188-NameConstraints.ts
@@ -1,0 +1,275 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class NameConstraints1782925307188 implements MigrationInterface {
+    name = "NameConstraints1782925307188";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "instance_bans" RENAME CONSTRAINT "FK_0b02d18d0d830f160c921192a30" TO "FK_origin_instance_ban_id"`);
+
+        await queryRunner.query(`ALTER TABLE "applications" RENAME CONSTRAINT "FK_2ce5a55796fe4c2f77ece57a647" TO "FK_application_bot_user_id"`);
+        await queryRunner.query(`ALTER TABLE "applications" RENAME CONSTRAINT "FK_a36ed02953077f408d0f3ebc424" TO "FK_application_team_id"`);
+        await queryRunner.query(`ALTER TABLE "applications" RENAME CONSTRAINT "FK_e57508958bf92b9d9d25231b5e8" TO "FK_application_owner_id"`);
+        await queryRunner.query(`ALTER TABLE "applications" RENAME CONSTRAINT "FK_e5bf78cdbbe9ba91062d74c5aba" TO "FK_application_guild_id"`);
+
+        await queryRunner.query(`ALTER TABLE "attachments" RENAME CONSTRAINT "FK_623e10eec51ada466c5038979e3" TO "FK_attachment_message_id"`);
+        await queryRunner.query(`ALTER TABLE "attachments" RENAME CONSTRAINT "attachments_channels_fk" TO "FK_attachment_channel_id"`);
+
+        await queryRunner.query(`ALTER TABLE "audit_logs" RENAME CONSTRAINT "FK_3cd01cd3ae7aab010310d96ac8e" TO "FK_audit_log_target_user_id"`);
+        await queryRunner.query(`ALTER TABLE "audit_logs" RENAME CONSTRAINT "FK_bd2726fd31b35443f2245b93ba0" TO "FK_audit_log_source_user_id"`);
+
+        await queryRunner.query(`ALTER TABLE "automod_rules" RENAME CONSTRAINT "FK_12d3d60b961393d310429c062b7" TO "FK_automod_rule_creator_id"`);
+        await queryRunner.query(`ALTER TABLE "automod_rules" RENAME CONSTRAINT "automod_rules_guilds_fk" TO "FK_automod_rule_guild_id"`);
+
+        await queryRunner.query(`ALTER TABLE "bans" RENAME CONSTRAINT "FK_07ad88c86d1f290d46748410d58" TO "FK_ban_executor_id"`);
+        await queryRunner.query(`ALTER TABLE "bans" RENAME CONSTRAINT "FK_5999e8e449f80a236ff72023559" TO "FK_ban_user_id"`);
+        await queryRunner.query(`ALTER TABLE "bans" RENAME CONSTRAINT "FK_9d3ab7dd180ebdd245cdb66ecad" TO "FK_ban_guild_id"`);
+
+        await queryRunner.query(`ALTER TABLE "channels" RENAME CONSTRAINT "FK_3274522d14af40540b1a883fc80" TO "FK_channel_parent_id"`);
+        await queryRunner.query(`ALTER TABLE "channels" RENAME CONSTRAINT "FK_3873ed438575cce703ecff4fc7b" TO "FK_channel_owner_id"`);
+        await queryRunner.query(`ALTER TABLE "channels" RENAME CONSTRAINT "FK_c253dafe5f3a03ec00cd8fb4581" TO "FK_channel_guild_id"`);
+
+        await queryRunner.query(`ALTER TABLE "cloud_attachments" RENAME CONSTRAINT "FK_8bf8cc8767e48cb482ff644fce6" TO "FK_cloud_attachment_user_id"`);
+        await queryRunner.query(`ALTER TABLE "cloud_attachments" RENAME CONSTRAINT "FK_998d5fe91008ba5b09e1322104c" TO "FK_cloud_attachment_channel_id"`);
+
+        await queryRunner.query(`ALTER TABLE "connected_accounts" RENAME CONSTRAINT "FK_f47244225a6a1eac04a3463dd90" TO "FK_connected_account_user_id"`);
+
+        await queryRunner.query(`ALTER TABLE "emojis" RENAME CONSTRAINT "FK_4b988e0db89d94cebcf07f598cc" TO "FK_emoji_guild_id"`);
+        await queryRunner.query(`ALTER TABLE "emojis" RENAME CONSTRAINT "FK_fa7ddd5f9a214e28ce596548421" TO "FK_emoji_user_id"`);
+
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_8d450b016dc8bec35f36729e4b0" TO "FK_guild_public_updates_channel_id"`);
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_95828668aa333460582e0ca6396" TO "FK_guild_rules_channel_id"`);
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_9d1d665379eefde7876a17afa99" TO "FK_guild_widget_channel_id"`);
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_cfc3d3ad260f8121c95b31a1fce" TO "FK_guild_system_channel_id"`);
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_e2a2f873a64a5cf62526de42325" TO "FK_guild_template_id"`);
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_f591a66b8019d87b0fe6c12dad6" TO "FK_guild_afk_channel_id"`);
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_fc1a451727e3643ca572a3bb394" TO "FK_guild_owner_id"`);
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "guilds_categories_fk" TO "FK_guild_primary_category_id"`);
+
+        await queryRunner.query(`ALTER TABLE "invites" RENAME CONSTRAINT "FK_11a0d394f8fc649c19ce5f16b59" TO "FK_invite_target_user_id"`);
+        await queryRunner.query(`ALTER TABLE "invites" RENAME CONSTRAINT "FK_15c35422032e0b22b4ada95f48f" TO "FK_invite_inviter_id"`);
+        await queryRunner.query(`ALTER TABLE "invites" RENAME CONSTRAINT "FK_3f4939aa1461e8af57fea3fb05d" TO "FK_invite_guild_id"`);
+        await queryRunner.query(`ALTER TABLE "invites" RENAME CONSTRAINT "FK_6a15b051fe5050aa00a4b9ff0f6" TO "FK_invite_channel_id"`);
+
+        await queryRunner.query(`ALTER TABLE "member_roles" RENAME CONSTRAINT "FK_5d7ddc8a5f9c167f548625e772e" TO "FK_member_role_member_index"`);
+        await queryRunner.query(`ALTER TABLE "member_roles" RENAME CONSTRAINT "FK_e9080e7a7997a0170026d5139c1" TO "FK_member_role_role_id"`);
+
+        await queryRunner.query(`ALTER TABLE "members" RENAME CONSTRAINT "FK_16aceddd5b89825b8ed6029ad1c" TO "FK_member_guild_id"`);
+        await queryRunner.query(`ALTER TABLE "members" RENAME CONSTRAINT "FK_28b53062261b996d9c99fa12404" TO "FK_member_user_id"`);
+
+        await queryRunner.query(`ALTER TABLE "message_channel_mentions" RENAME CONSTRAINT "FK_2a27102ecd1d81b4582a4360921" TO "FK_message_channel_mention_message_id"`);
+        await queryRunner.query(`ALTER TABLE "message_channel_mentions" RENAME CONSTRAINT "FK_bdb8c09e1464cabf62105bf4b9d" TO "FK_message_channel_mention_channel_id"`);
+
+        await queryRunner.query(`ALTER TABLE "message_role_mentions" RENAME CONSTRAINT "FK_a8242cf535337a490b0feaea0b4" TO "FK_message_role_mention_message_id"`);
+        await queryRunner.query(`ALTER TABLE "message_role_mentions" RENAME CONSTRAINT "FK_29d63eb1a458200851bc37d074b" TO "FK_message_role_mention_role_id"`);
+
+        await queryRunner.query(`ALTER TABLE "message_stickers" RENAME CONSTRAINT "FK_40bb6f23e7cc133292e92829d28" TO "FK_message_stickers_message_id"`);
+        await queryRunner.query(`ALTER TABLE "message_stickers" RENAME CONSTRAINT "FK_e22a70819d07659c7a71c112a1f" TO "FK_message_stickers_sticker_id"`);
+
+        await queryRunner.query(`ALTER TABLE "message_user_mentions" RENAME CONSTRAINT "FK_a343387fc560ef378760681c236" TO "FK_message_user_mentions_message_id"`);
+        await queryRunner.query(`ALTER TABLE "message_user_mentions" RENAME CONSTRAINT "FK_b831eb18ceebd28976239b1e2f8" TO "FK_message_user_mentions_user_id"`);
+
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_05535bc695e9f7ee104616459d3" TO "FK_message_author_id"`);
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_5d3ec1cb962de6488637fd779d6" TO "FK_message_application_id"`);
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_61a92bb65b302a76d9c1fcd3174" TO "FK_message_message_reference_id"`);
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_86b9109b155eb70c0a2ca3b4b6d" TO "FK_message_channel_id"`);
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_b0525304f2262b7014245351c76" TO "FK_message_member_id"`);
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_b193588441b085352a4c0109423" TO "FK_message_guild_id"`);
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_bb3af7f695d50083e6523290d41" TO "FK_message_thread_id"`);
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_f83c04bcf1df4e5c0e7a52ed348" TO "FK_message_webhook_id"`);
+
+        await queryRunner.query(`ALTER TABLE "notes" RENAME CONSTRAINT "FK_23e08e5b4481711d573e1abecdc" TO "FK_note_target_id"`);
+        await queryRunner.query(`ALTER TABLE "notes" RENAME CONSTRAINT "FK_f9e103f8ae67cb1787063597925" TO "FK_note_owner_id"`);
+
+        await queryRunner.query(`ALTER TABLE "read_states" RENAME CONSTRAINT "FK_195f92e4dd1254a4e348c043763" TO "FK_read_state_user_id"`);
+        await queryRunner.query(`ALTER TABLE "read_states" RENAME CONSTRAINT "FK_40da2fca4e0eaf7a23b5bfc5d34" TO "FK_read_state_channel_id"`);
+
+        await queryRunner.query(`ALTER TABLE "recipients" RENAME CONSTRAINT "FK_2f18ee1ba667f233ae86c0ea60e" TO "FK_recipient_channel_id"`);
+        await queryRunner.query(`ALTER TABLE "recipients" RENAME CONSTRAINT "FK_6157e8b6ba4e6e3089616481fe2" TO "FK_recipient_user_id"`);
+
+        await queryRunner.query(`ALTER TABLE "relationships" RENAME CONSTRAINT "FK_9af4194bab1250b1c584ae4f1d7" TO "FK_relationship_from_id"`);
+        await queryRunner.query(`ALTER TABLE "relationships" RENAME CONSTRAINT "FK_9c7f6b98a9843b76dce1b0c878b" TO "FK_relationship_to_id"`);
+
+        await queryRunner.query(`ALTER TABLE "roles" RENAME CONSTRAINT "FK_c32c1ab1c4dc7dcb0278c4b1b8b" TO "FK_role_guild_id"`);
+
+        await queryRunner.query(`ALTER TABLE "security_keys" RENAME CONSTRAINT "FK_24c97d0771cafedce6d7163eaad" TO "FK_security_key_user_id"`);
+
+        await queryRunner.query(`ALTER TABLE "sessions" RENAME CONSTRAINT "FK_085d540d9f418cfbdc7bd55bb19" TO "FK_session_user_id"`);
+
+        await queryRunner.query(`ALTER TABLE "sticker_packs" RENAME CONSTRAINT "FK_448fafba4355ee1c837bbc865f1" TO "FK_sticker_pack_cover_sticker_id"`);
+
+        await queryRunner.query(`ALTER TABLE "stickers" RENAME CONSTRAINT "FK_193d551d852aca5347ef5c9f205" TO "FK_sticker_guild_id"`);
+        await queryRunner.query(`ALTER TABLE "stickers" RENAME CONSTRAINT "FK_8f4ee73f2bb2325ff980502e158" TO "FK_sticker_user_id"`);
+        await queryRunner.query(`ALTER TABLE "stickers" RENAME CONSTRAINT "FK_e7cfa5cefa6661b3fb8fda8ce69" TO "FK_sticker_pack_id"`);
+
+        await queryRunner.query(`ALTER TABLE "stream_sessions" RENAME CONSTRAINT "FK_13ae5c29aff4d0890c54179511a" TO "FK_stream_session_user_id"`);
+        await queryRunner.query(`ALTER TABLE "stream_sessions" RENAME CONSTRAINT "FK_8b5a028a34dae9ee54af37c9c32" TO "FK_stream_session_stream_id"`);
+
+        await queryRunner.query(`ALTER TABLE "streams" RENAME CONSTRAINT "FK_1b566f9b54d1cda271da53ac82f" TO "FK_stream_owner_id"`);
+        await queryRunner.query(`ALTER TABLE "streams" RENAME CONSTRAINT "FK_5101f0cded27ff0aae78fc4eed7" TO "FK_stream_channel_id"`);
+
+        await queryRunner.query(`ALTER TABLE "tags" RENAME CONSTRAINT "FK_2e2df07f6dacc12e1932b361fe4" TO "FK_tag_channel_id"`);
+
+        await queryRunner.query(`ALTER TABLE "team_members" RENAME CONSTRAINT "FK_c2bf4967c8c2a6b845dadfbf3d4" TO "FK_team_member_user_id"`);
+        await queryRunner.query(`ALTER TABLE "team_members" RENAME CONSTRAINT "FK_fdad7d5768277e60c40e01cdcea" TO "FK_team_member_team_id"`);
+
+        await queryRunner.query(`ALTER TABLE "teams" RENAME CONSTRAINT "FK_13f00abf7cb6096c43ecaf8c108" TO "FK_team_owner_user_id"`);
+
+        await queryRunner.query(`ALTER TABLE "templates" RENAME CONSTRAINT "FK_445d00eaaea0e60a017a5ed0c11" TO "FK_template_source_guild_id"`);
+        await queryRunner.query(`ALTER TABLE "templates" RENAME CONSTRAINT "FK_d7374b7f8f5fbfdececa4fb62e1" TO "FK_template_creator_id"`);
+
+        await queryRunner.query(`ALTER TABLE "thread_members" RENAME CONSTRAINT "FK_4721015b4e24ad29da55dbd2de0" TO "FK_thread_member_member_index"`);
+        await queryRunner.query(`ALTER TABLE "thread_members" RENAME CONSTRAINT "FK_cf20e37d71b0e1bf1ab633861c8" TO "FK_thread_member_channel_id"`);
+
+        await queryRunner.query(`ALTER TABLE "user_settings_protos" RENAME CONSTRAINT "FK_8ff3d1961a48b693810c9f99853" TO "FK_user_settings_proto_user_id"`);
+
+        await queryRunner.query(`ALTER TABLE "users" RENAME CONSTRAINT "FK_0c14beb78d8c5ccba66072adbc7" TO "FK_user_settings_index"`);
+
+        await queryRunner.query(`ALTER TABLE "voice_states" RENAME CONSTRAINT "FK_03779ef216d4b0358470d9cb748" TO "FK_voice_state_guild_id"`);
+        await queryRunner.query(`ALTER TABLE "voice_states" RENAME CONSTRAINT "FK_5fe1d5f931a67e85039c640001b" TO "FK_voice_state_user_id"`);
+        await queryRunner.query(`ALTER TABLE "voice_states" RENAME CONSTRAINT "FK_9f8d389866b40b6657edd026dd4" TO "FK_voice_state_channel_id"`);
+
+        await queryRunner.query(`ALTER TABLE "webhooks" RENAME CONSTRAINT "FK_0d523f6f997c86e052c49b1455f" TO "FK_webhook_user_id"`);
+        await queryRunner.query(`ALTER TABLE "webhooks" RENAME CONSTRAINT "FK_3a285f4f49c40e0706d3018bc9f" TO "FK_webhook_source_guild_id"`);
+        await queryRunner.query(`ALTER TABLE "webhooks" RENAME CONSTRAINT "FK_4495b7032a33c6b8b605d030398" TO "FK_webhook_source_channel_id"`);
+        await queryRunner.query(`ALTER TABLE "webhooks" RENAME CONSTRAINT "FK_487a7af59d189f744fe394368fc" TO "FK_webhook_guild_id"`);
+        await queryRunner.query(`ALTER TABLE "webhooks" RENAME CONSTRAINT "FK_c3e5305461931763b56aa905f1c" TO "FK_webhook_application_id"`);
+        await queryRunner.query(`ALTER TABLE "webhooks" RENAME CONSTRAINT "FK_df528cf77e82f8032230e7e37d8" TO "FK_webhook_channel_id"`);
+
+        await queryRunner.query(`ALTER TABLE "backup_codes" RENAME CONSTRAINT "FK_70066ea80d2f4b871beda32633b" TO "FK_backup_code_user_id"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "instance_bans" RENAME CONSTRAINT "FK_origin_instance_ban_id" TO "FK_0b02d18d0d830f160c921192a30"`);
+
+        await queryRunner.query(`ALTER TABLE "applications" RENAME CONSTRAINT "FK_application_bot_user_id" TO "FK_2ce5a55796fe4c2f77ece57a647"`);
+        await queryRunner.query(`ALTER TABLE "applications" RENAME CONSTRAINT "FK_application_team_id" TO "FK_a36ed02953077f408d0f3ebc424"`);
+        await queryRunner.query(`ALTER TABLE "applications" RENAME CONSTRAINT "FK_application_owner_id" TO "FK_e57508958bf92b9d9d25231b5e8"`);
+        await queryRunner.query(`ALTER TABLE "applications" RENAME CONSTRAINT "FK_application_guild_id" TO "FK_e5bf78cdbbe9ba91062d74c5aba"`);
+
+        await queryRunner.query(`ALTER TABLE "attachments" RENAME CONSTRAINT "FK_attachment_message_id" TO "FK_623e10eec51ada466c5038979e3"`);
+        await queryRunner.query(`ALTER TABLE "attachments" RENAME CONSTRAINT "FK_attachment_channel_id" TO "attachments_channels_fk"`);
+
+        await queryRunner.query(`ALTER TABLE "audit_logs" RENAME CONSTRAINT "FK_audit_log_target_user_id" TO "FK_3cd01cd3ae7aab010310d96ac8e"`);
+        await queryRunner.query(`ALTER TABLE "audit_logs" RENAME CONSTRAINT "FK_audit_log_source_user_id" TO "FK_bd2726fd31b35443f2245b93ba0"`);
+
+        await queryRunner.query(`ALTER TABLE "automod_rules" RENAME CONSTRAINT "FK_automod_rule_creator_id" TO "FK_12d3d60b961393d310429c062b7"`);
+        await queryRunner.query(`ALTER TABLE "automod_rules" RENAME CONSTRAINT "FK_automod_rule_guild_id" TO "automod_rules_guilds_fk"`);
+
+        await queryRunner.query(`ALTER TABLE "bans" RENAME CONSTRAINT "FK_ban_executor_id" TO "FK_07ad88c86d1f290d46748410d58"`);
+        await queryRunner.query(`ALTER TABLE "bans" RENAME CONSTRAINT "FK_ban_user_id" TO "FK_5999e8e449f80a236ff72023559"`);
+        await queryRunner.query(`ALTER TABLE "bans" RENAME CONSTRAINT "FK_ban_guild_id" TO "FK_9d3ab7dd180ebdd245cdb66ecad"`);
+
+        await queryRunner.query(`ALTER TABLE "channels" RENAME CONSTRAINT "FK_channel_parent_id" TO "FK_3274522d14af40540b1a883fc80"`);
+        await queryRunner.query(`ALTER TABLE "channels" RENAME CONSTRAINT "FK_channel_owner_id" TO "FK_3873ed438575cce703ecff4fc7b"`);
+        await queryRunner.query(`ALTER TABLE "channels" RENAME CONSTRAINT "FK_channel_guild_id" TO "FK_c253dafe5f3a03ec00cd8fb4581"`);
+
+        await queryRunner.query(`ALTER TABLE "cloud_attachments" RENAME CONSTRAINT "FK_cloud_attachment_user_id" TO "FK_8bf8cc8767e48cb482ff644fce6"`);
+        await queryRunner.query(`ALTER TABLE "cloud_attachments" RENAME CONSTRAINT "FK_cloud_attachment_channel_id" TO "FK_998d5fe91008ba5b09e1322104c"`);
+
+        await queryRunner.query(`ALTER TABLE "connected_accounts" RENAME CONSTRAINT "FK_connected_account_user_id" TO "FK_f47244225a6a1eac04a3463dd90"`);
+
+        await queryRunner.query(`ALTER TABLE "emojis" RENAME CONSTRAINT "FK_emoji_guild_id" TO "FK_4b988e0db89d94cebcf07f598cc"`);
+        await queryRunner.query(`ALTER TABLE "emojis" RENAME CONSTRAINT "FK_emoji_user_id" TO "FK_fa7ddd5f9a214e28ce596548421"`);
+
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_guild_public_updates_channel_id" TO "FK_8d450b016dc8bec35f36729e4b0"`);
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_guild_rules_channel_id" TO "FK_95828668aa333460582e0ca6396"`);
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_guild_widget_channel_id" TO "FK_9d1d665379eefde7876a17afa99"`);
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_guild_system_channel_id" TO "FK_cfc3d3ad260f8121c95b31a1fce"`);
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_guild_template_id" TO "FK_e2a2f873a64a5cf62526de42325"`);
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_guild_afk_channel_id" TO "FK_f591a66b8019d87b0fe6c12dad6"`);
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_guild_owner_id" TO "FK_fc1a451727e3643ca572a3bb394"`);
+        await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_guild_primary_category_id" TO "guilds_categories_fk"`);
+
+        await queryRunner.query(`ALTER TABLE "invites" RENAME CONSTRAINT "FK_invite_target_user_id" TO "FK_11a0d394f8fc649c19ce5f16b59"`);
+        await queryRunner.query(`ALTER TABLE "invites" RENAME CONSTRAINT "FK_invite_inviter_id" TO "FK_15c35422032e0b22b4ada95f48f"`);
+        await queryRunner.query(`ALTER TABLE "invites" RENAME CONSTRAINT "FK_invite_guild_id" TO "FK_3f4939aa1461e8af57fea3fb05d"`);
+        await queryRunner.query(`ALTER TABLE "invites" RENAME CONSTRAINT "FK_invite_channel_id" TO "FK_6a15b051fe5050aa00a4b9ff0f6"`);
+
+        await queryRunner.query(`ALTER TABLE "member_roles" RENAME CONSTRAINT "FK_member_role_member_index" TO "FK_5d7ddc8a5f9c167f548625e772e"`);
+        await queryRunner.query(`ALTER TABLE "member_roles" RENAME CONSTRAINT "FK_member_role_role_id" TO "FK_e9080e7a7997a0170026d5139c1"`);
+
+        await queryRunner.query(`ALTER TABLE "members" RENAME CONSTRAINT "FK_member_guild_id" TO "FK_16aceddd5b89825b8ed6029ad1c"`);
+        await queryRunner.query(`ALTER TABLE "members" RENAME CONSTRAINT "FK_member_user_id" TO "FK_28b53062261b996d9c99fa12404"`);
+
+        await queryRunner.query(`ALTER TABLE "message_channel_mentions" RENAME CONSTRAINT "FK_message_channel_mention_message_id" TO "FK_2a27102ecd1d81b4582a4360921"`);
+        await queryRunner.query(`ALTER TABLE "message_channel_mentions" RENAME CONSTRAINT "FK_message_channel_mention_channel_id" TO "FK_bdb8c09e1464cabf62105bf4b9d"`);
+
+        await queryRunner.query(`ALTER TABLE "message_role_mentions" RENAME CONSTRAINT "FK_message_role_mention_message_id" TO "FK_a8242cf535337a490b0feaea0b4"`);
+        await queryRunner.query(`ALTER TABLE "message_role_mentions" RENAME CONSTRAINT "FK_message_role_mention_role_id" TO "FK_29d63eb1a458200851bc37d074b"`);
+
+        await queryRunner.query(`ALTER TABLE "message_stickers" RENAME CONSTRAINT "FK_message_stickers_message_id" TO "FK_40bb6f23e7cc133292e92829d28"`);
+        await queryRunner.query(`ALTER TABLE "message_stickers" RENAME CONSTRAINT "FK_message_stickers_sticker_id" TO "FK_e22a70819d07659c7a71c112a1f"`);
+
+        await queryRunner.query(`ALTER TABLE "message_user_mentions" RENAME CONSTRAINT "FK_message_user_mentions_message_id" TO "FK_a343387fc560ef378760681c236"`);
+        await queryRunner.query(`ALTER TABLE "message_user_mentions" RENAME CONSTRAINT "FK_message_user_mentions_user_id" TO "FK_b831eb18ceebd28976239b1e2f8"`);
+
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_message_author_id" TO "FK_05535bc695e9f7ee104616459d3"`);
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_message_application_id" TO "FK_5d3ec1cb962de6488637fd779d6"`);
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_message_message_reference_id" TO "FK_61a92bb65b302a76d9c1fcd3174"`);
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_message_channel_id" TO "FK_86b9109b155eb70c0a2ca3b4b6d"`);
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_message_member_id" TO "FK_b0525304f2262b7014245351c76"`);
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_message_guild_id" TO "FK_b193588441b085352a4c0109423"`);
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_message_thread_id" TO "FK_bb3af7f695d50083e6523290d41"`);
+        await queryRunner.query(`ALTER TABLE "messages" RENAME CONSTRAINT "FK_message_webhook_id" TO "FK_f83c04bcf1df4e5c0e7a52ed348"`);
+
+        await queryRunner.query(`ALTER TABLE "notes" RENAME CONSTRAINT "FK_note_target_id" TO "FK_23e08e5b4481711d573e1abecdc"`);
+        await queryRunner.query(`ALTER TABLE "notes" RENAME CONSTRAINT "FK_note_owner_id" TO "FK_f9e103f8ae67cb1787063597925"`);
+
+        await queryRunner.query(`ALTER TABLE "read_states" RENAME CONSTRAINT "FK_read_state_user_id" TO "FK_195f92e4dd1254a4e348c043763"`);
+        await queryRunner.query(`ALTER TABLE "read_states" RENAME CONSTRAINT "FK_read_state_channel_id" TO "FK_40da2fca4e0eaf7a23b5bfc5d34"`);
+
+        await queryRunner.query(`ALTER TABLE "recipients" RENAME CONSTRAINT "FK_recipient_channel_id" TO "FK_2f18ee1ba667f233ae86c0ea60e"`);
+        await queryRunner.query(`ALTER TABLE "recipients" RENAME CONSTRAINT "FK_recipient_user_id" TO "FK_6157e8b6ba4e6e3089616481fe2"`);
+
+        await queryRunner.query(`ALTER TABLE "relationships" RENAME CONSTRAINT "FK_relationship_from_id" TO "FK_9af4194bab1250b1c584ae4f1d7"`);
+        await queryRunner.query(`ALTER TABLE "relationships" RENAME CONSTRAINT "FK_relationship_to_id" TO "FK_9c7f6b98a9843b76dce1b0c878b"`);
+
+        await queryRunner.query(`ALTER TABLE "roles" RENAME CONSTRAINT "FK_role_guild_id" TO "FK_c32c1ab1c4dc7dcb0278c4b1b8b"`);
+
+        await queryRunner.query(`ALTER TABLE "security_keys" RENAME CONSTRAINT "FK_security_key_user_id" TO "FK_24c97d0771cafedce6d7163eaad"`);
+
+        await queryRunner.query(`ALTER TABLE "sessions" RENAME CONSTRAINT "FK_session_user_id" TO "FK_085d540d9f418cfbdc7bd55bb19"`);
+
+        await queryRunner.query(`ALTER TABLE "sticker_packs" RENAME CONSTRAINT "FK_sticker_pack_cover_sticker_id" TO "FK_448fafba4355ee1c837bbc865f1"`);
+
+        await queryRunner.query(`ALTER TABLE "stickers" RENAME CONSTRAINT "FK_sticker_guild_id" TO "FK_193d551d852aca5347ef5c9f205"`);
+        await queryRunner.query(`ALTER TABLE "stickers" RENAME CONSTRAINT "FK_sticker_user_id" TO "FK_8f4ee73f2bb2325ff980502e158"`);
+        await queryRunner.query(`ALTER TABLE "stickers" RENAME CONSTRAINT "FK_sticker_pack_id" TO "FK_e7cfa5cefa6661b3fb8fda8ce69"`);
+
+        await queryRunner.query(`ALTER TABLE "stream_sessions" RENAME CONSTRAINT "FK_stream_session_user_id" TO "FK_13ae5c29aff4d0890c54179511a"`);
+        await queryRunner.query(`ALTER TABLE "stream_sessions" RENAME CONSTRAINT "FK_stream_session_stream_id" TO "FK_8b5a028a34dae9ee54af37c9c32"`);
+
+        await queryRunner.query(`ALTER TABLE "streams" RENAME CONSTRAINT "FK_stream_owner_id" TO "FK_1b566f9b54d1cda271da53ac82f"`);
+        await queryRunner.query(`ALTER TABLE "streams" RENAME CONSTRAINT "FK_stream_channel_id" TO "FK_5101f0cded27ff0aae78fc4eed7"`);
+
+        await queryRunner.query(`ALTER TABLE "tags" RENAME CONSTRAINT "FK_tag_channel_id" TO "FK_2e2df07f6dacc12e1932b361fe4"`);
+
+        await queryRunner.query(`ALTER TABLE "team_members" RENAME CONSTRAINT "FK_team_member_user_id" TO "FK_c2bf4967c8c2a6b845dadfbf3d4"`);
+        await queryRunner.query(`ALTER TABLE "team_members" RENAME CONSTRAINT "FK_team_member_team_id" TO "FK_fdad7d5768277e60c40e01cdcea"`);
+
+        await queryRunner.query(`ALTER TABLE "teams" RENAME CONSTRAINT "FK_team_owner_user_id" TO "FK_13f00abf7cb6096c43ecaf8c108"`);
+
+        await queryRunner.query(`ALTER TABLE "templates" RENAME CONSTRAINT "FK_template_source_guild_id" TO "FK_445d00eaaea0e60a017a5ed0c11"`);
+        await queryRunner.query(`ALTER TABLE "templates" RENAME CONSTRAINT "FK_template_creator_id" TO "FK_d7374b7f8f5fbfdececa4fb62e1"`);
+
+        await queryRunner.query(`ALTER TABLE "thread_members" RENAME CONSTRAINT "FK_thread_member_member_index" TO "FK_4721015b4e24ad29da55dbd2de0"`);
+        await queryRunner.query(`ALTER TABLE "thread_members" RENAME CONSTRAINT "FK_thread_member_channel_id" TO "FK_cf20e37d71b0e1bf1ab633861c8"`);
+
+        await queryRunner.query(`ALTER TABLE "user_settings_protos" RENAME CONSTRAINT "FK_user_settings_proto_user_id" TO "FK_8ff3d1961a48b693810c9f99853"`);
+
+        await queryRunner.query(`ALTER TABLE "users" RENAME CONSTRAINT "FK_user_settings_index" TO "FK_0c14beb78d8c5ccba66072adbc7"`);
+
+        await queryRunner.query(`ALTER TABLE "voice_states" RENAME CONSTRAINT "FK_voice_state_guild_id" TO "FK_03779ef216d4b0358470d9cb748"`);
+        await queryRunner.query(`ALTER TABLE "voice_states" RENAME CONSTRAINT "FK_voice_state_user_id" TO "FK_5fe1d5f931a67e85039c640001b"`);
+        await queryRunner.query(`ALTER TABLE "voice_states" RENAME CONSTRAINT "FK_voice_state_channel_id" TO "FK_9f8d389866b40b6657edd026dd4"`);
+
+        await queryRunner.query(`ALTER TABLE "webhooks" RENAME CONSTRAINT "FK_webhook_user_id" TO "FK_0d523f6f997c86e052c49b1455f"`);
+        await queryRunner.query(`ALTER TABLE "webhooks" RENAME CONSTRAINT "FK_webhook_source_guild_id" TO "FK_3a285f4f49c40e0706d3018bc9f"`);
+        await queryRunner.query(`ALTER TABLE "webhooks" RENAME CONSTRAINT "FK_webhook_source_channel_id" TO "FK_4495b7032a33c6b8b605d030398"`);
+        await queryRunner.query(`ALTER TABLE "webhooks" RENAME CONSTRAINT "FK_webhook_guild_id" TO "FK_487a7af59d189f744fe394368fc"`);
+        await queryRunner.query(`ALTER TABLE "webhooks" RENAME CONSTRAINT "FK_webhook_application_id" TO "FK_c3e5305461931763b56aa905f1c"`);
+        await queryRunner.query(`ALTER TABLE "webhooks" RENAME CONSTRAINT "FK_webhook_channel_id" TO "FK_df528cf77e82f8032230e7e37d8"`);
+
+        await queryRunner.query(`ALTER TABLE "backup_codes" RENAME CONSTRAINT "FK_backup_code_user_id" TO "FK_70066ea80d2f4b871beda32633b"`);
+    }
+}

--- a/src/database/migration/postgres/1782925307188-NameConstraints.ts
+++ b/src/database/migration/postgres/1782925307188-NameConstraints.ts
@@ -33,7 +33,6 @@ export class NameConstraints1782925307188 implements MigrationInterface {
 
         await queryRunner.query(`ALTER TABLE "connected_accounts" RENAME CONSTRAINT "FK_f47244225a6a1eac04a3463dd90" TO "FK_connected_account_user_id"`);
 
-        await queryRunner.query(`ALTER TABLE "emojis" RENAME CONSTRAINT "FK_4b988e0db89d94cebcf07f598cc" TO "FK_emoji_guild_id"`);
         await queryRunner.query(`ALTER TABLE "emojis" RENAME CONSTRAINT "FK_fa7ddd5f9a214e28ce596548421" TO "FK_emoji_user_id"`);
 
         await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_8d450b016dc8bec35f36729e4b0" TO "FK_guild_public_updates_channel_id"`);
@@ -168,7 +167,6 @@ export class NameConstraints1782925307188 implements MigrationInterface {
 
         await queryRunner.query(`ALTER TABLE "connected_accounts" RENAME CONSTRAINT "FK_connected_account_user_id" TO "FK_f47244225a6a1eac04a3463dd90"`);
 
-        await queryRunner.query(`ALTER TABLE "emojis" RENAME CONSTRAINT "FK_emoji_guild_id" TO "FK_4b988e0db89d94cebcf07f598cc"`);
         await queryRunner.query(`ALTER TABLE "emojis" RENAME CONSTRAINT "FK_emoji_user_id" TO "FK_fa7ddd5f9a214e28ce596548421"`);
 
         await queryRunner.query(`ALTER TABLE "guilds" RENAME CONSTRAINT "FK_guild_public_updates_channel_id" TO "FK_8d450b016dc8bec35f36729e4b0"`);

--- a/src/database/migration/postgres/1782925307189-NameIndexes.ts
+++ b/src/database/migration/postgres/1782925307189-NameIndexes.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class NameIndexes1782925307189 implements MigrationInterface {
+    name = "NameIndexes1782925307189";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER INDEX "instance_bans_fingerprint_idx" RENAME TO "IDX_instance_ban_fingerprint"`);
+        await queryRunner.query(`ALTER INDEX "instance_bans_ip_address_idx" RENAME TO "IDX_instance_ban_ip_address"`);
+        await queryRunner.query(`ALTER INDEX "instance_bans_user_id_idx" RENAME TO "IDX_instance_ban_user_id"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER INDEX "IDX_instance_ban_fingerprint" RENAME TO "instance_bans_fingerprint_idx"`);
+        await queryRunner.query(`ALTER INDEX "IDX_instance_ban_ip_address" RENAME TO "instance_bans_ip_address_idx"`);
+        await queryRunner.query(`ALTER INDEX "IDX_instance_ban_user_id" RENAME TO "instance_bans_user_id_idx"`);
+    }
+}

--- a/src/database/migration/postgres/1782925307190-NameJoinTableColumns.ts
+++ b/src/database/migration/postgres/1782925307190-NameJoinTableColumns.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class NameJoinTableColumns1782925307190 implements MigrationInterface {
+    name = "NameJoinTableColumns1782925307190";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE message_channel_mentions RENAME COLUMN "messagesId" TO "message_id"`);
+        await queryRunner.query(`ALTER TABLE message_channel_mentions RENAME COLUMN "channelsId" TO "channel_id"`);
+
+        await queryRunner.query(`ALTER TABLE message_role_mentions RENAME COLUMN "messagesId" TO "message_id"`);
+        await queryRunner.query(`ALTER TABLE message_role_mentions RENAME COLUMN "rolesId" TO "role_id"`);
+
+        await queryRunner.query(`ALTER TABLE message_stickers RENAME COLUMN "messagesId" TO "message_id"`);
+        await queryRunner.query(`ALTER TABLE message_stickers RENAME COLUMN "stickersId" TO "sticker_id"`);
+
+        await queryRunner.query(`ALTER TABLE message_user_mentions RENAME COLUMN "messagesId" TO "message_id"`);
+        await queryRunner.query(`ALTER TABLE message_user_mentions RENAME COLUMN "usersId" TO "user_id"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE message_channel_mentions RENAME COLUMN "message_id" TO "messagesId"`);
+        await queryRunner.query(`ALTER TABLE message_channel_mentions RENAME COLUMN "channel_id" TO "channelsId"`);
+
+        await queryRunner.query(`ALTER TABLE message_role_mentions RENAME COLUMN "message_id" TO "messagesId"`);
+        await queryRunner.query(`ALTER TABLE message_role_mentions RENAME COLUMN "role_id" TO "rolesId"`);
+
+        await queryRunner.query(`ALTER TABLE message_stickers RENAME COLUMN "message_id" TO "messagesId"`);
+        await queryRunner.query(`ALTER TABLE message_stickers RENAME COLUMN "sticker_id" TO "stickersId"`);
+
+        await queryRunner.query(`ALTER TABLE message_user_mentions RENAME COLUMN "message_id" TO "messagesId"`);
+        await queryRunner.query(`ALTER TABLE message_user_mentions RENAME COLUMN "user_id" TO "usersId"`);
+    }
+}

--- a/src/database/migration/postgres/1783086174271-ReconcileTypeormModels.ts
+++ b/src/database/migration/postgres/1783086174271-ReconcileTypeormModels.ts
@@ -1,0 +1,147 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ReconcileTypeormModels1783086174271 implements MigrationInterface {
+    name = "ReconcileTypeormModels1783086174271";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "application_commands" DROP CONSTRAINT "application_commands_applications_fk"`);
+        await queryRunner.query(`ALTER TABLE "automod_rules" DROP CONSTRAINT "FK_automod_rule_guild_id"`);
+        await queryRunner.query(`ALTER TABLE "webhooks" DROP CONSTRAINT "FK_webhook_application_id"`);
+        await queryRunner.query(`ALTER TABLE "thread_members" DROP CONSTRAINT "FK_thread_member_member_index"`);
+        await queryRunner.query(`ALTER TABLE "guilds" DROP CONSTRAINT "FK_guild_primary_category_id"`);
+        await queryRunner.query(`ALTER TABLE "guilds" DROP CONSTRAINT "FK_guild_owner_id"`);
+        await queryRunner.query(`ALTER TABLE "message_user_mentions" DROP CONSTRAINT "FK_message_user_mentions_user_id"`);
+        await queryRunner.query(`ALTER TABLE "message_user_mentions" DROP CONSTRAINT "FK_message_user_mentions_message_id"`);
+        await queryRunner.query(`ALTER TABLE "message_role_mentions" DROP CONSTRAINT "FK_message_role_mention_role_id"`);
+        await queryRunner.query(`ALTER TABLE "message_role_mentions" DROP CONSTRAINT "FK_message_role_mention_message_id"`);
+        await queryRunner.query(`ALTER TABLE "message_channel_mentions" DROP CONSTRAINT "FK_message_channel_mention_channel_id"`);
+        await queryRunner.query(`ALTER TABLE "message_channel_mentions" DROP CONSTRAINT "FK_message_channel_mention_message_id"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_a343387fc560ef378760681c23"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_b831eb18ceebd28976239b1e2f"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_a8242cf535337a490b0feaea0b"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_29d63eb1a458200851bc37d074"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_bdb8c09e1464cabf62105bf4b9"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_2a27102ecd1d81b4582a436092"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_40bb6f23e7cc133292e92829d2"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_e22a70819d07659c7a71c112a1"`);
+        await queryRunner.query(
+            `CREATE TABLE "report_menus" ("id" bigint NOT NULL, "type" integer NOT NULL, "variant" character varying NOT NULL, "isCurrent" boolean NOT NULL, "inherits" character varying, "content" jsonb NOT NULL, CONSTRAINT "PK_1b5d649a189d57579d558ace79f" PRIMARY KEY ("id"))`,
+        );
+        await queryRunner.query(`ALTER TABLE "application_commands" ALTER COLUMN "version" SET DEFAULT '0::bigint'`);
+        await queryRunner.query(`ALTER TABLE "embed_cache" ALTER COLUMN "created_at" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "security_settings" DROP COLUMN "allowed_algorithms"`);
+        await queryRunner.query(`ALTER TABLE "security_settings" ADD "allowed_algorithms" character varying array NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "applications" DROP CONSTRAINT "FK_application_owner_id"`);
+        await queryRunner.query(`ALTER TABLE "applications" ALTER COLUMN "owner_id" SET NOT NULL`);
+        await queryRunner.query(`CREATE INDEX "IDX_972e8e013af7698f8aa8bc3fc8" ON "message_user_mentions"  ("message_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_16395c9069e88c5f93cd658e9a" ON "message_user_mentions"  ("user_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_30114cbe788f0affbd8b8bf1f1" ON "message_role_mentions"  ("message_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_ce866308ad8ddf9b6abce06b33" ON "message_role_mentions"  ("role_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_900f52a6d0f53bdcb2e9079017" ON "message_channel_mentions"  ("message_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_32f530caa79d0e7d295eb59f62" ON "message_channel_mentions"  ("channel_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_724f8b11056c706429933bdf87" ON "message_stickers"  ("message_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_2b34e1145cafb79c6c5c193d12" ON "message_stickers"  ("sticker_id") `);
+        await queryRunner.query(
+            `ALTER TABLE "webhooks" ADD CONSTRAINT "FK_webhook_application_id" FOREIGN KEY ("application_id") REFERENCES "applications"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "thread_members" ADD CONSTRAINT "FK_thread_member_member_id" FOREIGN KEY ("member_idx") REFERENCES "members"("index") ON DELETE CASCADE ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "guilds" ADD CONSTRAINT "FK_guild_owner_id" FOREIGN KEY ("owner_id") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "applications" ADD CONSTRAINT "FK_application_owner_id" FOREIGN KEY ("owner_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "message_user_mentions" ADD CONSTRAINT "FK_message_mentions_message_id" FOREIGN KEY ("message_id") REFERENCES "messages"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "message_user_mentions" ADD CONSTRAINT "FK_message_mentions_user_id" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "message_role_mentions" ADD CONSTRAINT "FK_message_role_mentions_message_id" FOREIGN KEY ("message_id") REFERENCES "messages"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "message_role_mentions" ADD CONSTRAINT "FK_message_role_mentions_role_id" FOREIGN KEY ("role_id") REFERENCES "roles"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "message_channel_mentions" ADD CONSTRAINT "FK_message_channel_mentions_message_id" FOREIGN KEY ("message_id") REFERENCES "messages"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "message_channel_mentions" ADD CONSTRAINT "FK_message_channel_mentions_channel_id" FOREIGN KEY ("channel_id") REFERENCES "channels"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "message_channel_mentions" DROP CONSTRAINT "FK_message_channel_mentions_channel_id"`);
+        await queryRunner.query(`ALTER TABLE "message_channel_mentions" DROP CONSTRAINT "FK_message_channel_mentions_message_id"`);
+        await queryRunner.query(`ALTER TABLE "message_role_mentions" DROP CONSTRAINT "FK_message_role_mentions_role_id"`);
+        await queryRunner.query(`ALTER TABLE "message_role_mentions" DROP CONSTRAINT "FK_message_role_mentions_message_id"`);
+        await queryRunner.query(`ALTER TABLE "message_user_mentions" DROP CONSTRAINT "FK_message_mentions_user_id"`);
+        await queryRunner.query(`ALTER TABLE "message_user_mentions" DROP CONSTRAINT "FK_message_mentions_message_id"`);
+        await queryRunner.query(`ALTER TABLE "applications" DROP CONSTRAINT "FK_application_owner_id"`);
+        await queryRunner.query(`ALTER TABLE "guilds" DROP CONSTRAINT "FK_guild_owner_id"`);
+        await queryRunner.query(`ALTER TABLE "thread_members" DROP CONSTRAINT "FK_thread_member_member_id"`);
+        await queryRunner.query(`ALTER TABLE "webhooks" DROP CONSTRAINT "FK_webhook_application_id"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_2b34e1145cafb79c6c5c193d12"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_724f8b11056c706429933bdf87"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_32f530caa79d0e7d295eb59f62"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_900f52a6d0f53bdcb2e9079017"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_ce866308ad8ddf9b6abce06b33"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_30114cbe788f0affbd8b8bf1f1"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_16395c9069e88c5f93cd658e9a"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_972e8e013af7698f8aa8bc3fc8"`);
+        await queryRunner.query(`ALTER TABLE "applications" ALTER COLUMN "owner_id" DROP NOT NULL`);
+        await queryRunner.query(
+            `ALTER TABLE "applications" ADD CONSTRAINT "FK_application_owner_id" FOREIGN KEY ("owner_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(`ALTER TABLE "security_settings" DROP COLUMN "allowed_algorithms"`);
+        await queryRunner.query(`ALTER TABLE "security_settings" ADD "allowed_algorithms" text NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "embed_cache" ALTER COLUMN "created_at" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "application_commands" ALTER COLUMN "version" SET DEFAULT (0)`);
+        await queryRunner.query(`DROP TABLE "report_menus"`);
+        await queryRunner.query(`CREATE INDEX "IDX_e22a70819d07659c7a71c112a1" ON "message_stickers" USING btree ("sticker_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_40bb6f23e7cc133292e92829d2" ON "message_stickers" USING btree ("message_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_2a27102ecd1d81b4582a436092" ON "message_channel_mentions" USING btree ("message_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_bdb8c09e1464cabf62105bf4b9" ON "message_channel_mentions" USING btree ("channel_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_29d63eb1a458200851bc37d074" ON "message_role_mentions" USING btree ("role_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_a8242cf535337a490b0feaea0b" ON "message_role_mentions" USING btree ("message_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_b831eb18ceebd28976239b1e2f" ON "message_user_mentions" USING btree ("user_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_a343387fc560ef378760681c23" ON "message_user_mentions" USING btree ("message_id") `);
+        await queryRunner.query(
+            `ALTER TABLE "message_channel_mentions" ADD CONSTRAINT "FK_message_channel_mention_message_id" FOREIGN KEY ("message_id") REFERENCES "messages"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "message_channel_mentions" ADD CONSTRAINT "FK_message_channel_mention_channel_id" FOREIGN KEY ("channel_id") REFERENCES "channels"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "message_role_mentions" ADD CONSTRAINT "FK_message_role_mention_message_id" FOREIGN KEY ("message_id") REFERENCES "messages"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "message_role_mentions" ADD CONSTRAINT "FK_message_role_mention_role_id" FOREIGN KEY ("role_id") REFERENCES "roles"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "message_user_mentions" ADD CONSTRAINT "FK_message_user_mentions_message_id" FOREIGN KEY ("message_id") REFERENCES "messages"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "message_user_mentions" ADD CONSTRAINT "FK_message_user_mentions_user_id" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+        );
+        await queryRunner.query(`ALTER TABLE "guilds" ADD CONSTRAINT "FK_guild_owner_id" FOREIGN KEY ("owner_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(
+            `ALTER TABLE "guilds" ADD CONSTRAINT "FK_guild_primary_category_id" FOREIGN KEY ("primary_category_id") REFERENCES "categories"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "thread_members" ADD CONSTRAINT "FK_thread_member_member_index" FOREIGN KEY ("member_idx") REFERENCES "members"("index") ON DELETE CASCADE ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "webhooks" ADD CONSTRAINT "FK_webhook_application_id" FOREIGN KEY ("application_id") REFERENCES "applications"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "automod_rules" ADD CONSTRAINT "FK_automod_rule_guild_id" FOREIGN KEY ("guild_id") REFERENCES "guilds"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "application_commands" ADD CONSTRAINT "application_commands_applications_fk" FOREIGN KEY ("application_id") REFERENCES "applications"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+        );
+    }
+}

--- a/src/database/migration/postgres/1783086174271-ReconcileTypeormModels.ts
+++ b/src/database/migration/postgres/1783086174271-ReconcileTypeormModels.ts
@@ -27,7 +27,6 @@ export class ReconcileTypeormModels1783086174271 implements MigrationInterface {
         await queryRunner.query(
             `CREATE TABLE "report_menus" ("id" bigint NOT NULL, "type" integer NOT NULL, "variant" character varying NOT NULL, "isCurrent" boolean NOT NULL, "inherits" character varying, "content" jsonb NOT NULL, CONSTRAINT "PK_1b5d649a189d57579d558ace79f" PRIMARY KEY ("id"))`,
         );
-        await queryRunner.query(`ALTER TABLE "application_commands" ALTER COLUMN "version" SET DEFAULT '0::bigint'`);
         await queryRunner.query(`ALTER TABLE "embed_cache" ALTER COLUMN "created_at" SET NOT NULL`);
         await queryRunner.query(`ALTER TABLE "security_settings" DROP COLUMN "allowed_algorithms"`);
         await queryRunner.query(`ALTER TABLE "security_settings" ADD "allowed_algorithms" character varying array NOT NULL`);
@@ -99,7 +98,6 @@ export class ReconcileTypeormModels1783086174271 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "security_settings" DROP COLUMN "allowed_algorithms"`);
         await queryRunner.query(`ALTER TABLE "security_settings" ADD "allowed_algorithms" text NOT NULL`);
         await queryRunner.query(`ALTER TABLE "embed_cache" ALTER COLUMN "created_at" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "application_commands" ALTER COLUMN "version" SET DEFAULT (0)`);
         await queryRunner.query(`DROP TABLE "report_menus"`);
         await queryRunner.query(`CREATE INDEX "IDX_e22a70819d07659c7a71c112a1" ON "message_stickers" USING btree ("sticker_id") `);
         await queryRunner.query(`CREATE INDEX "IDX_40bb6f23e7cc133292e92829d2" ON "message_stickers" USING btree ("message_id") `);

--- a/src/database/migration/postgres/1783086517091-ReconcileTypeormModels.ts
+++ b/src/database/migration/postgres/1783086517091-ReconcileTypeormModels.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ReconcileTypeormModels1783086517091 implements MigrationInterface {
+    name = "ReconcileTypeormModels1783086517091";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "application_commands" ALTER COLUMN "version" SET DEFAULT 0`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "application_commands" ALTER COLUMN "version" SET DEFAULT (0)`);
+    }
+}


### PR DESCRIPTION
Names constraints/indexes explicitly where possible, also fixes up the parts where typeorm's thoughts about the model had drifted from reality.